### PR TITLE
Phase 2: Implement add reaction endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -66,6 +66,7 @@ func main() {
 	postHandler := handlers.NewPostHandler(dbConn)
 	commentHandler := handlers.NewCommentHandler(dbConn)
 	adminHandler := handlers.NewAdminHandler(dbConn)
+	reactionHandler := handlers.NewReactionHandler(dbConn)
 
 	// API routes
 	mux.HandleFunc("/api/v1/auth/register", authHandler.Register)
@@ -85,6 +86,11 @@ func main() {
 			// Apply auth middleware and call RestorePost
 			authHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(postHandler.RestorePost))
 			authHandler.ServeHTTP(w, r)
+		} else if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/reactions") {
+			// Check if this is an add reaction request (POST /api/v1/posts/{id}/reactions)
+			// Apply auth middleware and call AddReactionToPost
+			reactionAuthHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(reactionHandler.AddReactionToPost))
+			reactionAuthHandler.ServeHTTP(w, r)
 		} else if r.Method == http.MethodGet {
 			postHandler.GetPost(w, r)
 		}

--- a/backend/internal/handlers/reaction.go
+++ b/backend/internal/handlers/reaction.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// ReactionHandler handles reaction endpoints
+type ReactionHandler struct {
+	reactionService *services.ReactionService
+}
+
+// NewReactionHandler creates a new reaction handler
+func NewReactionHandler(db *sql.DB) *ReactionHandler {
+	return &ReactionHandler{
+		reactionService: services.NewReactionService(db),
+	}
+}
+
+// AddReactionToPost handles POST /api/v1/posts/{postId}/reactions
+func (h *ReactionHandler) AddReactionToPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.CreateReactionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	reaction, err := h.reactionService.AddReactionToPost(r.Context(), postID, userID, req.Emoji)
+	if err != nil {
+		switch err.Error() {
+		case "emoji is required":
+			writeError(w, http.StatusBadRequest, "EMOJI_REQUIRED", err.Error())
+		case "emoji must be 10 characters or less":
+			writeError(w, http.StatusBadRequest, "EMOJI_TOO_LONG", err.Error())
+		case "post not found":
+			writeError(w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "REACTION_CREATION_FAILED", "Failed to add reaction")
+		}
+		return
+	}
+
+	response := models.CreateReactionResponse{
+		Reaction: *reaction,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}
+
+func extractPostIDFromPath(path string) (uuid.UUID, error) {
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part == "posts" && i+1 < len(pathParts) {
+			return uuid.Parse(pathParts[i+1])
+		}
+	}
+	return uuid.Nil, errors.New("post ID not found in path")
+}

