### PR TITLE
Fix issue #136: map created posts and include author

### DIFF
--- a/backend/internal/handlers/post.go
+++ b/backend/internal/handlers/post.go
@@ -78,6 +78,10 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if user, err := h.userService.GetUserByID(r.Context(), userID); err == nil {
+		post.User = user
+	}
+
 	response := models.CreatePostResponse{
 		Post: *post,
 	}

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -69,10 +69,18 @@ describe('api client', () => {
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
-      json: vi.fn().mockResolvedValue({ post: {} }),
+      json: vi.fn().mockResolvedValue({
+        post: {
+          id: 'post-1',
+          user_id: 'user-1',
+          section_id: 'section-1',
+          content: 'Hello',
+          created_at: '2025-01-01T00:00:00Z',
+        },
+      }),
     });
 
-    await api.createPost({
+    const response = await api.createPost({
       sectionId: 'section-1',
       content: 'Hello',
       links: [{ url: 'https://example.com' }],
@@ -81,6 +89,8 @@ describe('api client', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.section_id).toBe('section-1');
     expect(body.content).toBe('Hello');
+    expect(response.post.createdAt).toBe('2025-01-01T00:00:00Z');
+    expect(response.post.userId).toBe('user-1');
   });
 
   it('createComment maps fields', async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,7 @@
 import type { Post, CreatePostRequest, LinkMetadata } from '../stores/postStore';
 import type { CreateCommentRequest } from '../stores/commentStore';
 import type { ApiComment } from '../stores/commentMapper';
+import { mapApiPost, type ApiPost } from '../stores/postMapper';
 
 const API_BASE = '/api/v1';
 
@@ -74,11 +75,12 @@ class ApiClient {
   }
 
   async createPost(data: CreatePostRequest): Promise<{ post: Post }> {
-    return this.post('/posts', {
+    const response = await this.post<{ post: ApiPost }>('/posts', {
       section_id: data.sectionId,
       content: data.content,
       links: data.links,
     });
+    return { post: mapApiPost(response.post) };
   }
 
   async getFeed(


### PR DESCRIPTION
## Summary
Fixes new posts rendering with Unknown username and Invalid Date by mapping create-post responses and enriching the create-post payload with author data.

## Changes
- Map create-post API responses to frontend Post shape so createdAt and userId are populated.
- Include author data in create-post responses so user info is available immediately (and for real-time events).
- Update api client test coverage for create-post mapping.

## Testing
npm run test -- api.test

Closes #136
