### PR TITLE
Bug: Query error when performing a search

### DIFF
--- a/backend/internal/services/search.go
+++ b/backend/internal/services/search.go
@@ -83,7 +83,7 @@ func (s *SearchService) Search(ctx context.Context, query string, scope string, 
 					OR l.search_vector @@ q.query
 				)
 				%s
-			GROUP BY p.id
+			GROUP BY p.id, q.query
 		),
 		comment_matches AS (
 			SELECT c.id,
@@ -100,7 +100,7 @@ func (s *SearchService) Search(ctx context.Context, query string, scope string, 
 					OR l.search_vector @@ q.query
 				)
 				%s
-			GROUP BY c.id
+			GROUP BY c.id, q.query
 		),
 		link_matches AS (
 			SELECT l.id,


### PR DESCRIPTION
Summary:
- add q.query to GROUP BY in search ranking CTEs to satisfy Postgres grouping rules
- keep search results ranking behavior unchanged

Tests:
- go test ./internal/services -run TestSearchService -v

Closes #160