### PR TITLE
Phase 6: Implement Web Push notifications (frontend)

### DIFF
--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { sections, activeSection, sectionStore, uiStore, isAdmin, activeView } from '../stores';
+  import { sections, activeSection, sectionStore, uiStore, isAdmin, activeView, isAuthenticated } from '../stores';
   import type { Section } from '../stores/sectionStore';
+  import NotificationSettings from './NotificationSettings.svelte';
 
   function handleSectionClick(section: Section) {
     sectionStore.setActiveSection(section);
@@ -35,6 +36,13 @@
       {/each}
     </ul>
   </div>
+
+  {#if $isAuthenticated}
+    <div class="border-t border-gray-200 px-3 py-4">
+      <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Settings</h2>
+      <NotificationSettings />
+    </div>
+  {/if}
 
   {#if $isAdmin}
     <div class="border-t border-gray-200 px-3 py-4">

--- a/frontend/src/components/NotificationSettings.svelte
+++ b/frontend/src/components/NotificationSettings.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { pwaStore, isPushSubscribed } from '../stores/pwaStore';
+  import { derived, get } from 'svelte/store';
+
+  // Derived stores for push notification state
+  const isPushSupported = derived(pwaStore, ($pwa) => $pwa.isPushSupported);
+  const pushPermission = derived(pwaStore, ($pwa) => $pwa.pushPermission);
+  const isServiceWorkerReady = derived(pwaStore, ($pwa) => $pwa.isServiceWorkerReady);
+
+  let isLoading = false;
+  let error = '';
+
+  async function handleToggle() {
+    isLoading = true;
+    error = '';
+
+    try {
+      if (get(isPushSubscribed)) {
+        const success = await pwaStore.unsubscribeFromPush();
+        if (!success) {
+          error = 'Failed to disable notifications. Please try again.';
+        }
+      } else {
+        const success = await pwaStore.subscribeToPush();
+        if (!success) {
+          // Check if permission was denied
+          const permission = get(pushPermission);
+          if (permission === 'denied') {
+            error = 'Permission denied. Please enable notifications in your browser settings.';
+          } else {
+            error = 'Failed to enable notifications. Please try again.';
+          }
+        }
+      }
+    } catch (e) {
+      error = 'An unexpected error occurred.';
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="notification-settings">
+  {#if !$isPushSupported}
+    <div class="flex items-center gap-3 px-3 py-2 text-sm text-gray-500">
+      <span class="text-lg" aria-hidden="true">🔕</span>
+      <span>Notifications not supported</span>
+    </div>
+  {:else if !$isServiceWorkerReady}
+    <div class="flex items-center gap-3 px-3 py-2 text-sm text-gray-500">
+      <span class="text-lg" aria-hidden="true">⏳</span>
+      <span>Loading...</span>
+    </div>
+  {:else}
+    <button
+      on:click={handleToggle}
+      disabled={isLoading || $pushPermission === 'denied'}
+      class="w-full flex items-center justify-between gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
+        {$pushPermission === 'denied'
+        ? 'text-gray-400 cursor-not-allowed'
+        : 'text-gray-700 hover:bg-gray-100'}"
+      title={$pushPermission === 'denied'
+        ? 'Enable notifications in browser settings'
+        : $isPushSubscribed
+          ? 'Disable push notifications'
+          : 'Enable push notifications'}
+    >
+      <div class="flex items-center gap-3">
+        <span class="text-lg" aria-hidden="true">
+          {#if $pushPermission === 'denied'}
+            🚫
+          {:else if $isPushSubscribed}
+            🔔
+          {:else}
+            🔕
+          {/if}
+        </span>
+        <span>
+          {#if $pushPermission === 'denied'}
+            Notifications blocked
+          {:else if isLoading}
+            {$isPushSubscribed ? 'Disabling...' : 'Enabling...'}
+          {:else if $isPushSubscribed}
+            Notifications enabled
+          {:else}
+            Enable notifications
+          {/if}
+        </span>
+      </div>
+
+      {#if $pushPermission !== 'denied'}
+        <div
+          class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none
+            {$isPushSubscribed ? 'bg-primary' : 'bg-gray-200'}"
+          role="switch"
+          aria-checked={$isPushSubscribed}
+        >
+          <span
+            class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out
+              {$isPushSubscribed ? 'translate-x-4' : 'translate-x-0'}"
+          />
+        </div>
+      {/if}
+    </button>
+
+    {#if error}
+      <p class="px-3 mt-1 text-xs text-red-600">{error}</p>
+    {/if}
+
+    {#if $pushPermission === 'denied'}
+      <p class="px-3 mt-1 text-xs text-gray-500">
+        To enable, allow notifications in your browser settings.
+      </p>
+    {/if}
+  {/if}
+</div>

--- a/frontend/src/components/__tests__/NotificationSettings.test.ts
+++ b/frontend/src/components/__tests__/NotificationSettings.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+// Mock the pwaStore module with inline mock implementations
+vi.mock('../../stores/pwaStore', () => {
+  const mockState = writable({
+    isInstallable: false,
+    isInstalled: false,
+    isServiceWorkerReady: true,
+    isPushSupported: true,
+    isPushSubscribed: false,
+    pushPermission: 'default' as NotificationPermission | null,
+    updateAvailable: false,
+  });
+
+  return {
+    pwaStore: {
+      subscribe: mockState.subscribe,
+      subscribeToPush: vi.fn().mockResolvedValue(true),
+      unsubscribeFromPush: vi.fn().mockResolvedValue(true),
+    },
+    isPushSubscribed: {
+      subscribe: (fn: (value: boolean) => void) => mockState.subscribe((s) => fn(s.isPushSubscribed)),
+    },
+    _setMockState: (newState: Partial<{
+      isInstallable: boolean;
+      isInstalled: boolean;
+      isServiceWorkerReady: boolean;
+      isPushSupported: boolean;
+      isPushSubscribed: boolean;
+      pushPermission: NotificationPermission | null;
+      updateAvailable: boolean;
+    }>) => {
+      mockState.update((s) => ({ ...s, ...newState }));
+    },
+  };
+});
+
+// Import component after mocking
+import NotificationSettings from '../NotificationSettings.svelte';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - we're using test-only exports
+import { pwaStore, _setMockState } from '../../stores/pwaStore';
+
+describe('NotificationSettings', () => {
+  beforeEach(() => {
+    // Reset mock state
+    _setMockState({
+      isServiceWorkerReady: true,
+      isPushSupported: true,
+      isPushSubscribed: false,
+      pushPermission: 'default',
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('when push is not supported', () => {
+    it('should show "Notifications not supported" message', () => {
+      _setMockState({ isPushSupported: false });
+      render(NotificationSettings);
+
+      expect(screen.getByText('Notifications not supported')).toBeInTheDocument();
+    });
+  });
+
+  describe('when service worker is not ready', () => {
+    it('should show loading state', () => {
+      _setMockState({ isServiceWorkerReady: false });
+      render(NotificationSettings);
+
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+
+  describe('when push is supported and ready', () => {
+    it('should show "Enable notifications" when not subscribed', () => {
+      _setMockState({ isPushSubscribed: false });
+      render(NotificationSettings);
+
+      expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+    });
+
+    it('should show "Notifications enabled" when subscribed', () => {
+      _setMockState({ isPushSubscribed: true });
+      render(NotificationSettings);
+
+      expect(screen.getByText('Notifications enabled')).toBeInTheDocument();
+    });
+
+    it('should call subscribeToPush when enabling notifications', async () => {
+      _setMockState({ isPushSubscribed: false });
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      await fireEvent.click(button);
+
+      expect(pwaStore.subscribeToPush).toHaveBeenCalled();
+    });
+
+    it('should call unsubscribeFromPush when disabling notifications', async () => {
+      _setMockState({ isPushSubscribed: true });
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      await fireEvent.click(button);
+
+      expect(pwaStore.unsubscribeFromPush).toHaveBeenCalled();
+    });
+
+    it('should show toggle switch in correct state when not subscribed', () => {
+      _setMockState({ isPushSubscribed: false });
+      render(NotificationSettings);
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should show toggle switch in correct state when subscribed', () => {
+      _setMockState({ isPushSubscribed: true });
+      render(NotificationSettings);
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  describe('when permission is denied', () => {
+    it('should show "Notifications blocked" message', () => {
+      _setMockState({ pushPermission: 'denied' });
+      render(NotificationSettings);
+
+      expect(screen.getByText('Notifications blocked')).toBeInTheDocument();
+    });
+
+    it('should show help text about browser settings', () => {
+      _setMockState({ pushPermission: 'denied' });
+      render(NotificationSettings);
+
+      expect(screen.getByText('To enable, allow notifications in your browser settings.')).toBeInTheDocument();
+    });
+
+    it('should disable the button when permission is denied', () => {
+      _setMockState({ pushPermission: 'denied' });
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+    });
+
+    it('should not show toggle switch when permission is denied', () => {
+      _setMockState({ pushPermission: 'denied' });
+      render(NotificationSettings);
+
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should show error when subscribeToPush fails', async () => {
+      _setMockState({ isPushSubscribed: false });
+      (pwaStore.subscribeToPush as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to enable notifications. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when unsubscribeFromPush fails', async () => {
+      _setMockState({ isPushSubscribed: true });
+      (pwaStore.unsubscribeFromPush as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to disable notifications. Please try again.')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -8,3 +8,4 @@ export { default as PostCard } from './PostCard.svelte';
 export { default as SectionFeed } from './SectionFeed.svelte';
 export * from './search';
 export { default as InstallPrompt } from './InstallPrompt.svelte';
+export { default as NotificationSettings } from './NotificationSettings.svelte';


### PR DESCRIPTION
## Summary
- Added `NotificationSettings` component for managing Web Push notifications
- Integrated notification settings toggle into the sidebar (Nav component)
- Shows current subscription status with visual toggle switch
- Handles permission denied state gracefully with helpful message
- Includes 14 comprehensive tests for all component states

## Implementation Details
- Uses existing `pwaStore` methods (`subscribeToPush`, `unsubscribeFromPush`)
- Creates derived stores for `isPushSupported`, `pushPermission`, `isServiceWorkerReady`
- Shows appropriate UI states:
  - "Notifications not supported" when browser doesn't support push
  - "Loading..." while service worker initializes
  - "Enable notifications" / "Notifications enabled" with toggle
  - "Notifications blocked" when permission is denied

## Test plan
- [x] Unit tests for all component states (14 tests, all passing)
- [ ] Manual testing: verify toggle enables/disables push notifications
- [ ] Manual testing: verify permission denied state shows correct message
- [ ] Manual testing: verify UI updates correctly when toggling

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)