### PR TITLE
Phase 2: Implement get user comments endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -82,6 +82,10 @@ func main() {
 			// GET /api/v1/users/{id}/posts
 			postsHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(userHandler.GetUserPosts))
 			postsHandler.ServeHTTP(w, r)
+		} else if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments") {
+			// GET /api/v1/users/{id}/comments
+			commentsHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(userHandler.GetUserComments))
+			commentsHandler.ServeHTTP(w, r)
 		} else if r.Method == http.MethodGet {
 			// GET /api/v1/users/{id}
 			profileHandler := middleware.RequireAuth(redisConn)(http.HandlerFunc(userHandler.GetProfile))


### PR DESCRIPTION
## Summary
- Implements `GET /api/v1/users/{id}/comments` endpoint
- Returns paginated list of user's comments with cursor-based pagination
- Excludes soft-deleted comments from results
- Includes tests for success, not found, invalid ID, method not allowed, and soft-delete exclusion cases

## Test plan
- [ ] Verify endpoint returns user's comments ordered by created_at DESC
- [ ] Verify cursor-based pagination works correctly
- [ ] Verify soft-deleted comments are excluded
- [ ] Verify 404 returned for non-existent users
- [ ] Verify 400 returned for invalid user ID format

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)