### PR TITLE
Bug: Admin moderation section in sidebar not fixed to viewport

### DIFF
--- a/frontend/src/components/Layout.svelte
+++ b/frontend/src/components/Layout.svelte
@@ -36,7 +36,7 @@
   <div class="flex">
     <Sidebar />
 
-    <main class="flex-1 lg:ml-0">
+    <main class="flex-1 lg:ml-64">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <slot />
       </div>

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -28,11 +28,11 @@
 
 <!-- Sidebar -->
 <aside
-  class="fixed lg:static inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 ease-in-out
+  class="fixed top-16 bottom-0 left-0 z-50 lg:z-30 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 ease-in-out
     {sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}"
   aria-label="Sidebar"
 >
-  <div class="h-full flex flex-col pt-16 lg:pt-0">
+  <div class="h-full flex flex-col">
     <!-- Mobile header in sidebar -->
     <div class="lg:hidden flex items-center justify-between h-16 px-4 border-b border-gray-200">
       <span class="text-lg font-bold text-gray-900">Sections</span>


### PR DESCRIPTION
## Summary
- Fixed sidebar positioning to use `fixed` instead of `lg:static` on desktop
- Sidebar now positioned below header (`top-16 bottom-0`) and stays fixed to viewport
- Added `lg:ml-64` to main content to account for the fixed 256px sidebar width
- Admin section is now always visible at the bottom of the sidebar when scrolling

## Changes
- `frontend/src/components/Sidebar.svelte`: Changed from `fixed lg:static inset-y-0` to `fixed top-16 bottom-0`, adjusted z-index to `z-50 lg:z-30`
- `frontend/src/components/Layout.svelte`: Changed main content margin from `lg:ml-0` to `lg:ml-64`

## Test plan
- [x] Build passes (`npm run build`)
- [x] 140 unit/component tests pass
- [ ] Manual test: Admin section stays pinned to bottom when scrolling posts
- [ ] Manual test: Sidebar works correctly on mobile (overlay behavior preserved)
- [ ] Manual test: Layout works on various viewport heights

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)