--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -8,18 +8,18 @@ import (
 
 // Comment represents a comment in the system
 type Comment struct {
-	ID                uuid.UUID  `json:"id"`
-	UserID            uuid.UUID  `json:"user_id"`
-	PostID            uuid.UUID  `json:"post_id"`
-	ParentCommentID   *uuid.UUID `json:"parent_comment_id,omitempty"`
-	Content           string     `json:"content"`
-	Links             []Link     `json:"links,omitempty"`
-	CreatedAt         time.Time  `json:"created_at"`
-	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
-	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
-	DeletedByUserID   *uuid.UUID `json:"deleted_by_user_id,omitempty"`
-	User              *User      `json:"user,omitempty"`
-	Replies           []Comment  `json:"replies,omitempty"`
+	ID              uuid.UUID  `json:"id"`
+	UserID          uuid.UUID  `json:"user_id"`
+	PostID          uuid.UUID  `json:"post_id"`
+	ParentCommentID *uuid.UUID `json:"parent_comment_id,omitempty"`
+	Content         string     `json:"content"`
+	Links           []Link     `json:"links,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletedByUserID *uuid.UUID `json:"deleted_by_user_id,omitempty"`
+	User            *User      `json:"user,omitempty"`
+	Replies         []Comment  `json:"replies,omitempty"`
 }
 
 // CreateCommentRequest represents the request body for creating a comment

--- a/backend/internal/models/reaction.go
+++ b/backend/internal/models/reaction.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Reaction represents a reaction on a post or comment
+type Reaction struct {
+	ID        uuid.UUID  `json:"id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	PostID    *uuid.UUID `json:"post_id,omitempty"`
+	CommentID *uuid.UUID `json:"comment_id,omitempty"`
+	Emoji     string     `json:"emoji"`
+	CreatedAt time.Time  `json:"created_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+// CreateReactionRequest represents the request body for creating a reaction
+type CreateReactionRequest struct {
+	Emoji string `json:"emoji"`
+}
+
+// CreateReactionResponse represents the response for creating a reaction
+type CreateReactionResponse struct {
+	Reaction Reaction `json:"reaction"`
+}

--- a/backend/internal/services/reaction.go
+++ b/backend/internal/services/reaction.go
@@ -1,0 +1,136 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+// ReactionService handles reaction-related operations
+type ReactionService struct {
+	db *sql.DB
+}
+
+// NewReactionService creates a new reaction service
+func NewReactionService(db *sql.DB) *ReactionService {
+	return &ReactionService{db: db}
+}
+
+// AddReactionToPost adds a reaction to a post
+func (s *ReactionService) AddReactionToPost(ctx context.Context, postID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	if err := validateEmoji(emoji); err != nil {
+		return nil, err
+	}
+
+	if err := s.verifyPostExists(ctx, postID); err != nil {
+		return nil, err
+	}
+
+	existingReaction, err := s.getExistingPostReaction(ctx, postID, userID, emoji)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingReaction != nil {
+		if existingReaction.DeletedAt != nil {
+			return s.restoreReaction(ctx, existingReaction.ID)
+		}
+		return existingReaction, nil
+	}
+
+	return s.createPostReaction(ctx, postID, userID, emoji)
+}
+
+func validateEmoji(emoji string) error {
+	emoji = strings.TrimSpace(emoji)
+	if emoji == "" {
+		return fmt.Errorf("emoji is required")
+	}
+	if len(emoji) > 10 {
+		return fmt.Errorf("emoji must be 10 characters or less")
+	}
+	return nil
+}
+
+func (s *ReactionService) verifyPostExists(ctx context.Context, postID uuid.UUID) error {
+	var postExists bool
+	err := s.db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM posts WHERE id = $1 AND deleted_at IS NULL)",
+		postID,
+	).Scan(&postExists)
+	if err != nil {
+		return fmt.Errorf("failed to check post existence: %w", err)
+	}
+	if !postExists {
+		return errors.New("post not found")
+	}
+	return nil
+}
+
+func (s *ReactionService) getExistingPostReaction(ctx context.Context, postID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	query := `
+		SELECT id, user_id, post_id, comment_id, emoji, created_at, deleted_at
+		FROM reactions
+		WHERE user_id = $1 AND post_id = $2 AND emoji = $3
+	`
+
+	var reaction models.Reaction
+	err := s.db.QueryRowContext(ctx, query, userID, postID, emoji).Scan(
+		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
+		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing reaction: %w", err)
+	}
+
+	return &reaction, nil
+}
+
+func (s *ReactionService) restoreReaction(ctx context.Context, reactionID uuid.UUID) (*models.Reaction, error) {
+	query := `
+		UPDATE reactions
+		SET deleted_at = NULL
+		WHERE id = $1
+		RETURNING id, user_id, post_id, comment_id, emoji, created_at, deleted_at
+	`
+
+	var reaction models.Reaction
+	err := s.db.QueryRowContext(ctx, query, reactionID).Scan(
+		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
+		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to restore reaction: %w", err)
+	}
+
+	return &reaction, nil
+}
+
+func (s *ReactionService) createPostReaction(ctx context.Context, postID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	query := `
+		INSERT INTO reactions (id, user_id, post_id, emoji, created_at)
+		VALUES ($1, $2, $3, $4, now())
+		RETURNING id, user_id, post_id, comment_id, emoji, created_at, deleted_at
+	`
+
+	reactionID := uuid.New()
+	var reaction models.Reaction
+	err := s.db.QueryRowContext(ctx, query, reactionID, userID, postID, emoji).Scan(
+		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
+		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reaction: %w", err)
+	}
+
+	return &reaction, nil
+}

--- a/backend/internal/services/reaction_test.go
+++ b/backend/internal/services/reaction_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestAddReactionToPost(t *testing.T) {
+	t.Skip("requires test database setup")
+}
+
+func TestValidateEmoji(t *testing.T) {
+	tests := []struct {
+		name    string
+		emoji   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid emoji",
+			emoji:   "👍",
+			wantErr: false,
+		},
+		{
+			name:    "valid text emoji",
+			emoji:   ":thumbsup:",
+			wantErr: false,
+		},
+		{
+			name:    "empty emoji",
+			emoji:   "",
+			wantErr: true,
+			errMsg:  "emoji is required",
+		},
+		{
+			name:    "whitespace only",
+			emoji:   "   ",
+			wantErr: true,
+			errMsg:  "emoji is required",
+		},
+		{
+			name:    "emoji too long",
+			emoji:   "12345678901",
+			wantErr: true,
+			errMsg:  "emoji must be 10 characters or less",
+		},
+		{
+			name:    "emoji at max length",
+			emoji:   "1234567890",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEmoji(tt.emoji)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateEmoji() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err.Error() != tt.errMsg {
+				t.Errorf("validateEmoji() error message = %q, want %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #21

## Summary
Implements POST /api/v1/posts/{postId}/reactions endpoint for adding reactions to posts.

## Changes
- **Model**: Added `Reaction` model with request/response types
- **Service**: Added `ReactionService` with `AddReactionToPost` method
- **Handler**: Added `ReactionHandler` with authentication via middleware
- **Routing**: Wired endpoint in main.go

## Behavior
- Accepts emoji in request body
- Creates reaction record (user_id, post_id, emoji)
- Returns existing reaction if duplicate (one reaction per user per post per emoji)
- Restores soft-deleted reaction if user is re-adding
- Returns 404 if post not found

## Testing
- Unit tests for emoji validation
- Build verified with `go build ./...`