### PR TITLE
Phase 2: Implement get user posts endpoint

### DIFF
--- a/backend/internal/handlers/user.go
+++ b/backend/internal/handlers/user.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -13,12 +14,14 @@ import (
 // UserHandler handles user endpoints
 type UserHandler struct {
 	userService *services.UserService
+	postService *services.PostService
 }
 
 // NewUserHandler creates a new user handler
 func NewUserHandler(db *sql.DB) *UserHandler {
 	return &UserHandler{
 		userService: services.NewUserService(db),
+		postService: services.NewPostService(db),
 	}
 }
 
@@ -55,4 +58,58 @@ func (h *UserHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(profile)
+}
+
+// GetUserPosts handles GET /api/v1/users/{id}/posts
+func (h *UserHandler) GetUserPosts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	// Extract user ID from URL path: /api/v1/users/{id}/posts
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 6 || pathParts[5] != "posts" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "User ID is required")
+		return
+	}
+
+	userIDStr := pathParts[4]
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_USER_ID", "Invalid user ID format")
+		return
+	}
+
+	// Parse query parameters
+	cursor := r.URL.Query().Get("cursor")
+	limitStr := r.URL.Query().Get("limit")
+
+	limit := 20
+	if limitStr != "" {
+		if parsedLimit, err := strconv.Atoi(limitStr); err == nil && parsedLimit > 0 {
+			limit = parsedLimit
+		}
+	}
+
+	// Clamp limit to reasonable range
+	if limit > 100 {
+		limit = 100
+	}
+
+	// Get user posts from service
+	var cursorPtr *string
+	if cursor != "" {
+		cursorPtr = &cursor
+	}
+
+	feed, err := h.postService.GetPostsByUserID(r.Context(), userID, cursorPtr, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "GET_USER_POSTS_FAILED", "Failed to get user posts")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(feed)
 }

--- a/backend/internal/handlers/user_test.go
+++ b/backend/internal/handlers/user_test.go
@@ -248,3 +248,322 @@ func TestGetProfileUnapprovedUser(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
 	}
 }
