### PR TITLE
Bug: Grafana piechart panel plugin fails to load - Angular plugins deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
-      GF_INSTALL_PLUGINS: grafana-piechart-panel
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
Summary:
- remove deprecated grafana-piechart-panel from Grafana container config
- rely on Grafana native visualizations to avoid Angular plugin errors

Closes #143