### PR TITLE
Phase 2: Implement soft delete comment endpoint

### DIFF
--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -8,18 +8,18 @@ import (
 
 // Comment represents a comment in the system
 type Comment struct {
-	ID                uuid.UUID  `json:"id"`
-	UserID            uuid.UUID  `json:"user_id"`
-	PostID            uuid.UUID  `json:"post_id"`
-	ParentCommentID   *uuid.UUID `json:"parent_comment_id,omitempty"`
-	Content           string     `json:"content"`
-	Links             []Link     `json:"links,omitempty"`
-	CreatedAt         time.Time  `json:"created_at"`
-	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
-	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
-	DeletedByUserID   *uuid.UUID `json:"deleted_by_user_id,omitempty"`
-	User              *User      `json:"user,omitempty"`
-	Replies           []Comment  `json:"replies,omitempty"`
+	ID              uuid.UUID  `json:"id"`
+	UserID          uuid.UUID  `json:"user_id"`
+	PostID          uuid.UUID  `json:"post_id"`
+	ParentCommentID *uuid.UUID `json:"parent_comment_id,omitempty"`
+	Content         string     `json:"content"`
+	Links           []Link     `json:"links,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletedByUserID *uuid.UUID `json:"deleted_by_user_id,omitempty"`
+	User            *User      `json:"user,omitempty"`
+	Replies         []Comment  `json:"replies,omitempty"`
 }
 
 // CreateCommentRequest represents the request body for creating a comment
@@ -50,4 +50,10 @@ type PageMeta struct {
 type GetThreadResponse struct {
 	Comments []Comment `json:"comments"`
 	Meta     PageMeta  `json:"meta"`
+}
+
+// DeleteCommentResponse represents the response for deleting a comment
+type DeleteCommentResponse struct {
+	Comment *Comment `json:"comment"`
+	Message string   `json:"message"`
 }


### PR DESCRIPTION
## Summary
Implements DELETE /api/v1/comments/{id} for soft-deleting comments.

## Changes
- Add `DeleteComment` service method with transaction support
- Add `DeleteComment` handler with proper auth/permission checks
- Add `DeleteCommentResponse` model
- Register DELETE route in main.go with auth middleware
- Add handler tests

## Acceptance Criteria
- ✅ Owner can delete own comment
- ✅ Admin can delete any comment  
- ✅ Permissions enforced (403 for unauthorized)
- ✅ Audit logged if admin deletes another user's comment

Closes #19