### PR TITLE
Bug: Grafana dashboards show 'No data' - metrics not being collected or exported

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - clubhouse
     depends_on:
       - loki
+      - backend
 
   # Tempo (Traces)
   tempo:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -9,6 +9,6 @@ scrape_configs:
 
   - job_name: 'clubhouse'
     static_configs:
-      - targets: ['localhost:8080']
+      - targets: ['backend:8080']
     metrics_path: '/metrics'
     scrape_interval: 15s


### PR DESCRIPTION
## Summary

Fixed the root cause of all Grafana dashboards showing 'No data' for metrics.

## Root Cause

The `prometheus.yml` was configured to scrape metrics from `localhost:8080`, but when running inside Docker, Prometheus runs in its own container where `localhost` refers to itself, not the backend service. This meant Prometheus could never reach the backend's `/metrics` endpoint.

## Changes

1. **prometheus.yml**: Changed scrape target from `localhost:8080` to `backend:8080` (Docker service name)
2. **docker-compose.yml**: Added `backend` to Prometheus `depends_on` to ensure proper startup order

## Testing

- Backend builds successfully
- All existing tests pass
- After restarting the stack with `docker-compose down && docker-compose up -d`:
  - Prometheus targets page should show backend as "UP"
  - Grafana dashboards should display metrics within 15-30 seconds

## Verification Steps

```bash
# Check Prometheus target status
curl http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health: .health}'

# Verify metrics are being scraped
curl 'http://localhost:9090/api/v1/query?query=up{job="clubhouse"}' | jq
```

Closes #141