### PR TITLE
Auth: Track sessions per user + add logout-all endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -137,6 +137,7 @@ func main() {
 	mux.HandleFunc("/api/v1/auth/login", authHandler.Login)
 	mux.HandleFunc("/api/v1/auth/logout", authHandler.Logout)
 	mux.HandleFunc("/api/v1/auth/me", authHandler.GetMe)
+	mux.Handle("/api/v1/auth/logout-all", requireAuth(http.HandlerFunc(authHandler.LogoutAll)))
 	mux.Handle("/api/v1/sections", requireAuth(http.HandlerFunc(sectionHandler.ListSections)))
 	sectionRouteHandler := newSectionRouteHandler(requireAuth, sectionRouteDeps{
 		listSections: sectionHandler.ListSections,

--- a/backend/internal/services/session_test.go
+++ b/backend/internal/services/session_test.go
@@ -1,0 +1,105 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestCreateSessionTracksUserSession(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	service := NewSessionService(client)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	session, err := service.CreateSession(ctx, userID, "tester", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	userKey := UserSessionSetPrefix + userID.String()
+	isMember, err := client.SIsMember(ctx, userKey, session.ID).Result()
+	if err != nil {
+		t.Fatalf("unexpected redis error: %v", err)
+	}
+	if !isMember {
+		t.Fatalf("expected session to be tracked in user session set")
+	}
+}
+
+func TestDeleteSessionRemovesFromUserSet(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	service := NewSessionService(client)
+
+	ctx := context.Background()
+	userID := uuid.New()
+
+	session, err := service.CreateSession(ctx, userID, "tester", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := service.DeleteSession(ctx, session.ID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	userKey := UserSessionSetPrefix + userID.String()
+	isMember, err := client.SIsMember(ctx, userKey, session.ID).Result()
+	if err != nil {
+		t.Fatalf("unexpected redis error: %v", err)
+	}
+	if isMember {
+		t.Fatalf("expected session to be removed from user session set")
+	}
+}
+
+func TestDeleteAllSessionsForUser(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	service := NewSessionService(client)
+
+	ctx := context.Background()
+	userID := uuid.New()
+	otherUserID := uuid.New()
+
+	session1, err := service.CreateSession(ctx, userID, "tester", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	session2, err := service.CreateSession(ctx, userID, "tester", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	otherSession, err := service.CreateSession(ctx, otherUserID, "other", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := service.DeleteAllSessionsForUser(ctx, userID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := service.GetSession(ctx, session1.ID); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected session1 to be deleted, got %v", err)
+	}
+	if _, err := service.GetSession(ctx, session2.ID); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected session2 to be deleted, got %v", err)
+	}
+	if _, err := service.GetSession(ctx, otherSession.ID); err != nil {
+		t.Fatalf("expected other session to remain, got %v", err)
+	}
+
+	userKey := UserSessionSetPrefix + userID.String()
+	if exists, err := client.Exists(ctx, userKey).Result(); err != nil {
+		t.Fatalf("unexpected redis error: %v", err)
+	} else if exists != 0 {
+		t.Fatalf("expected user session set to be deleted")
+	}
+}


### PR DESCRIPTION
Summary:
- track session IDs per user in Redis sets and keep them in sync on logout
- add logout-all handler + route to revoke all sessions for the current user
- add session service tests covering revoke-all behavior

Closes #195