### PR TITLE
feat: implement auth pages (register, login, logout)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -71,6 +71,7 @@ func main() {
 	mux.HandleFunc("/api/v1/auth/register", authHandler.Register)
 	mux.HandleFunc("/api/v1/auth/login", authHandler.Login)
 	mux.HandleFunc("/api/v1/auth/logout", authHandler.Logout)
+	mux.HandleFunc("/api/v1/auth/me", authHandler.GetMe)
 	mux.HandleFunc("/api/v1/sections/", postHandler.GetFeed)
 	mux.HandleFunc("/api/v1/comments/", commentHandler.GetComment)
 

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -83,3 +83,13 @@ type RejectUserResponse struct {
 	ID      uuid.UUID `json:"id"`
 	Message string    `json:"message"`
 }
+
+// MeResponse represents the response from /auth/me endpoint
+type MeResponse struct {
+	ID                uuid.UUID `json:"id"`
+	Username          string    `json:"username"`
+	Email             string    `json:"email"`
+	ProfilePictureUrl *string   `json:"profile_picture_url,omitempty"`
+	Bio               *string   `json:"bio,omitempty"`
+	IsAdmin           bool      `json:"is_admin"`
+}

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -70,6 +70,29 @@ func (s *UserService) RegisterUser(ctx context.Context, req *models.RegisterRequ
 	return &user, nil
 }
 
+// GetUserByID retrieves a user by ID
+func (s *UserService) GetUserByID(ctx context.Context, id uuid.UUID) (*models.User, error) {
+	query := `
+		SELECT id, username, email, password_hash, profile_picture_url, bio, is_admin, approved_at, created_at, updated_at, deleted_at
+		FROM users
+		WHERE id = $1 AND deleted_at IS NULL
+	`
+
+	var user models.User
+	err := s.db.QueryRowContext(ctx, query, id).
+		Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash, &user.ProfilePictureURL,
+			&user.Bio, &user.IsAdmin, &user.ApprovedAt, &user.CreatedAt, &user.UpdatedAt, &user.DeletedAt)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("user not found")
+		}
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	return &user, nil
+}
+
 // GetUserByUsername retrieves a user by username
 func (s *UserService) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	query := `

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,29 +1,59 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import './styles/globals.css';
   import { Layout } from './components';
-  import { activeSection } from './stores';
+  import { Login, Register } from './routes';
+  import { authStore, isAuthenticated, activeSection } from './stores';
+
+  let authPage: 'login' | 'register' = 'login';
+
+  onMount(() => {
+    authStore.checkSession();
+  });
+
+  function handleNavigate(page: 'login' | 'register') {
+    authPage = page;
+  }
 </script>
 
-<Layout>
-  <div class="space-y-6">
-    {#if $activeSection}
-      <div class="flex items-center gap-3">
-        <span class="text-3xl">{$activeSection.icon}</span>
-        <h1 class="text-2xl font-bold text-gray-900">{$activeSection.name}</h1>
-      </div>
-
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <p class="text-gray-600">
-          Welcome to the {$activeSection.name} section. Posts will appear here.
-        </p>
-      </div>
-    {:else}
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h1 class="text-2xl font-bold text-gray-900 mb-4">Welcome to Clubhouse</h1>
-        <p class="text-gray-600">
-          Select a section from the sidebar to get started.
-        </p>
-      </div>
-    {/if}
+{#if $authStore.isLoading}
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <div class="flex flex-col items-center">
+      <svg class="animate-spin h-10 w-10 text-indigo-600 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+      <p class="text-gray-600">Loading...</p>
+    </div>
   </div>
-</Layout>
+{:else if !$isAuthenticated}
+  {#if authPage === 'login'}
+    <Login onNavigate={handleNavigate} />
+  {:else}
+    <Register onNavigate={handleNavigate} />
+  {/if}
+{:else}
+  <Layout>
+    <div class="space-y-6">
+      {#if $activeSection}
+        <div class="flex items-center gap-3">
+          <span class="text-3xl">{$activeSection.icon}</span>
+          <h1 class="text-2xl font-bold text-gray-900">{$activeSection.name}</h1>
+        </div>
+
+        <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <p class="text-gray-600">
+            Welcome to the {$activeSection.name} section. Posts will appear here.
+          </p>
+        </div>
+      {:else}
+        <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <h1 class="text-2xl font-bold text-gray-900 mb-4">Welcome to Clubhouse</h1>
+          <p class="text-gray-600">
+            Select a section from the sidebar to get started.
+          </p>
+        </div>
+      {/if}
+    </div>
+  </Layout>
+{/if}

--- a/frontend/src/components/Header.svelte
+++ b/frontend/src/components/Header.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-  import { uiStore, currentUser, isAuthenticated } from '../stores';
+  import { uiStore, currentUser, isAuthenticated, authStore } from '../stores';
 
   function toggleSidebar() {
     uiStore.toggleSidebar();
+  }
+
+  async function handleLogout() {
+    await authStore.logout();
   }
 </script>
 
@@ -54,20 +58,16 @@
               {$currentUser.username.charAt(0).toUpperCase()}
             </div>
           {/if}
+          <button
+            on:click={handleLogout}
+            class="text-sm font-medium text-gray-600 hover:text-gray-900 ml-2"
+            title="Logout"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+          </button>
         </div>
-      {:else}
-        <a
-          href="/login"
-          class="text-sm font-medium text-gray-700 hover:text-primary"
-        >
-          Log in
-        </a>
-        <a
-          href="/register"
-          class="text-sm font-medium text-white bg-primary hover:bg-secondary px-4 py-2 rounded-lg transition-colors"
-        >
-          Register
-        </a>
       {/if}
     </div>
   </div>

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import { api } from '../services/api';
+  import { authStore, type User } from '../stores';
+
+  let email = '';
+  let password = '';
+  let error = '';
+  let isLoading = false;
+
+  interface LoginResponse {
+    id: string;
+    username: string;
+    email: string;
+    is_admin: boolean;
+    message: string;
+  }
+
+  async function handleSubmit() {
+    error = '';
+    isLoading = true;
+
+    try {
+      const response = await api.post<LoginResponse>('/auth/login', {
+        email,
+        password,
+      });
+
+      const user: User = {
+        id: response.id,
+        username: response.username,
+        email: response.email,
+        isAdmin: response.is_admin,
+      };
+
+      authStore.setUser(user);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Login failed';
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  export let onNavigate: (page: 'login' | 'register') => void;
+</script>
+
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        Sign in to Clubhouse
+      </h2>
+      <p class="mt-2 text-center text-sm text-gray-600">
+        Or
+        <button
+          type="button"
+          on:click={() => onNavigate('register')}
+          class="font-medium text-indigo-600 hover:text-indigo-500"
+        >
+          create a new account
+        </button>
+      </p>
+    </div>
+
+    <form class="mt-8 space-y-6" on:submit|preventDefault={handleSubmit}>
+      {#if error}
+        <div class="rounded-md bg-red-50 p-4">
+          <p class="text-sm text-red-700">{error}</p>
+        </div>
+      {/if}
+
+      <div class="rounded-md shadow-sm -space-y-px">
+        <div>
+          <label for="email" class="sr-only">Email address</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autocomplete="email"
+            required
+            bind:value={email}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Email address"
+          />
+        </div>
+        <div>
+          <label for="password" class="sr-only">Password</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+            bind:value={password}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Password"
+          />
+        </div>
+      </div>
+
+      <div>
+        <button
+          type="submit"
+          disabled={isLoading}
+          class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {#if isLoading}
+            <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            Signing in...
+          {:else}
+            Sign in
+          {/if}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/frontend/src/routes/Register.svelte
+++ b/frontend/src/routes/Register.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { api } from '../services/api';
+
+  let username = '';
+  let email = '';
+  let password = '';
+  let confirmPassword = '';
+  let error = '';
+  let success = '';
+  let isLoading = false;
+
+  async function handleSubmit() {
+    error = '';
+    success = '';
+
+    if (password !== confirmPassword) {
+      error = 'Passwords do not match';
+      return;
+    }
+
+    isLoading = true;
+
+    try {
+      const response = await api.post<{ message: string }>('/auth/register', {
+        username,
+        email,
+        password,
+      });
+      success = response.message;
+      username = '';
+      email = '';
+      password = '';
+      confirmPassword = '';
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Registration failed';
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  export let onNavigate: (page: 'login' | 'register') => void;
+</script>
+
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        Create your account
+      </h2>
+      <p class="mt-2 text-center text-sm text-gray-600">
+        Or
+        <button
+          type="button"
+          on:click={() => onNavigate('login')}
+          class="font-medium text-indigo-600 hover:text-indigo-500"
+        >
+          sign in to your account
+        </button>
+      </p>
+    </div>
+
+    <form class="mt-8 space-y-6" on:submit|preventDefault={handleSubmit}>
+      {#if error}
+        <div class="rounded-md bg-red-50 p-4">
+          <p class="text-sm text-red-700">{error}</p>
+        </div>
+      {/if}
+
+      {#if success}
+        <div class="rounded-md bg-green-50 p-4">
+          <p class="text-sm text-green-700">{success}</p>
+        </div>
+      {/if}
+
+      <div class="rounded-md shadow-sm -space-y-px">
+        <div>
+          <label for="username" class="sr-only">Username</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            required
+            bind:value={username}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Username"
+          />
+        </div>
+        <div>
+          <label for="email" class="sr-only">Email address</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            bind:value={email}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Email address"
+          />
+        </div>
+        <div>
+          <label for="password" class="sr-only">Password</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            bind:value={password}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Password"
+          />
+        </div>
+        <div>
+          <label for="confirmPassword" class="sr-only">Confirm Password</label>
+          <input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            required
+            bind:value={confirmPassword}
+            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+            placeholder="Confirm password"
+          />
+        </div>
+      </div>
+
+      <div>
+        <button
+          type="submit"
+          disabled={isLoading}
+          class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {#if isLoading}
+            <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            Creating account...
+          {:else}
+            Create account
+          {/if}
+        </button>
+      </div>
+
+      <p class="mt-2 text-center text-xs text-gray-500">
+        Your account will need admin approval before you can sign in.
+      </p>
+    </form>
+  </div>
+</div>

--- a/frontend/src/routes/index.ts
+++ b/frontend/src/routes/index.ts
@@ -1,0 +1,2 @@
+export { default as Login } from './Login.svelte';
+export { default as Register } from './Register.svelte';


### PR DESCRIPTION
## Summary
Implements Phase 2 authentication pages for the frontend.

## Changes
- **Register.svelte**: Registration form with username, email, password fields and validation
- **Login.svelte**: Login form with email/password, redirects on success
- **SessionStore**: Updated authStore with `checkSession()` for session persistence across refreshes
- **Backend /me endpoint**: Added `GET /api/v1/auth/me` to retrieve current authenticated user
- **Logout button**: Added to Header component with session cleanup

## Acceptance Criteria
- ✅ Registration works (creates account pending admin approval)
- ✅ Login works (sets httpOnly cookie, redirects to main app)
- ✅ Session persists across refreshes (via `/auth/me` endpoint)
- ✅ Logout works (clears session cookie and redirects to login)

Closes #50