### PR TITLE
Phase 7: Search query length and token guards

### DIFF
--- a/backend/internal/services/search.go
+++ b/backend/internal/services/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sanderginn/clubhouse/internal/models"
@@ -25,6 +26,15 @@ func NewSearchService(db *sql.DB) *SearchService {
 		postService:    NewPostService(db),
 		commentService: NewCommentService(db),
 	}
+}
+
+// IsQueryMeaningful checks if a query produces a non-empty tsquery.
+func (s *SearchService) IsQueryMeaningful(ctx context.Context, query string) (bool, error) {
+	var tsquery string
+	if err := s.db.QueryRowContext(ctx, "SELECT plainto_tsquery('english', $1)::text", query).Scan(&tsquery); err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(tsquery) != "", nil
 }
 
 // Search searches posts and comments, including link metadata, with optional scope filtering.


### PR DESCRIPTION
Summary:
- enforce maximum search query length
- reject stopword-only queries via tsquery validation
- add handler coverage for query guards

Closes #101