### PR TITLE
Phase 7: Search scope without explicit section_id

### DIFF
--- a/backend/internal/handlers/search_test.go
+++ b/backend/internal/handlers/search_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/middleware"
 	"github.com/sanderginn/clubhouse/internal/models"
 )
 
@@ -98,6 +100,90 @@ func TestSearchSectionScopeMissingSectionID(t *testing.T) {
 
 	if response.Code != "SECTION_ID_REQUIRED" {
 		t.Fatalf("expected code SECTION_ID_REQUIRED, got %s", response.Code)
+	}
+}
+
+func TestSearchSectionScopeUsesContextSectionID(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewSearchHandler(db)
+
+	query := "section search"
+	limit := 2
+	postID := uuid.New()
+	commentID := uuid.New()
+	userID := uuid.New()
+	sectionID := uuid.New()
+	postCreated := time.Now()
+	commentCreated := time.Now()
+	userCreated := time.Now()
+
+	searchRows := sqlmock.NewRows([]string{"result_type", "id", "rank"}).
+		AddRow("post", postID, 0.42).
+		AddRow("comment", commentID, 0.31)
+
+	mock.ExpectQuery(regexp.QuoteMeta("WITH q AS")).
+		WithArgs(query, sectionID, limit).
+		WillReturnRows(searchRows)
+
+	postRows := sqlmock.NewRows([]string{
+		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+	}).AddRow(
+		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).
+		WithArgs(postID).
+		WillReturnRows(postRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(postID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	commentRows := sqlmock.NewRows([]string{
+		"id", "user_id", "post_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
+	}).AddRow(
+		commentID, userID, postID, nil, "comment content", commentCreated, nil, nil, nil,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
+	)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM comments c")).
+		WithArgs(commentID).
+		WillReturnRows(commentRows)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM links")).
+		WithArgs(commentID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "url", "metadata", "created_at"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=section%20search&scope=section&limit=2", nil)
+	ctx := context.WithValue(req.Context(), middleware.SectionIDContextKey, sectionID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Search(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	var response models.SearchResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(response.Results))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unfulfilled expectations: %v", err)
 	}
 }
 

--- a/backend/internal/middleware/context.go
+++ b/backend/internal/middleware/context.go
@@ -64,3 +64,16 @@ func GetIsAdminFromContext(ctx context.Context) (bool, error) {
 	}
 	return session.IsAdmin, nil
 }
+
+// GetSectionIDFromContext extracts the current section ID from the request context
+func GetSectionIDFromContext(ctx context.Context) (uuid.UUID, error) {
+	sectionID := ctx.Value(SectionIDContextKey)
+	if sectionID == nil {
+		return uuid.Nil, fmt.Errorf("section id not found in context")
+	}
+	parsedID, ok := sectionID.(uuid.UUID)
+	if !ok {
+		return uuid.Nil, fmt.Errorf("invalid section id context type")
+	}
+	return parsedID, nil
+}

--- a/backend/internal/middleware/middleware.go
+++ b/backend/internal/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -20,6 +21,8 @@ const (
 	UserContextKey ContextKey = "user"
 	// SessionIDContextKey is the key for storing session ID in context
 	SessionIDContextKey ContextKey = "session_id"
+	// SectionIDContextKey is the key for storing the current section ID in context
+	SectionIDContextKey ContextKey = "section_id"
 )
 
 // ChainMiddleware applies middleware in order
@@ -72,6 +75,11 @@ func RequireAuth(redis *redis.Client) Middleware {
 			// Inject session and user into context
 			ctx := context.WithValue(r.Context(), SessionIDContextKey, sessionID)
 			ctx = context.WithValue(ctx, UserContextKey, session)
+			if sectionID := strings.TrimSpace(r.Header.Get("X-Section-ID")); sectionID != "" {
+				if parsedID, err := uuid.Parse(sectionID); err == nil {
+					ctx = context.WithValue(ctx, SectionIDContextKey, parsedID)
+				}
+			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -108,6 +116,11 @@ func RequireAdmin(redis *redis.Client) Middleware {
 			// Inject session and user into context
 			ctx := context.WithValue(r.Context(), SessionIDContextKey, sessionID)
 			ctx = context.WithValue(ctx, UserContextKey, session)
+			if sectionID := strings.TrimSpace(r.Header.Get("X-Section-ID")); sectionID != "" {
+				if parsedID, err := uuid.Parse(sectionID); err == nil {
+					ctx = context.WithValue(ctx, SectionIDContextKey, parsedID)
+				}
+			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})


### PR DESCRIPTION
Summary:
- allow section-scoped search to use section id from request context when query param is missing
- populate section id context from X-Section-ID header for authenticated requests
- add handler coverage for context-based section search

Closes #99