### PR TITLE
Infra: Backend Dockerfile installs wrong migrate binary on amd64

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,22 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates curl postgresql-client
 
 # Install golang-migrate
-RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-arm64.tar.gz | tar xvz && \
+ARG TARGETARCH
+RUN set -eux; \
+    arch="$TARGETARCH"; \
+    if [ -z "$arch" ]; then \
+        arch="$(uname -m)"; \
+        case "$arch" in \
+            x86_64) arch=amd64 ;; \
+            aarch64) arch=arm64 ;; \
+            *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+        esac; \
+    fi; \
+    case "$arch" in \
+        amd64|arm64) ;; \
+        *) echo "unsupported TARGETARCH: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -L "https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-${arch}.tar.gz" | tar xvz; \
     mv migrate /usr/local/bin/migrate
 
 WORKDIR /app


### PR DESCRIPTION
Summary:
- download golang-migrate based on TARGETARCH or uname -m
- fail fast on unsupported architectures

Closes #187