### PR TITLE
Bug: Deprecated GF_INSTALL_PLUGINS environment variable in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
+      # Optional plugin preinstall list (e.g. "grafana-piechart-panel")
+      GF_PLUGINS_PREINSTALL: ${GF_PLUGINS_PREINSTALL:-}
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
Summary:
- pass Grafana plugin preinstall list via GF_PLUGINS_PREINSTALL
- avoid deprecated GF_INSTALL_PLUGINS usage in compose

Closes #145