### PR TITLE
Phase 4: Implement full-text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ go mod download
 # Build
 go build -o clubhouse-server ./cmd/server
 
+# Run migrations (if database is running)
+migrate -path migrations -database "$DATABASE_URL" up
+
 # Run (ensure .env is configured)
 ./clubhouse-server
 ```

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -69,6 +69,7 @@ func main() {
 	reactionHandler := handlers.NewReactionHandler(dbConn, redisConn)
 	userHandler := handlers.NewUserHandler(dbConn)
 	sectionHandler := handlers.NewSectionHandler(dbConn)
+	searchHandler := handlers.NewSearchHandler(dbConn)
 	wsHandler := handlers.NewWebSocketHandler(redisConn)
 
 	// API routes
@@ -182,6 +183,9 @@ func main() {
 		http.HandlerFunc(commentHandler.CreateComment),
 	)
 	mux.Handle("/api/v1/comments", commentCreateHandler)
+
+	// Search routes (protected)
+	mux.Handle("/api/v1/search", middleware.RequireAuth(redisConn)(http.HandlerFunc(searchHandler.Search)))
 
 	// Admin routes (protected by RequireAdmin middleware)
 	mux.Handle("/api/v1/admin/users", middleware.RequireAdmin(redisConn)(http.HandlerFunc(adminHandler.ListPendingUsers)))

--- a/backend/internal/handlers/search.go
+++ b/backend/internal/handlers/search.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// SearchHandler handles search endpoints.
+type SearchHandler struct {
+	searchService *services.SearchService
+}
+
+// NewSearchHandler creates a new search handler.
+func NewSearchHandler(db *sql.DB) *SearchHandler {
+	return &SearchHandler{
+		searchService: services.NewSearchService(db),
+	}
+}
+
+// Search handles GET /api/v1/search?q=query&scope=global.
+func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "QUERY_REQUIRED", "Query is required")
+		return
+	}
+
+	scope := strings.TrimSpace(r.URL.Query().Get("scope"))
+	if scope == "" {
+		scope = "section"
+	}
+
+	var sectionID *uuid.UUID
+	if scope == "section" {
+		sectionIDStr := strings.TrimSpace(r.URL.Query().Get("section_id"))
+		if sectionIDStr == "" {
+			writeError(w, http.StatusBadRequest, "SECTION_ID_REQUIRED", "Section ID is required for section scope")
+			return
+		}
+
+		parsedID, err := uuid.Parse(sectionIDStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_SECTION_ID", "Invalid section ID format")
+			return
+		}
+
+		sectionID = &parsedID
+	} else if scope != "global" {
+		writeError(w, http.StatusBadRequest, "INVALID_SCOPE", "Scope must be 'section' or 'global'")
+		return
+	}
+
+	limit := 20
+	if limitStr := strings.TrimSpace(r.URL.Query().Get("limit")); limitStr != "" {
+		parsedLimit, err := parseIntParam(limitStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_LIMIT", "Limit must be a number")
+			return
+		}
+		limit = parsedLimit
+	}
+
+	results, err := h.searchService.Search(r.Context(), q, scope, sectionID, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "SEARCH_FAILED", "Failed to search")
+		return
+	}
+
+	response := models.SearchResponse{Results: results}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/backend/internal/handlers/search_test.go
+++ b/backend/internal/handlers/search_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+func TestSearchMethodNotAllowed(t *testing.T) {
+	handler := &SearchHandler{}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/search", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, status)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "METHOD_NOT_ALLOWED" {
+		t.Fatalf("expected code METHOD_NOT_ALLOWED, got %s", response.Code)
+	}
+}
+
+func TestSearchMissingQuery(t *testing.T) {
+	handler := &SearchHandler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "QUERY_REQUIRED" {
+		t.Fatalf("expected code QUERY_REQUIRED, got %s", response.Code)
+	}
+}
+
+func TestSearchInvalidScope(t *testing.T) {
+	handler := &SearchHandler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=test&scope=invalid", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_SCOPE" {
+		t.Fatalf("expected code INVALID_SCOPE, got %s", response.Code)
+	}
+}
+
+func TestSearchSectionScopeMissingSectionID(t *testing.T) {
+	handler := &SearchHandler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=test&scope=section", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "SECTION_ID_REQUIRED" {
+		t.Fatalf("expected code SECTION_ID_REQUIRED, got %s", response.Code)
+	}
+}
+
+func TestSearchInvalidLimit(t *testing.T) {
+	handler := &SearchHandler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=test&scope=global&limit=abc", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_LIMIT" {
+		t.Fatalf("expected code INVALID_LIMIT, got %s", response.Code)
+	}
+}
+
+func TestSearchSuccessGlobal(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewSearchHandler(db)
+
+	query := "hello world"
+	limit := 2
+	postID := uuid.New()
+	commentID := uuid.New()
+	userID := uuid.New()
+	sectionID := uuid.New()
+	postCreated := time.Now()
+	commentCreated := time.Now()
+	userCreated := time.Now()
+
+	searchRows := sqlmock.NewRows([]string{"result_type", "id", "rank"}).
+		AddRow("post", postID, 0.42).
+		AddRow("comment", commentID, 0.31)
+
+	mock.ExpectQuery(regexp.QuoteMeta("WITH q AS")).
+		WithArgs(query, limit).
+		WillReturnRows(searchRows)
+
+	postRows := sqlmock.NewRows([]string{
+		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+	}).AddRow(
+		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).
+		WithArgs(postID).
+		WillReturnRows(postRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(postID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	commentRows := sqlmock.NewRows([]string{
+		"id", "user_id", "post_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
+	}).AddRow(
+		commentID, userID, postID, nil, "comment content", commentCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM comments c")).
+		WithArgs(commentID).
+		WillReturnRows(commentRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(commentID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=hello%20world&scope=global&limit=2", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	var response models.SearchResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(response.Results))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unfulfilled expectations: %v", err)
+	}
+}

--- a/backend/internal/models/search.go
+++ b/backend/internal/models/search.go
@@ -1,0 +1,14 @@
+package models
+
+// SearchResult represents a single search hit.
+type SearchResult struct {
+	Type    string   `json:"type"`
+	Score   float64  `json:"score"`
+	Post    *Post    `json:"post,omitempty"`
+	Comment *Comment `json:"comment,omitempty"`
+}
+
+// SearchResponse represents the response for search requests.
+type SearchResponse struct {
+	Results []SearchResult `json:"results"`
+}

--- a/backend/internal/services/search.go
+++ b/backend/internal/services/search.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+// SearchService handles search operations.
+type SearchService struct {
+	db             *sql.DB
+	postService    *PostService
+	commentService *CommentService
+}
+
+// NewSearchService creates a new search service.
+func NewSearchService(db *sql.DB) *SearchService {
+	return &SearchService{
+		db:             db,
+		postService:    NewPostService(db),
+		commentService: NewCommentService(db),
+	}
+}
+
+// Search searches posts and comments, including link metadata, with optional scope filtering.
+func (s *SearchService) Search(ctx context.Context, query string, scope string, sectionID *uuid.UUID, limit int) ([]models.SearchResult, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	linkText := "COALESCE(l.metadata->>'title','') || ' ' || COALESCE(l.metadata->>'description','') || ' ' || COALESCE(l.metadata->>'author','') || ' ' || COALESCE(l.metadata->>'artist','') || ' ' || COALESCE(l.metadata->>'provider','') || ' ' || COALESCE(l.url,'')"
+
+	postScopeFilter := ""
+	commentScopeFilter := ""
+	args := []any{query}
+	limitPlaceholder := "$2"
+	if scope == "section" {
+		postScopeFilter = " AND p.section_id = $2"
+		commentScopeFilter = " AND p.section_id = $2"
+		args = append(args, *sectionID)
+		limitPlaceholder = "$3"
+	}
+
+	queryText := fmt.Sprintf(`
+		WITH q AS (SELECT plainto_tsquery('english', $1) AS query),
+		post_matches AS (
+			SELECT p.id,
+				ts_rank_cd(to_tsvector('english', p.content), q.query)
+				+ COALESCE(MAX(ts_rank_cd(to_tsvector('english', %s), q.query)), 0) AS rank
+			FROM posts p
+			LEFT JOIN links l ON l.post_id = p.id
+			CROSS JOIN q
+			WHERE p.deleted_at IS NULL
+				AND (
+					to_tsvector('english', p.content) @@ q.query
+					OR to_tsvector('english', %s) @@ q.query
+				)
+				%s
+			GROUP BY p.id
+		),
+		comment_matches AS (
+			SELECT c.id,
+				ts_rank_cd(to_tsvector('english', c.content), q.query)
+				+ COALESCE(MAX(ts_rank_cd(to_tsvector('english', %s), q.query)), 0) AS rank
+			FROM comments c
+			JOIN posts p ON c.post_id = p.id
+			LEFT JOIN links l ON l.comment_id = c.id
+			CROSS JOIN q
+			WHERE c.deleted_at IS NULL
+				AND p.deleted_at IS NULL
+				AND (
+					to_tsvector('english', c.content) @@ q.query
+					OR to_tsvector('english', %s) @@ q.query
+				)
+				%s
+			GROUP BY c.id
+		)
+		SELECT 'post' AS result_type, id, rank FROM post_matches
+		UNION ALL
+		SELECT 'comment' AS result_type, id, rank FROM comment_matches
+		ORDER BY rank DESC
+		LIMIT %s
+	`, linkText, linkText, postScopeFilter, linkText, linkText, commentScopeFilter, limitPlaceholder)
+
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, queryText, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make([]models.SearchResult, 0)
+	for rows.Next() {
+		var resultType string
+		var id uuid.UUID
+		var rank float64
+
+		if err := rows.Scan(&resultType, &id, &rank); err != nil {
+			return nil, err
+		}
+
+		switch resultType {
+		case "post":
+			post, err := s.postService.GetPostByID(ctx, id)
+			if err != nil {
+				continue
+			}
+			results = append(results, models.SearchResult{
+				Type:  "post",
+				Score: rank,
+				Post:  post,
+			})
+		case "comment":
+			comment, err := s.commentService.GetCommentByID(ctx, id)
+			if err != nil {
+				continue
+			}
+			results = append(results, models.SearchResult{
+				Type:    "comment",
+				Score:   rank,
+				Comment: comment,
+			})
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/backend/internal/services/search_test.go
+++ b/backend/internal/services/search_test.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+)
+
+func TestSearchServiceGlobal(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	service := NewSearchService(db)
+
+	query := "hello world"
+	limit := 5
+	postID := uuid.New()
+	commentID := uuid.New()
+	userID := uuid.New()
+	sectionID := uuid.New()
+	postCreated := time.Now()
+	commentCreated := time.Now()
+	userCreated := time.Now()
+
+	searchRows := sqlmock.NewRows([]string{"result_type", "id", "rank"}).
+		AddRow("post", postID, 0.42).
+		AddRow("comment", commentID, 0.31)
+
+	mock.ExpectQuery(regexp.QuoteMeta("WITH q AS")).
+		WithArgs(query, limit).
+		WillReturnRows(searchRows)
+
+	postRows := sqlmock.NewRows([]string{
+		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+	}).AddRow(
+		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).
+		WithArgs(postID).
+		WillReturnRows(postRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(postID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	commentRows := sqlmock.NewRows([]string{
+		"id", "user_id", "post_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
+	}).AddRow(
+		commentID, userID, postID, nil, "comment content", commentCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM comments c")).
+		WithArgs(commentID).
+		WillReturnRows(commentRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(commentID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	results, err := service.Search(context.Background(), query, "global", nil, limit)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestSearchServiceSectionScope(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	service := NewSearchService(db)
+
+	query := "hello"
+	limit := 10
+	sectionID := uuid.New()
+
+	searchRows := sqlmock.NewRows([]string{"result_type", "id", "rank"})
+
+	mock.ExpectQuery(regexp.QuoteMeta("WITH q AS")).
+		WithArgs(query, sectionID, limit).
+		WillReturnRows(searchRows)
+
+	results, err := service.Search(context.Background(), query, "section", &sectionID, limit)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unfulfilled expectations: %v", err)
+	}
+}

--- a/backend/migrations/012_add_fulltext_indexes.down.sql
+++ b/backend/migrations/012_add_fulltext_indexes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_links_metadata_fts;
+DROP INDEX IF EXISTS idx_comments_content_fts;
+DROP INDEX IF EXISTS idx_posts_content_fts;

--- a/backend/migrations/012_add_fulltext_indexes.up.sql
+++ b/backend/migrations/012_add_fulltext_indexes.up.sql
@@ -1,0 +1,13 @@
+CREATE INDEX idx_posts_content_fts ON posts USING GIN(to_tsvector('english', content));
+CREATE INDEX idx_comments_content_fts ON comments USING GIN(to_tsvector('english', content));
+CREATE INDEX idx_links_metadata_fts ON links USING GIN(
+  to_tsvector(
+    'english',
+    COALESCE(metadata->>'title','') || ' ' ||
+    COALESCE(metadata->>'description','') || ' ' ||
+    COALESCE(metadata->>'author','') || ' ' ||
+    COALESCE(metadata->>'artist','') || ' ' ||
+    COALESCE(metadata->>'provider','') || ' ' ||
+    COALESCE(url,'')
+  )
+);


### PR DESCRIPTION
Summary:
  - Add GET /api/v1/search with full-text ranking across posts, comments, and link metadata.
  - Support global vs section scope with parameter validation and sensible defaults.
  - Add service/handler tests for both validation and success paths.
  - Add FTS GIN indexes for posts, comments, and link metadata.
  - Document running migrations during backend development.

  Implementation notes:
  - Search results are ranked with `ts_rank_cd` and hydrated into full post/comment payloads.
  - Section scope uses section_id when provided; global scope searches all content.

  Testing:
  - go test ./... (backend)

  Closes #37