### PR TITLE
Phase 2: Implement update own profile endpoint

### DIFF
--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -109,3 +109,19 @@ type UserProfileResponse struct {
 	CreatedAt         time.Time `json:"created_at"`
 	Stats             UserStats `json:"stats"`
 }
+
+// UpdateUserRequest represents the request to update user profile
+type UpdateUserRequest struct {
+	Bio               *string `json:"bio,omitempty"`
+	ProfilePictureUrl *string `json:"profile_picture_url,omitempty"`
+}
+
+// UpdateUserResponse represents the response from updating user profile
+type UpdateUserResponse struct {
+	ID                uuid.UUID `json:"id"`
+	Username          string    `json:"username"`
+	Email             string    `json:"email"`
+	ProfilePictureUrl *string   `json:"profile_picture_url,omitempty"`
+	Bio               *string   `json:"bio,omitempty"`
+	IsAdmin           bool      `json:"is_admin"`
+}

--- a/backend/internal/services/user_test.go
+++ b/backend/internal/services/user_test.go
@@ -194,3 +194,70 @@ func TestIsStrongPassword(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateProfilePictureURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid https URL",
+			url:     "https://example.com/image.png",
+			wantErr: false,
+		},
+		{
+			name:    "valid http URL",
+			url:     "http://example.com/image.jpg",
+			wantErr: false,
+		},
+		{
+			name:    "valid URL with path and query",
+			url:     "https://cdn.example.com/images/avatar.png?size=256",
+			wantErr: false,
+		},
+		{
+			name:    "invalid - no scheme",
+			url:     "example.com/image.png",
+			wantErr: true,
+			errMsg:  "profile picture URL must use http or https scheme",
+		},
+		{
+			name:    "invalid - ftp scheme",
+			url:     "ftp://example.com/image.png",
+			wantErr: true,
+			errMsg:  "profile picture URL must use http or https scheme",
+		},
+		{
+			name:    "invalid - file scheme",
+			url:     "file:///etc/passwd",
+			wantErr: true,
+			errMsg:  "profile picture URL must use http or https scheme",
+		},
+		{
+			name:    "invalid - javascript scheme",
+			url:     "javascript:alert(1)",
+			wantErr: true,
+			errMsg:  "profile picture URL must use http or https scheme",
+		},
+		{
+			name:    "invalid - no host",
+			url:     "https:///path",
+			wantErr: true,
+			errMsg:  "invalid profile picture URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProfilePictureURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateProfilePictureURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("validateProfilePictureURL() error = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/v1/users/me` endpoint for authenticated users to update their own profile
- Users can update `bio` and `profile_picture_url` fields
- Profile picture URL is validated to ensure it uses http/https scheme
- Returns the updated user object

## Changes
- **Models**: Added `UpdateUserRequest` and `UpdateUserResponse` types
- **Service**: Added `UpdateProfile` method with `validateProfilePictureURL` helper
- **Handler**: Added `UpdateMe` handler that extracts user from auth context
- **Routes**: Registered the new endpoint with auth middleware
- **Tests**: Added handler and service tests for the new functionality

## Test plan
- [x] Unit tests for URL validation pass
- [x] Handler tests cover success and error cases
- [x] Backend builds without errors
- [x] Existing tests still pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)