### PR TITLE
feat: implement user login endpoint

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,8 +11,10 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -2,6 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -15,6 +17,8 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.17.2 h1:P2EGsA4qVIM3Pp+aPocCJ7DguDHhqrXNhVcEp4ViluI=
+github.com/redis/go-redis/v9 v9.17.2/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/backend/internal/cache/redis.go
+++ b/backend/internal/cache/redis.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Init initializes and returns a Redis client
+func Init(ctx context.Context) (*redis.Client, error) {
+	redisHost := os.Getenv("REDIS_HOST")
+	if redisHost == "" {
+		redisHost = "localhost"
+	}
+
+	redisPort := os.Getenv("REDIS_PORT")
+	if redisPort == "" {
+		redisPort = "6379"
+	}
+
+	redisPassword := os.Getenv("REDIS_PASSWORD")
+
+	client := redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%s", redisHost, redisPort),
+		Password: redisPassword,
+		DB:       0,
+	})
+
+	// Test connection
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
+	}
+
+	return client, nil
+}

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -5,19 +5,22 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/sanderginn/clubhouse/internal/models"
 	"github.com/sanderginn/clubhouse/internal/services"
 )
 
 // AuthHandler handles authentication endpoints
 type AuthHandler struct {
-	userService *services.UserService
+	userService    *services.UserService
+	sessionService *services.SessionService
 }
 
 // NewAuthHandler creates a new auth handler
-func NewAuthHandler(db *sql.DB) *AuthHandler {
+func NewAuthHandler(db *sql.DB, redis *redis.Client) *AuthHandler {
 	return &AuthHandler{
-		userService: services.NewUserService(db),
+		userService:    services.NewUserService(db),
+		sessionService: services.NewSessionService(redis),
 	}
 }
 
@@ -71,6 +74,71 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}
+
+// Login handles user login
+func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	var req models.LoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	user, err := h.userService.LoginUser(r.Context(), &req)
+	if err != nil {
+		// Determine appropriate error code and status
+		switch err.Error() {
+		case "email is required":
+			writeError(w, http.StatusBadRequest, "EMAIL_REQUIRED", err.Error())
+		case "invalid email format":
+			writeError(w, http.StatusBadRequest, "INVALID_EMAIL", err.Error())
+		case "password is required":
+			writeError(w, http.StatusBadRequest, "PASSWORD_REQUIRED", err.Error())
+		case "invalid email or password":
+			writeError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", err.Error())
+		case "user not approved":
+			writeError(w, http.StatusForbidden, "USER_NOT_APPROVED", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "LOGIN_FAILED", "Failed to login")
+		}
+		return
+	}
+
+	// Create session
+	session, err := h.sessionService.CreateSession(r.Context(), user.ID, user.Username, user.IsAdmin)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "Failed to create session")
+		return
+	}
+
+	// Set httpOnly secure cookie
+	cookie := &http.Cookie{
+		Name:     "session_id",
+		Value:    session.ID,
+		Path:     "/",
+		MaxAge:   int(services.SessionDuration.Seconds()),
+		HttpOnly: true,
+		Secure:   true, // Set to false in development, true in production
+		SameSite: http.SameSiteLaxMode,
+	}
+	http.SetCookie(w, cookie)
+
+	response := models.LoginResponse{
+		ID:       user.ID,
+		Username: user.Username,
+		Email:    user.Email,
+		IsAdmin:  user.IsAdmin,
+		Message:  "Login successful",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(response)
 }
 

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -36,6 +36,21 @@ type RegisterResponse struct {
 	Message  string    `json:"message"`
 }
 
+// LoginRequest represents the login request body
+type LoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// LoginResponse represents the login response
+type LoginResponse struct {
+	ID       uuid.UUID `json:"id"`
+	Username string    `json:"username"`
+	Email    string    `json:"email"`
+	IsAdmin  bool      `json:"is_admin"`
+	Message  string    `json:"message"`
+}
+
 // ErrorResponse represents a standard error response
 type ErrorResponse struct {
 	Error string `json:"error"`

--- a/backend/internal/services/session.go
+++ b/backend/internal/services/session.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// SessionDuration is the duration a session is valid (30 days)
+	SessionDuration = 30 * 24 * time.Hour
+	// SessionKeyPrefix is the Redis key prefix for sessions
+	SessionKeyPrefix = "session:"
+)
+
+// Session represents a user session stored in Redis
+type Session struct {
+	ID        string    `json:"id"`
+	UserID    uuid.UUID `json:"user_id"`
+	Username  string    `json:"username"`
+	IsAdmin   bool      `json:"is_admin"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// SessionService handles session-related operations
+type SessionService struct {
+	redis *redis.Client
+}
+
+// NewSessionService creates a new session service
+func NewSessionService(redis *redis.Client) *SessionService {
+	return &SessionService{redis: redis}
+}
+
+// CreateSession creates a new session for a user
+func (s *SessionService) CreateSession(ctx context.Context, userID uuid.UUID, username string, isAdmin bool) (*Session, error) {
+	sessionID := uuid.New().String()
+	now := time.Now().UTC()
+	expiresAt := now.Add(SessionDuration)
+
+	session := &Session{
+		ID:        sessionID,
+		UserID:    userID,
+		Username:  username,
+		IsAdmin:   isAdmin,
+		CreatedAt: now,
+		ExpiresAt: expiresAt,
+	}
+
+	// Marshal session to JSON
+	sessionJSON, err := json.Marshal(session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal session: %w", err)
+	}
+
+	// Store in Redis with expiration
+	key := SessionKeyPrefix + sessionID
+	if err := s.redis.Set(ctx, key, sessionJSON, SessionDuration).Err(); err != nil {
+		return nil, fmt.Errorf("failed to store session in Redis: %w", err)
+	}
+
+	return session, nil
+}
+
+// GetSession retrieves a session from Redis
+func (s *SessionService) GetSession(ctx context.Context, sessionID string) (*Session, error) {
+	key := SessionKeyPrefix + sessionID
+	sessionJSON, err := s.redis.Get(ctx, key).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, fmt.Errorf("session not found or expired")
+		}
+		return nil, fmt.Errorf("failed to get session from Redis: %w", err)
+	}
+
+	var session Session
+	if err := json.Unmarshal([]byte(sessionJSON), &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// DeleteSession removes a session from Redis
+func (s *SessionService) DeleteSession(ctx context.Context, sessionID string) error {
+	key := SessionKeyPrefix + sessionID
+	if err := s.redis.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("failed to delete session from Redis: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #8

## Changes
- Implement POST /api/v1/auth/login endpoint with session management
- Add Redis session service with 30-day TTL
- Validate email and password, verify user approval status  
- Create secure httpOnly cookies for session management
- Add LoginUser service method with bcrypt password verification
- Update AUTH_ENDPOINTS.md with login endpoint documentation

## Implementation Details
- Uses redis/go-redis v9 for session storage
- Sessions stored with user ID, username, is_admin flag
- Password verified using bcrypt.CompareHashAndPassword
- Returns standard error responses as per API design
- Cookie flags: HttpOnly, Secure, SameSite=Lax