### PR TITLE
Phase 2: Implement reactions on comments

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -77,7 +77,15 @@ func main() {
 
 	// Comment routes - route to appropriate handler based on method
 	commentRouteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/reactions") {
+			// POST /api/v1/comments/{id}/reactions
+			reactionAuthHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(reactionHandler.AddReactionToComment))
+			reactionAuthHandler.ServeHTTP(w, r)
+		} else if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {
+			// DELETE /api/v1/comments/{id}/reactions/{emoji}
+			reactionAuthHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(reactionHandler.RemoveReactionFromComment))
+			reactionAuthHandler.ServeHTTP(w, r)
+		} else if r.Method == http.MethodGet {
 			commentHandler.GetComment(w, r)
 		} else if r.Method == http.MethodDelete {
 			authHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(commentHandler.DeleteComment))
@@ -107,7 +115,7 @@ func main() {
 			reactionAuthHandler.ServeHTTP(w, r)
 		} else if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {
 			// DELETE /api/v1/posts/{id}/reactions/{emoji}
-			reactionAuthHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(reactionHandler.RemoveReaction))
+			reactionAuthHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(reactionHandler.RemoveReactionFromPost))
 			reactionAuthHandler.ServeHTTP(w, r)
 		} else if r.Method == http.MethodGet {
 			postHandler.GetPost(w, r)

--- a/backend/internal/handlers/reaction.go
+++ b/backend/internal/handlers/reaction.go
@@ -75,8 +75,8 @@ func (h *ReactionHandler) AddReactionToPost(w http.ResponseWriter, r *http.Reque
 	json.NewEncoder(w).Encode(response)
 }
 
-// RemoveReaction handles DELETE /api/v1/posts/{postId}/reactions/{emoji}
-func (h *ReactionHandler) RemoveReaction(w http.ResponseWriter, r *http.Request) {
+// RemoveReactionFromPost handles DELETE /api/v1/posts/{postId}/reactions/{emoji}
+func (h *ReactionHandler) RemoveReactionFromPost(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
 		return
@@ -112,7 +112,106 @@ func (h *ReactionHandler) RemoveReaction(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err = h.reactionService.RemoveReaction(r.Context(), postID, emoji, userID)
+	err = h.reactionService.RemoveReactionFromPost(r.Context(), postID, emoji, userID)
+	if err != nil {
+		if err.Error() == "reaction not found" {
+			writeError(w, http.StatusNotFound, "REACTION_NOT_FOUND", "Reaction not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "REMOVE_REACTION_FAILED", "Failed to remove reaction")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AddReactionToComment handles POST /api/v1/comments/{commentId}/reactions
+func (h *ReactionHandler) AddReactionToComment(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	commentID, err := extractCommentIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_COMMENT_ID", "Invalid comment ID format")
+		return
+	}
+
+	var req models.CreateReactionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	reaction, err := h.reactionService.AddReactionToComment(r.Context(), commentID, userID, req.Emoji)
+	if err != nil {
+		switch err.Error() {
+		case "emoji is required":
+			writeError(w, http.StatusBadRequest, "EMOJI_REQUIRED", err.Error())
+		case "emoji must be 10 characters or less":
+			writeError(w, http.StatusBadRequest, "EMOJI_TOO_LONG", err.Error())
+		case "comment not found":
+			writeError(w, http.StatusNotFound, "COMMENT_NOT_FOUND", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "REACTION_CREATION_FAILED", "Failed to add reaction")
+		}
+		return
+	}
+
+	response := models.CreateReactionResponse{
+		Reaction: *reaction,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}
+
+// RemoveReactionFromComment handles DELETE /api/v1/comments/{commentId}/reactions/{emoji}
+func (h *ReactionHandler) RemoveReactionFromComment(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 7 {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Comment ID and emoji are required")
+		return
+	}
+
+	commentIDStr := pathParts[4]
+	commentID, err := uuid.Parse(commentIDStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_COMMENT_ID", "Invalid comment ID format")
+		return
+	}
+
+	emoji, err := url.PathUnescape(pathParts[6])
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_EMOJI", "Invalid emoji format")
+		return
+	}
+
+	if emoji == "" {
+		writeError(w, http.StatusBadRequest, "EMOJI_REQUIRED", "Emoji is required")
+		return
+	}
+
+	err = h.reactionService.RemoveReactionFromComment(r.Context(), commentID, emoji, userID)
 	if err != nil {
 		if err.Error() == "reaction not found" {
 			writeError(w, http.StatusNotFound, "REACTION_NOT_FOUND", "Reaction not found")
@@ -133,4 +232,14 @@ func extractPostIDFromPath(path string) (uuid.UUID, error) {
 		}
 	}
 	return uuid.Nil, errors.New("post ID not found in path")
+}
+
+func extractCommentIDFromPath(path string) (uuid.UUID, error) {
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part == "comments" && i+1 < len(pathParts) {
+			return uuid.Parse(pathParts[i+1])
+		}
+	}
+	return uuid.Nil, errors.New("comment ID not found in path")
 }

--- a/backend/internal/services/reaction.go
+++ b/backend/internal/services/reaction.go
@@ -46,15 +46,65 @@ func (s *ReactionService) AddReactionToPost(ctx context.Context, postID uuid.UUI
 	return s.createPostReaction(ctx, postID, userID, emoji)
 }
 
-// RemoveReaction removes a reaction from a post
+// RemoveReactionFromPost removes a reaction from a post
 // Users can only remove their own reactions
-func (s *ReactionService) RemoveReaction(ctx context.Context, postID uuid.UUID, emoji string, userID uuid.UUID) error {
+func (s *ReactionService) RemoveReactionFromPost(ctx context.Context, postID uuid.UUID, emoji string, userID uuid.UUID) error {
 	query := `
 		DELETE FROM reactions
 		WHERE post_id = $1 AND emoji = $2 AND user_id = $3 AND deleted_at IS NULL
 	`
 
 	result, err := s.db.ExecContext(ctx, query, postID, emoji, userID)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("reaction not found")
+	}
+
+	return nil
+}
+
+// AddReactionToComment adds a reaction to a comment
+func (s *ReactionService) AddReactionToComment(ctx context.Context, commentID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	if err := validateEmoji(emoji); err != nil {
+		return nil, err
+	}
+
+	if err := s.verifyCommentExists(ctx, commentID); err != nil {
+		return nil, err
+	}
+
+	existingReaction, err := s.getExistingCommentReaction(ctx, commentID, userID, emoji)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingReaction != nil {
+		if existingReaction.DeletedAt != nil {
+			return s.restoreReaction(ctx, existingReaction.ID)
+		}
+		return existingReaction, nil
+	}
+
+	return s.createCommentReaction(ctx, commentID, userID, emoji)
+}
+
+// RemoveReactionFromComment removes a reaction from a comment
+// Users can only remove their own reactions
+func (s *ReactionService) RemoveReactionFromComment(ctx context.Context, commentID uuid.UUID, emoji string, userID uuid.UUID) error {
+	query := `
+		DELETE FROM reactions
+		WHERE comment_id = $1 AND emoji = $2 AND user_id = $3 AND deleted_at IS NULL
+	`
+
+	result, err := s.db.ExecContext(ctx, query, commentID, emoji, userID)
 	if err != nil {
 		return err
 	}
@@ -150,6 +200,64 @@ func (s *ReactionService) createPostReaction(ctx context.Context, postID uuid.UU
 	reactionID := uuid.New()
 	var reaction models.Reaction
 	err := s.db.QueryRowContext(ctx, query, reactionID, userID, postID, emoji).Scan(
+		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
+		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reaction: %w", err)
+	}
+
+	return &reaction, nil
+}
+
+func (s *ReactionService) verifyCommentExists(ctx context.Context, commentID uuid.UUID) error {
+	var commentExists bool
+	err := s.db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM comments WHERE id = $1 AND deleted_at IS NULL)",
+		commentID,
+	).Scan(&commentExists)
+	if err != nil {
+		return fmt.Errorf("failed to check comment existence: %w", err)
+	}
+	if !commentExists {
+		return errors.New("comment not found")
+	}
+	return nil
+}
+
+func (s *ReactionService) getExistingCommentReaction(ctx context.Context, commentID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	query := `
+		SELECT id, user_id, post_id, comment_id, emoji, created_at, deleted_at
+		FROM reactions
+		WHERE user_id = $1 AND comment_id = $2 AND emoji = $3
+	`
+
+	var reaction models.Reaction
+	err := s.db.QueryRowContext(ctx, query, userID, commentID, emoji).Scan(
+		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
+		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing reaction: %w", err)
+	}
+
+	return &reaction, nil
+}
+
+func (s *ReactionService) createCommentReaction(ctx context.Context, commentID uuid.UUID, userID uuid.UUID, emoji string) (*models.Reaction, error) {
+	query := `
+		INSERT INTO reactions (id, user_id, comment_id, emoji, created_at)
+		VALUES ($1, $2, $3, $4, now())
+		RETURNING id, user_id, post_id, comment_id, emoji, created_at, deleted_at
+	`
+
+	reactionID := uuid.New()
+	var reaction models.Reaction
+	err := s.db.QueryRowContext(ctx, query, reactionID, userID, commentID, emoji).Scan(
 		&reaction.ID, &reaction.UserID, &reaction.PostID, &reaction.CommentID,
 		&reaction.Emoji, &reaction.CreatedAt, &reaction.DeletedAt,
 	)


### PR DESCRIPTION
Adds POST/DELETE endpoints for comment reactions:

- `POST /api/v1/comments/{commentId}/reactions` - Add a reaction to a comment
- `DELETE /api/v1/comments/{commentId}/reactions/{emoji}` - Remove a reaction from a comment

Same validation as post reactions:
- Emoji required and max 10 characters
- Users can only remove their own reactions
- 404 if comment not found

Closes #23