### PR TITLE
Infra: Pin observability image versions in compose files

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,7 +106,7 @@ services:
       - clubhouse
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.0.1
     container_name: clubhouse-loki
     restart: unless-stopped
     command: -config.file=/etc/loki/local-config.yaml
@@ -116,7 +116,7 @@ services:
       - clubhouse
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:2.54.1
     container_name: clubhouse-prometheus
     restart: unless-stopped
     command:
@@ -131,7 +131,7 @@ services:
       - backend
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.6.1
     container_name: clubhouse-tempo
     restart: unless-stopped
     command: ["-config.file=/etc/tempo/tempo.yml"]
@@ -142,7 +142,7 @@ services:
       - clubhouse
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.2.0
     container_name: clubhouse-grafana
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   # Loki (Log Aggregation)
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.0.1
     container_name: clubhouse-loki
     command: -config.file=/etc/loki/local-config.yaml
     ports:
@@ -50,7 +50,7 @@ services:
 
   # Prometheus (Metrics)
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:2.54.1
     container_name: clubhouse-prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -68,7 +68,7 @@ services:
 
   # Tempo (Traces)
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.6.1
     container_name: clubhouse-tempo
     command: ["-config.file=/etc/tempo/tempo.yml"]
     ports:
@@ -83,7 +83,7 @@ services:
 
   # Grafana (Observability UI)
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.2.0
     container_name: clubhouse-grafana
     environment:
       GF_SECURITY_ADMIN_USER: admin

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -125,6 +125,13 @@ The backup/restore scripts source `.env.production` automatically when present.
 
 Grafana dashboards are provisioned from `grafana/dashboards`.
 
+Pinned observability image versions (see `docker-compose.yml` and `docker-compose.prod.yml`):
+
+- Grafana: `grafana/grafana:11.2.0`
+- Loki: `grafana/loki:3.0.1`
+- Prometheus: `prom/prometheus:2.54.1`
+- Tempo: `grafana/tempo:2.6.1`
+
 ## 9) Security hardening checklist
 
 - Replace the default admin password on first login. The seed user is created from `backend/migrations/seed_admin.sql`.


### PR DESCRIPTION
Summary:
- replace latest tags for Grafana, Loki, Prometheus, and Tempo in dev/prod compose files
- document pinned observability image versions in the production guide

Closes #188