### PR TITLE
feat: implement get feed endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -70,6 +70,7 @@ func main() {
 	mux.HandleFunc("/api/v1/auth/register", authHandler.Register)
 	mux.HandleFunc("/api/v1/auth/login", authHandler.Login)
 	mux.HandleFunc("/api/v1/auth/logout", authHandler.Logout)
+	mux.HandleFunc("/api/v1/sections/", postHandler.GetFeed)
 	mux.HandleFunc("/api/v1/posts/", postHandler.GetPost)
 
 	// Protected post routes

--- a/backend/internal/handlers/post_test.go
+++ b/backend/internal/handlers/post_test.go
@@ -190,6 +190,169 @@ func TestGetPostMethodNotAllowed(t *testing.T) {
 	}
 }
 
+// TestGetFeedSuccess tests successfully retrieving a feed
+func TestGetFeedSuccess(t *testing.T) {
+	db, mock, err := setupMockDB(t)
+	if err != nil {
+		t.Fatalf("failed to setup mock db: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewPostHandler(db)
+	sectionID := uuid.New()
+	post1ID := uuid.New()
+	post2ID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+	earlier := now.Add(-time.Hour)
+
+	// Mock the posts query (returns 2 posts + 1 extra to determine hasMore)
+	rows := mock.NewRows([]string{
+		"id", "user_id", "section_id", "content",
+		"created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
+		"comment_count",
+	}).AddRow(
+		post1ID, userID, sectionID, "First post",
+		now, nil, nil, nil,
+		userID, "testuser", "test@example.com", nil, nil, false, now,
+		2,
+	).AddRow(
+		post2ID, userID, sectionID, "Second post",
+		earlier, nil, nil, nil,
+		userID, "testuser", "test@example.com", nil, nil, false, earlier,
+		0,
+	)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	// Mock links queries
+	linksRows := mock.NewRows([]string{"id", "url", "metadata", "created_at"})
+	mock.ExpectQuery("SELECT id, url, metadata, created_at").WillReturnRows(linksRows)
+	mock.ExpectQuery("SELECT id, url, metadata, created_at").WillReturnRows(linksRows)
+
+	req, err := http.NewRequest("GET", "/api/v1/sections/"+sectionID.String()+"/feed", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.GetFeed(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 2 {
+		t.Errorf("expected 2 posts, got %d", len(response.Posts))
+	}
+
+	if response.HasMore {
+		t.Errorf("expected hasMore to be false, got true")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestGetFeedWithCursor tests feed retrieval with cursor pagination
+func TestGetFeedWithCursor(t *testing.T) {
+	db, mock, err := setupMockDB(t)
+	if err != nil {
+		t.Fatalf("failed to setup mock db: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewPostHandler(db)
+	sectionID := uuid.New()
+	postID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	// Mock the posts query
+	rows := mock.NewRows([]string{
+		"id", "user_id", "section_id", "content",
+		"created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
+		"comment_count",
+	}).AddRow(
+		postID, userID, sectionID, "Post after cursor",
+		now, nil, nil, nil,
+		userID, "testuser", "test@example.com", nil, nil, false, now,
+		1,
+	)
+
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+
+	// Mock links query
+	linksRows := mock.NewRows([]string{"id", "url", "metadata", "created_at"})
+	mock.ExpectQuery("SELECT id, url, metadata, created_at").WillReturnRows(linksRows)
+
+	cursor := now.Add(-2 * time.Hour).Format("2006-01-02T15:04:05.000Z07:00")
+	req, err := http.NewRequest("GET", "/api/v1/sections/"+sectionID.String()+"/feed?cursor="+cursor, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.GetFeed(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 1 {
+		t.Errorf("expected 1 post, got %d", len(response.Posts))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// TestGetFeedInvalidSectionID tests with invalid section ID format
+func TestGetFeedInvalidSectionID(t *testing.T) {
+	db, _, err := setupMockDB(t)
+	if err != nil {
+		t.Fatalf("failed to setup mock db: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewPostHandler(db)
+
+	req, err := http.NewRequest("GET", "/api/v1/sections/not-a-uuid/feed", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.GetFeed(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_SECTION_ID" {
+		t.Errorf("expected code INVALID_SECTION_ID, got %s", response.Code)
+	}
+}
+
 // setupMockDB creates a mock database connection for testing
 func setupMockDB(t *testing.T) (*sql.DB, interface{}, error) {
 	// In a real test setup, we'd use sqlmock or similar

--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -54,6 +54,13 @@ type GetPostResponse struct {
 	Post *Post `json:"post"`
 }
 
+// FeedResponse represents the paginated feed response
+type FeedResponse struct {
+	Posts      []*Post `json:"posts"`
+	HasMore    bool    `json:"has_more"`
+	NextCursor *string `json:"next_cursor,omitempty"`
+}
+
 // JSONMap is a custom type for storing JSON metadata
 type JSONMap map[string]interface{}
 


### PR DESCRIPTION
Closes #14

- Added GET /api/v1/sections/{sectionId}/feed endpoint
- Implements cursor-based pagination with configurable limit
- Supports soft-delete filtering
- Returns posts with user info and comment counts
- Includes hasMore flag and next cursor for pagination
- Default limit: 20, maximum: 100
- Posts ordered by created_at DESC