### PR TITLE
Auth: Update login/register UI for username-based auth

### DIFF
--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -10,25 +10,32 @@
   interface LoginResponse {
     id: string;
     username: string;
-    email: string;
+    email?: string | null;
     is_admin: boolean;
     message: string;
   }
 
   async function handleSubmit() {
     error = '';
+    const trimmedUsername = username.trim();
+
+    if (!trimmedUsername || !password) {
+      error = 'Username and password are required';
+      return;
+    }
+
     isLoading = true;
 
     try {
       const response = await api.post<LoginResponse>('/auth/login', {
-        username,
+        username: trimmedUsername,
         password,
       });
 
       const user: User = {
         id: response.id,
         username: response.username,
-        email: response.email,
+        email: response.email ?? '',
         isAdmin: response.is_admin,
       };
 
@@ -59,7 +66,7 @@
       </p>
     </div>
 
-    <form class="mt-8 space-y-6" on:submit|preventDefault={handleSubmit}>
+    <form class="mt-8 space-y-6" novalidate on:submit|preventDefault={handleSubmit}>
       {#if error}
         <div class="rounded-md bg-red-50 p-4">
           <p class="text-sm text-red-700">{error}</p>

--- a/frontend/src/routes/Register.svelte
+++ b/frontend/src/routes/Register.svelte
@@ -2,7 +2,6 @@
   import { api } from '../services/api';
 
   let username = '';
-  let email = '';
   let password = '';
   let confirmPassword = '';
   let error = '';
@@ -13,6 +12,23 @@
     error = '';
     success = '';
 
+    const trimmedUsername = username.trim();
+
+    if (!trimmedUsername) {
+      error = 'Username is required';
+      return;
+    }
+
+    if (!password) {
+      error = 'Password is required';
+      return;
+    }
+
+    if (!confirmPassword) {
+      error = 'Please confirm your password';
+      return;
+    }
+
     if (password !== confirmPassword) {
       error = 'Passwords do not match';
       return;
@@ -22,13 +38,11 @@
 
     try {
       const response = await api.post<{ message: string }>('/auth/register', {
-        username,
-        email,
+        username: trimmedUsername,
         password,
       });
       success = response.message;
       username = '';
-      email = '';
       password = '';
       confirmPassword = '';
     } catch (e) {
@@ -57,7 +71,7 @@
       </p>
     </div>
 
-    <form class="mt-8 space-y-6" on:submit|preventDefault={handleSubmit}>
+    <form class="mt-8 space-y-6" novalidate on:submit|preventDefault={handleSubmit}>
       {#if error}
         <div class="rounded-md bg-red-50 p-4">
           <p class="text-sm text-red-700">{error}</p>
@@ -77,22 +91,11 @@
             id="username"
             name="username"
             type="text"
+            autocomplete="username"
             required
             bind:value={username}
             class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
             placeholder="Username"
-          />
-        </div>
-        <div>
-          <label for="email" class="sr-only">Email address</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            autocomplete="email"
-            bind:value={email}
-            class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-            placeholder="Email address (optional)"
           />
         </div>
         <div>

--- a/frontend/src/routes/__tests__/Login.test.ts
+++ b/frontend/src/routes/__tests__/Login.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup, waitFor } from '@testing-library/svelte';
+
+const apiPost = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    post: apiPost,
+  },
+}));
+
+const { default: Login } = await import('../Login.svelte');
+const { authStore } = await import('../../stores');
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  apiPost.mockReset();
+  authStore.setUser(null);
+});
+
+describe('Login', () => {
+  it('submits username and password', async () => {
+    apiPost.mockResolvedValue({
+      id: 'user-1',
+      username: 'sander',
+      email: 'sander@example.com',
+      is_admin: false,
+      message: 'ok',
+    });
+
+    const setUserSpy = vi.spyOn(authStore, 'setUser');
+
+    render(Login, { onNavigate: vi.fn() });
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'sander' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith('/auth/login', {
+        username: 'sander',
+        password: 'secret',
+      })
+    );
+
+    await waitFor(() =>
+      expect(setUserSpy).toHaveBeenCalledWith({
+        id: 'user-1',
+        username: 'sander',
+        email: 'sander@example.com',
+        isAdmin: false,
+      })
+    );
+  });
+
+  it('shows a validation message when missing credentials', async () => {
+    render(Login, { onNavigate: vi.fn() });
+
+    await fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(screen.getByText('Username and password are required')).toBeInTheDocument();
+    expect(apiPost).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/routes/__tests__/Register.test.ts
+++ b/frontend/src/routes/__tests__/Register.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup, waitFor } from '@testing-library/svelte';
+
+const apiPost = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    post: apiPost,
+  },
+}));
+
+const { default: Register } = await import('../Register.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  apiPost.mockReset();
+});
+
+describe('Register', () => {
+  it('submits username and password only', async () => {
+    apiPost.mockResolvedValue({ message: 'ok' });
+
+    render(Register, { onNavigate: vi.fn() });
+
+    expect(screen.queryByLabelText('Email address')).toBeNull();
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'newuser' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+    await fireEvent.input(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'secret' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith('/auth/register', {
+        username: 'newuser',
+        password: 'secret',
+      })
+    );
+  });
+
+  it('shows a validation message when passwords do not match', async () => {
+    render(Register, { onNavigate: vi.fn() });
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'newuser' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+    await fireEvent.input(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'not-secret' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    expect(apiPost).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -18,7 +18,7 @@ interface AuthState {
 interface MeResponse {
   id: string;
   username: string;
-  email: string;
+  email?: string | null;
   profile_picture_url?: string;
   bio?: string;
   is_admin: boolean;
@@ -49,7 +49,7 @@ function createAuthStore() {
         const user: User = {
           id: response.id,
           username: response.username,
-          email: response.email,
+          email: response.email ?? '',
           profilePictureUrl: response.profile_picture_url,
           bio: response.bio,
           isAdmin: response.is_admin,


### PR DESCRIPTION
Summary:
- switch login/register forms to username-only payloads
- add client-side validation and allow optional email in auth responses
- add login/register component tests for new behavior

Tests:
- npm run check
- npm run test -- src/routes/__tests__/Login.test.ts src/routes/__tests__/Register.test.ts

Closes #200