### PR TITLE
fix(issue-152): resolve 27 TypeScript typecheck errors in frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@sveltejs/vite-plugin-svelte": "^3.0.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
+        "@types/node": "^25.0.9",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.56.0",
@@ -3078,6 +3079,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -9443,6 +9454,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
+    "@types/node": "^25.0.9",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",

--- a/frontend/src/components/Layout.svelte
+++ b/frontend/src/components/Layout.svelte
@@ -12,7 +12,7 @@
     uiStore.setIsMobile(mediaQuery.matches);
 
     const handleResize = (event?: MediaQueryListEvent) => {
-      uiStore.setIsMobile(event?.matches ?? mediaQuery.matches);
+      uiStore.setIsMobile(event?.matches ?? mediaQuery?.matches ?? false);
     };
 
     handleResize();
@@ -20,8 +20,9 @@
       mediaQuery.addEventListener('change', handleResize);
       cleanupListener = () => mediaQuery?.removeEventListener('change', handleResize);
     } else {
-      mediaQuery.addListener(handleResize);
-      cleanupListener = () => mediaQuery?.removeListener(handleResize);
+      // Legacy browsers support addListener/removeListener
+      (mediaQuery as MediaQueryList).addListener(handleResize);
+      cleanupListener = () => (mediaQuery as MediaQueryList | null)?.removeListener(handleResize);
     }
   }
 

--- a/frontend/src/components/__tests__/Layout.test.ts
+++ b/frontend/src/components/__tests__/Layout.test.ts
@@ -8,15 +8,15 @@ const { default: Layout } = await import('../Layout.svelte');
 describe('Layout', () => {
   it('sets isMobile based on matchMedia changes', async () => {
     const listeners: Array<(event: MediaQueryListEvent) => void> = [];
-    const media = {
+    const media: { matches: boolean } & Omit<MediaQueryList, 'matches'> = {
       matches: true,
       media: '(max-width: 1023px)',
       onchange: null,
-      addEventListener: (_event: string, handler: (event: MediaQueryListEvent) => void) => {
-        listeners.push(handler);
+      addEventListener: (_event: string, handler: EventListenerOrEventListenerObject | null) => {
+        listeners.push(handler as (event: MediaQueryListEvent) => void);
       },
-      removeEventListener: (_event: string, handler: (event: MediaQueryListEvent) => void) => {
-        const index = listeners.indexOf(handler);
+      removeEventListener: (_event: string, handler: EventListenerOrEventListenerObject | null) => {
+        const index = listeners.indexOf(handler as (event: MediaQueryListEvent) => void);
         if (index >= 0) {
           listeners.splice(index, 1);
         }
@@ -24,8 +24,8 @@ describe('Layout', () => {
       addListener: () => {},
       removeListener: () => {},
       dispatchEvent: () => true,
-    } as MediaQueryList;
-    const matchMediaSpy = vi.spyOn(window, 'matchMedia').mockReturnValue(media);
+    };
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia').mockReturnValue(media as MediaQueryList);
     let isMobile = false;
     const unsubscribe = uiStore.subscribe((state) => {
       isMobile = state.isMobile;
@@ -37,7 +37,7 @@ describe('Layout', () => {
     expect(isMobile).toBe(true);
 
     media.matches = false;
-    listeners.forEach((handler) => handler(media as MediaQueryListEvent));
+    listeners.forEach((handler) => handler({ matches: false } as MediaQueryListEvent));
     expect(isMobile).toBe(false);
     matchMediaSpy.mockRestore();
     unsubscribe();

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -20,7 +20,7 @@ describe('Nav', () => {
     await fireEvent.click(button);
 
     expect(setActiveSpy).toHaveBeenCalled();
-    const call = setActiveSpy.mock.calls[0][0];
-    expect(call.id).toBe('section-2');
+    const call = setActiveSpy.mock.calls[0]?.[0];
+    expect(call?.id).toBe('section-2');
   });
 });

--- a/frontend/src/components/search/__tests__/SearchBar.test.ts
+++ b/frontend/src/components/search/__tests__/SearchBar.test.ts
@@ -1,28 +1,34 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, fireEvent, screen, cleanup } from '@testing-library/svelte';
 import { createRequire } from 'module';
+import type { Writable } from 'svelte/store';
 
 const require = createRequire(import.meta.url);
 const { writable } = require('svelte/store') as typeof import('svelte/store');
 
+interface SearchState {
+  query: string;
+  scope: string;
+}
+
 const storeRefs: {
-  activeSection: ReturnType<typeof writable>;
-  state: ReturnType<typeof writable>;
+  activeSection: Writable<{ id: string; name: string } | null>;
+  state: Writable<SearchState>;
   searchStore: {
-    subscribe: ReturnType<typeof writable>['subscribe'];
-    setQuery: ReturnType<typeof vi.fn>;
-    setScope: ReturnType<typeof vi.fn>;
-    search: ReturnType<typeof vi.fn>;
-    clear: ReturnType<typeof vi.fn>;
+    subscribe: Writable<SearchState>['subscribe'];
+    setQuery: Mock;
+    setScope: Mock;
+    search: Mock;
+    clear: Mock;
   };
-} = {} as any;
+} = {} as typeof storeRefs;
 
 vi.mock('../../../stores', () => {
   storeRefs.activeSection = writable<{ id: string; name: string } | null>({
     id: 'section-1',
     name: 'Music',
   });
-  storeRefs.state = writable({
+  storeRefs.state = writable<SearchState>({
     query: '',
     scope: 'section',
   });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,14 +4,14 @@ import { vi } from 'vitest';
 if (!window.matchMedia) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => {
     let listeners: Array<(event: MediaQueryListEvent) => void> = [];
-    const mediaQueryList: MediaQueryList = {
+    const mediaQueryList: { matches: boolean } & Omit<MediaQueryList, 'matches'> = {
       matches: false,
       media: query,
       onchange: null,
-      addEventListener: (_event, handler) => {
+      addEventListener: (_event: string, handler: EventListenerOrEventListenerObject | null) => {
         listeners.push(handler as (event: MediaQueryListEvent) => void);
       },
-      removeEventListener: (_event, handler) => {
+      removeEventListener: (_event: string, handler: EventListenerOrEventListenerObject | null) => {
         listeners = listeners.filter((item) => item !== handler);
       },
       addListener: () => {},
@@ -20,9 +20,9 @@ if (!window.matchMedia) {
     };
     (mediaQueryList as unknown as { trigger: (matches: boolean) => void }).trigger = (matches: boolean) => {
       mediaQueryList.matches = matches;
-      listeners.forEach((handler) => handler(mediaQueryList as MediaQueryListEvent));
+      listeners.forEach((handler) => handler({ matches } as MediaQueryListEvent));
     };
-    return mediaQueryList;
+    return mediaQueryList as MediaQueryList;
   }) as unknown as typeof window.matchMedia;
 }
 


### PR DESCRIPTION
## Summary
- Added `@types/node` to devDependencies to fix `module`, `global`, and `Buffer` type errors
- Fixed `mediaQuery` null checks in `Layout.svelte` with optional chaining
- Added proper type annotations for `MediaQueryList` mocking in test files
- Fixed implicit `any` types in `test/setup.ts` event handlers
- Used proper `Mock` type and `Writable` generics in `SearchBar.test.ts`
- Added null safety to `Nav.test.ts` spy assertions

## Test plan
- [x] `npm run check` passes with 0 errors (was 27 errors)
- [x] All 140 unit tests pass

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)