### PR TITLE
Phase 5: Implement section subscription opt-out

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -90,6 +90,21 @@ func main() {
 
 	// User routes (protected - requires auth)
 	userRouteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/users/me/section-subscriptions") {
+			sectionSubHandler := middleware.RequireAuth(redisConn)
+			if r.Method == http.MethodGet && r.URL.Path == "/api/v1/users/me/section-subscriptions" {
+				sectionSubHandler(http.HandlerFunc(userHandler.GetMySectionSubscriptions)).ServeHTTP(w, r)
+				return
+			}
+			if r.Method == http.MethodPatch {
+				sectionSubHandler(http.HandlerFunc(userHandler.UpdateMySectionSubscription)).ServeHTTP(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.Write([]byte(`{"error":"Method not allowed","code":"METHOD_NOT_ALLOWED"}`))
+			return
+		}
 		// Check if this is the /api/v1/users/me endpoint
 		if r.URL.Path == "/api/v1/users/me" {
 			if r.Method == http.MethodPatch {

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -125,3 +125,26 @@ type UpdateUserResponse struct {
 	Bio               *string   `json:"bio,omitempty"`
 	IsAdmin           bool      `json:"is_admin"`
 }
+
+// SectionSubscription represents an opt-out entry for a section.
+type SectionSubscription struct {
+	SectionID  uuid.UUID `json:"section_id"`
+	OptedOutAt time.Time `json:"opted_out_at"`
+}
+
+// GetSectionSubscriptionsResponse represents the response from listing section opt-outs.
+type GetSectionSubscriptionsResponse struct {
+	SectionSubscriptions []SectionSubscription `json:"section_subscriptions"`
+}
+
+// UpdateSectionSubscriptionRequest represents a request to opt in/out of section notifications.
+type UpdateSectionSubscriptionRequest struct {
+	OptedOut *bool `json:"opted_out"`
+}
+
+// UpdateSectionSubscriptionResponse represents the response from updating section opt-out status.
+type UpdateSectionSubscriptionResponse struct {
+	SectionID  uuid.UUID  `json:"section_id"`
+	OptedOut   bool       `json:"opted_out"`
+	OptedOutAt *time.Time `json:"opted_out_at,omitempty"`
+}


### PR DESCRIPTION
Summary:
- Added section subscription opt-out models/services/handlers with GET and PATCH endpoints.
- Wired routing for /users/me/section-subscriptions opt-out management.
- Added handler tests for section subscription opt-out/in behavior.

Tests:
- go build ./...
- go test ./internal/handlers -v (skipped DB-dependent tests: test database not configured)

Closes #43