+
+// TestGetUserPostsSuccess tests successfully retrieving a user's posts
+func TestGetUserPostsSuccess(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	// Create test user
+	userID := uuid.New()
+	testUsername := "postuser"
+	testEmail := "postuser@example.com"
+	testHash := "$2a$12$test"
+
+	userQuery := `
+		INSERT INTO users (id, username, email, password_hash, is_admin, approved_at, created_at)
+		VALUES ($1, $2, $3, $4, false, now(), now())
+	`
+	_, err = db.Exec(userQuery, userID, testUsername, testEmail, testHash)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// Create test section
+	sectionID := uuid.New()
+	sectionQuery := `INSERT INTO sections (id, name, type, created_at) VALUES ($1, 'Test Section', 'general', now())`
+	_, err = db.Exec(sectionQuery, sectionID)
+	if err != nil {
+		t.Fatalf("failed to create test section: %v", err)
+	}
+
+	// Create test posts
+	postID1 := uuid.New()
+	postID2 := uuid.New()
+	postQuery := `INSERT INTO posts (id, user_id, section_id, content, created_at) VALUES ($1, $2, $3, $4, now())`
+	_, err = db.Exec(postQuery, postID1, userID, sectionID, "Test post 1")
+	if err != nil {
+		t.Fatalf("failed to create test post 1: %v", err)
+	}
+	_, err = db.Exec(postQuery, postID2, userID, sectionID, "Test post 2")
+	if err != nil {
+		t.Fatalf("failed to create test post 2: %v", err)
+	}
+
+	handler := NewUserHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/users/"+userID.String()+"/posts", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 2 {
+		t.Errorf("expected 2 posts, got %d", len(response.Posts))
+	}
+
+	if response.HasMore {
+		t.Errorf("expected has_more to be false")
+	}
+}
+
+// TestGetUserPostsEmptyResult tests that non-existent user returns empty posts list
+func TestGetUserPostsEmptyResult(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	handler := NewUserHandler(db)
+	randomID := uuid.New()
+
+	req := httptest.NewRequest("GET", "/api/v1/users/"+randomID.String()+"/posts", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 0 {
+		t.Errorf("expected 0 posts, got %d", len(response.Posts))
+	}
+}
+
+// TestGetUserPostsInvalidID tests with invalid user ID format
+func TestGetUserPostsInvalidID(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	handler := NewUserHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/users/not-a-uuid/posts", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_USER_ID" {
+		t.Errorf("expected code INVALID_USER_ID, got %s", response.Code)
+	}
+}
+
+// TestGetUserPostsMethodNotAllowed tests with non-GET method
+func TestGetUserPostsMethodNotAllowed(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	handler := NewUserHandler(db)
+	userID := uuid.New()
+
+	req := httptest.NewRequest("POST", "/api/v1/users/"+userID.String()+"/posts", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "METHOD_NOT_ALLOWED" {
+		t.Errorf("expected code METHOD_NOT_ALLOWED, got %s", response.Code)
+	}
+}
+
+// TestGetUserPostsExcludesSoftDeleted tests that soft-deleted posts are excluded
+func TestGetUserPostsExcludesSoftDeleted(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	// Create test user
+	userID := uuid.New()
+	testUsername := "softdeletepostuser"
+	testEmail := "softdeletepost@example.com"
+	testHash := "$2a$12$test"
+
+	userQuery := `
+		INSERT INTO users (id, username, email, password_hash, is_admin, approved_at, created_at)
+		VALUES ($1, $2, $3, $4, false, now(), now())
+	`
+	_, err = db.Exec(userQuery, userID, testUsername, testEmail, testHash)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// Create test section
+	sectionID := uuid.New()
+	sectionQuery := `INSERT INTO sections (id, name, type, created_at) VALUES ($1, 'Test Section', 'general', now())`
+	_, err = db.Exec(sectionQuery, sectionID)
+	if err != nil {
+		t.Fatalf("failed to create test section: %v", err)
+	}
+
+	// Create normal post
+	normalPostID := uuid.New()
+	postQuery := `INSERT INTO posts (id, user_id, section_id, content, created_at) VALUES ($1, $2, $3, $4, now())`
+	_, err = db.Exec(postQuery, normalPostID, userID, sectionID, "Normal post")
+	if err != nil {
+		t.Fatalf("failed to create normal post: %v", err)
+	}
+
+	// Create soft-deleted post
+	deletedPostID := uuid.New()
+	deletedPostQuery := `INSERT INTO posts (id, user_id, section_id, content, created_at, deleted_at) VALUES ($1, $2, $3, $4, now(), now())`
+	_, err = db.Exec(deletedPostQuery, deletedPostID, userID, sectionID, "Deleted post")
+	if err != nil {
+		t.Fatalf("failed to create deleted post: %v", err)
+	}
+
+	handler := NewUserHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/users/"+userID.String()+"/posts", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 1 {
+		t.Errorf("expected 1 post (soft-deleted excluded), got %d", len(response.Posts))
+	}
+
+	if len(response.Posts) > 0 && response.Posts[0].ID != normalPostID {
+		t.Errorf("expected normal post ID %s, got %s", normalPostID, response.Posts[0].ID)
+	}
+}
+
+// TestGetUserPostsPagination tests cursor-based pagination
+func TestGetUserPostsPagination(t *testing.T) {
+	db, err := getTestDB()
+	if err != nil {
+		t.Fatalf("failed to get test DB: %v", err)
+	}
+	if db == nil {
+		t.Skip("test database not configured")
+	}
+	defer db.Close()
+
+	// Create test user
+	userID := uuid.New()
+	testUsername := "paginationuser"
+	testEmail := "pagination@example.com"
+	testHash := "$2a$12$test"
+
+	userQuery := `
+		INSERT INTO users (id, username, email, password_hash, is_admin, approved_at, created_at)
+		VALUES ($1, $2, $3, $4, false, now(), now())
+	`
+	_, err = db.Exec(userQuery, userID, testUsername, testEmail, testHash)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// Create test section
+	sectionID := uuid.New()
+	sectionQuery := `INSERT INTO sections (id, name, type, created_at) VALUES ($1, 'Test Section', 'general', now())`
+	_, err = db.Exec(sectionQuery, sectionID)
+	if err != nil {
+		t.Fatalf("failed to create test section: %v", err)
+	}
+
+	// Create 3 posts
+	for i := 0; i < 3; i++ {
+		postID := uuid.New()
+		postQuery := `INSERT INTO posts (id, user_id, section_id, content, created_at) VALUES ($1, $2, $3, $4, now())`
+		_, err = db.Exec(postQuery, postID, userID, sectionID, "Test post")
+		if err != nil {
+			t.Fatalf("failed to create test post: %v", err)
+		}
+	}
+
+	handler := NewUserHandler(db)
+
+	// Request with limit=2
+	req := httptest.NewRequest("GET", "/api/v1/users/"+userID.String()+"/posts?limit=2", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetUserPosts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Errorf("failed to decode response: %v", err)
+	}
+
+	if len(response.Posts) != 2 {
+		t.Errorf("expected 2 posts, got %d", len(response.Posts))
+	}
+
+	if !response.HasMore {
+		t.Errorf("expected has_more to be true")
+	}
+
+	if response.NextCursor == nil {
+		t.Errorf("expected next_cursor to be set")
+	}
+}

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -400,6 +400,97 @@ func (s *PostService) RestorePost(ctx context.Context, postID uuid.UUID, userID 
 	return &post, nil
 }
 
+// GetPostsByUserID retrieves a paginated list of posts by a specific user using cursor-based pagination
+func (s *PostService) GetPostsByUserID(ctx context.Context, userID uuid.UUID, cursor *string, limit int) (*models.FeedResponse, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	// Build base query
+	query := `
+		SELECT
+			p.id, p.user_id, p.section_id, p.content,
+			p.created_at, p.updated_at, p.deleted_at, p.deleted_by_user_id,
+			u.id, u.username, u.email, u.profile_picture_url, u.bio, u.is_admin, u.created_at,
+			COALESCE(COUNT(DISTINCT c.id), 0) as comment_count
+		FROM posts p
+		JOIN users u ON p.user_id = u.id
+		LEFT JOIN comments c ON p.id = c.post_id AND c.deleted_at IS NULL
+		WHERE p.user_id = $1 AND p.deleted_at IS NULL
+	`
+
+	args := []interface{}{userID}
+	argIndex := 2
+
+	// Apply cursor if provided (cursor is the created_at timestamp from the last post)
+	if cursor != nil && *cursor != "" {
+		query += fmt.Sprintf(" AND p.created_at < $%d", argIndex)
+		args = append(args, *cursor)
+		argIndex++
+	}
+
+	query += fmt.Sprintf(" GROUP BY p.id, u.id ORDER BY p.created_at DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1) // Fetch one extra to determine if hasMore
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var posts []*models.Post
+	for rows.Next() {
+		var post models.Post
+		var user models.User
+
+		err := rows.Scan(
+			&post.ID, &post.UserID, &post.SectionID, &post.Content,
+			&post.CreatedAt, &post.UpdatedAt, &post.DeletedAt, &post.DeletedByUserID,
+			&user.ID, &user.Username, &user.Email, &user.ProfilePictureURL, &user.Bio, &user.IsAdmin, &user.CreatedAt,
+			&post.CommentCount,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		post.User = &user
+
+		// Fetch links for this post
+		links, err := s.getPostLinks(ctx, post.ID)
+		if err != nil {
+			return nil, err
+		}
+		post.Links = links
+
+		posts = append(posts, &post)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Determine if there are more posts
+	hasMore := len(posts) > limit
+	if hasMore {
+		posts = posts[:limit] // Trim to the requested limit
+	}
+
+	// Determine next cursor
+	var nextCursor *string
+	if hasMore && len(posts) > 0 {
+		// Next cursor is the created_at of the last post in the result
+		lastPost := posts[len(posts)-1]
+		cursorStr := lastPost.CreatedAt.Format("2006-01-02T15:04:05.000Z07:00")
+		nextCursor = &cursorStr
+	}
+
+	return &models.FeedResponse{
+		Posts:      posts,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	}, nil
+}
+
 // validateCreatePostInput validates post creation input
 func validateCreatePostInput(req *models.CreatePostRequest) error {
 	if strings.TrimSpace(req.SectionID) == "" {


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/users/{id}/posts` endpoint for retrieving a user's posts
- Implement cursor-based pagination with configurable limit (default 20, max 100)
- Exclude soft-deleted posts from results
- Add comprehensive test coverage for the new endpoint

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Unit tests added for GetUserPosts handler
- [ ] Manual testing with real database

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)