### PR TITLE
Phase 5: Implement restore soft-deleted content

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -202,9 +202,31 @@ func main() {
 		}
 	})))
 
-	// Admin hard delete routes
-	mux.Handle("/api/v1/admin/posts/", middleware.RequireAdmin(redisConn)(http.HandlerFunc(adminHandler.HardDeletePost)))
-	mux.Handle("/api/v1/admin/comments/", middleware.RequireAdmin(redisConn)(http.HandlerFunc(adminHandler.HardDeleteComment)))
+	// Admin post routes (hard delete and restore)
+	mux.Handle("/api/v1/admin/posts/", middleware.RequireAdmin(redisConn)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/restore") {
+			adminHandler.AdminRestorePost(w, r)
+		} else if r.Method == http.MethodDelete {
+			adminHandler.HardDeletePost(w, r)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.Write([]byte(`{"error":"Method not allowed","code":"METHOD_NOT_ALLOWED"}`))
+		}
+	})))
+
+	// Admin comment routes (hard delete and restore)
+	mux.Handle("/api/v1/admin/comments/", middleware.RequireAdmin(redisConn)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/restore") {
+			adminHandler.AdminRestoreComment(w, r)
+		} else if r.Method == http.MethodDelete {
+			adminHandler.HardDeleteComment(w, r)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.Write([]byte(`{"error":"Method not allowed","code":"METHOD_NOT_ALLOWED"}`))
+		}
+	})))
 
 	// Admin config route
 	mux.Handle("/api/v1/admin/config", middleware.RequireAdmin(redisConn)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Adds `POST /admin/posts/{id}/restore` endpoint for admins to restore soft-deleted posts
- Adds `POST /admin/comments/{id}/restore` endpoint for admins to restore soft-deleted comments
- Both endpoints protected by RequireAdmin middleware
- Creates audit log entries (`restore_post`, `restore_comment`) for all restore actions
- Returns restored content in response

## Implementation Details
- `AdminRestorePost` service method uses transaction to atomically restore and log
- `AdminRestoreComment` service method uses transaction to atomically restore and log
- Returns 404 if content not found, 409 if content is not deleted
- Full post/comment with user info returned after restore

## Test plan
- [x] Unit tests for AdminRestorePost (skipped without DB)
- [x] Unit tests for AdminRestoreComment (skipped without DB)
- [x] Unit tests for restore conflict (not deleted)
- [x] Unit tests for restore not found
- [x] All existing tests pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)