### PR TITLE
Auth: Update frontend password guidance to match new policy

### DIFF
--- a/frontend/src/routes/Register.svelte
+++ b/frontend/src/routes/Register.svelte
@@ -24,6 +24,11 @@
       return;
     }
 
+    if (password.length < 12) {
+      error = 'Password must be at least 12 characters';
+      return;
+    }
+
     if (!confirmPassword) {
       error = 'Please confirm your password';
       return;
@@ -106,9 +111,13 @@
             type="password"
             required
             bind:value={password}
+            aria-describedby="password-help"
             class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
             placeholder="Password"
           />
+          <p id="password-help" class="px-3 py-2 text-xs text-gray-500">
+            Must be at least 12 characters.
+          </p>
         </div>
         <div>
           <label for="confirmPassword" class="sr-only">Confirm Password</label>

--- a/frontend/src/routes/__tests__/Register.test.ts
+++ b/frontend/src/routes/__tests__/Register.test.ts
@@ -31,19 +31,37 @@ describe('Register', () => {
       target: { value: 'newuser' },
     });
     await fireEvent.input(screen.getByLabelText('Password'), {
-      target: { value: 'secret' },
+      target: { value: 'longpassword12' },
     });
     await fireEvent.input(screen.getByLabelText('Confirm Password'), {
-      target: { value: 'secret' },
+      target: { value: 'longpassword12' },
     });
     await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() =>
       expect(apiPost).toHaveBeenCalledWith('/auth/register', {
         username: 'newuser',
-        password: 'secret',
+        password: 'longpassword12',
       })
     );
+  });
+
+  it('shows a validation message when password is too short', async () => {
+    render(Register, { onNavigate: vi.fn() });
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'newuser' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'short' },
+    });
+    await fireEvent.input(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'short' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(screen.getByText('Password must be at least 12 characters')).toBeInTheDocument();
+    expect(apiPost).not.toHaveBeenCalled();
   });
 
   it('shows a validation message when passwords do not match', async () => {
@@ -53,7 +71,7 @@ describe('Register', () => {
       target: { value: 'newuser' },
     });
     await fireEvent.input(screen.getByLabelText('Password'), {
-      target: { value: 'secret' },
+      target: { value: 'longpassword12' },
     });
     await fireEvent.input(screen.getByLabelText('Confirm Password'), {
       target: { value: 'not-secret' },


### PR DESCRIPTION
Summary:
- add 12-character password guidance and validation on registration
- update register tests for minimum length

Closes #203