### PR TITLE
Phase 4: Implement mark notification read endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .worktrees/
-backend/server

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -190,6 +190,7 @@ func main() {
 
 	// Notification routes (protected)
 	mux.Handle("/api/v1/notifications", middleware.RequireAuth(redisConn)(http.HandlerFunc(notificationHandler.GetNotifications)))
+	mux.Handle("/api/v1/notifications/", middleware.RequireAuth(redisConn)(http.HandlerFunc(notificationHandler.MarkNotificationRead)))
 
 	// Admin routes (protected by RequireAdmin middleware)
 	mux.Handle("/api/v1/admin/users", middleware.RequireAdmin(redisConn)(http.HandlerFunc(adminHandler.ListPendingUsers)))

--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -30,3 +30,8 @@ type GetNotificationsResponse struct {
 	Notifications []Notification   `json:"notifications"`
 	Meta          NotificationMeta `json:"meta"`
 }
+
+// UpdateNotificationResponse represents the response for updating a notification.
+type UpdateNotificationResponse struct {
+	Notification Notification `json:"notification"`
+}


### PR DESCRIPTION
Summary:
  - Add PATCH /api/v1/notifications/{id} handler and route
  - Update notification service to mark read and return updated record
  - Add update response model for notification payload

  Testing:
  - go test ./...

  Notes:
  - Enforces ownership checks on notifications before update
  - Preserves existing read_at if already set

  Closes #36