### PR TITLE
Auth: Add auth event logging (backend)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -314,6 +314,8 @@ func main() {
 
 	// Admin audit logs route
 	mux.Handle("/api/v1/admin/audit-logs", requireAdmin(http.HandlerFunc(adminHandler.GetAuditLogs)))
+	// Admin auth events route
+	mux.Handle("/api/v1/admin/auth-events", requireAdmin(http.HandlerFunc(adminHandler.GetAuthEvents)))
 
 	// Admin password reset route
 	mux.Handle("/api/v1/admin/password-reset/generate", requireAdminCSRF(http.HandlerFunc(adminHandler.GeneratePasswordResetToken)))

--- a/backend/internal/handlers/auth_event_test.go
+++ b/backend/internal/handlers/auth_event_test.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestLoginSuccessLogsAuthEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	redisClient := testutil.GetTestRedis(t)
+	t.Cleanup(func() { testutil.CleanupRedis(t) })
+
+	password := "Password1234!"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	userID := uuid.New()
+	_, err = db.Exec(`
+		INSERT INTO users (id, username, email, password_hash, is_admin, approved_at, created_at)
+		VALUES ($1, 'loginuser', 'loginuser@example.com', $2, false, now(), now())
+	`, userID, string(hash))
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	handler := NewAuthHandler(db, redisClient)
+
+	reqBody := `{"username":"loginuser","password":"` + password + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "test-agent")
+	req.RemoteAddr = "203.0.113.10:1234"
+	w := httptest.NewRecorder()
+
+	handler.Login(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var identifier, ipAddress, userAgent string
+	err = db.QueryRow(`
+		SELECT identifier, ip_address, user_agent
+		FROM auth_events
+		WHERE event_type = 'login_success' AND user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, userID).Scan(&identifier, &ipAddress, &userAgent)
+	if err != nil {
+		t.Fatalf("failed to query auth event: %v", err)
+	}
+
+	if identifier != "loginuser" {
+		t.Errorf("expected identifier loginuser, got %s", identifier)
+	}
+	if ipAddress != "203.0.113.10" {
+		t.Errorf("expected ip address 203.0.113.10, got %s", ipAddress)
+	}
+	if userAgent != "test-agent" {
+		t.Errorf("expected user agent test-agent, got %s", userAgent)
+	}
+}
+
+func TestLoginFailureLogsAuthEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	redisClient := testutil.GetTestRedis(t)
+	t.Cleanup(func() { testutil.CleanupRedis(t) })
+
+	handler := NewAuthHandler(db, redisClient)
+
+	reqBody := `{"username":"missinguser","password":"wrongpassword"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "test-agent")
+	req.RemoteAddr = "203.0.113.11:1234"
+	w := httptest.NewRecorder()
+
+	handler.Login(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusUnauthorized, w.Code, w.Body.String())
+	}
+
+	var identifier, ipAddress, userAgent string
+	err := db.QueryRow(`
+		SELECT identifier, ip_address, user_agent
+		FROM auth_events
+		WHERE event_type = 'login_failure' AND identifier = 'missinguser'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&identifier, &ipAddress, &userAgent)
+	if err != nil {
+		t.Fatalf("failed to query auth event: %v", err)
+	}
+
+	if identifier != "missinguser" {
+		t.Errorf("expected identifier missinguser, got %s", identifier)
+	}
+	if ipAddress != "203.0.113.11" {
+		t.Errorf("expected ip address 203.0.113.11, got %s", ipAddress)
+	}
+	if userAgent != "test-agent" {
+		t.Errorf("expected user agent test-agent, got %s", userAgent)
+	}
+}
+
+func TestLogoutLogsAuthEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	redisClient := testutil.GetTestRedis(t)
+	t.Cleanup(func() { testutil.CleanupRedis(t) })
+
+	userID := uuid.New()
+	_, err := db.Exec(`
+		INSERT INTO users (id, username, email, password_hash, is_admin, approved_at, created_at)
+		VALUES ($1, 'logoutuser', 'logoutuser@example.com', '$2a$12$test', false, now(), now())
+	`, userID)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	sessionService := services.NewSessionService(redisClient)
+	session, err := sessionService.CreateSession(context.Background(), userID, "logoutuser", false)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	handler := NewAuthHandler(db, redisClient)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: session.ID})
+	req.Header.Set("User-Agent", "test-agent")
+	req.RemoteAddr = "203.0.113.12:1234"
+	w := httptest.NewRecorder()
+
+	handler.Logout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var identifier, ipAddress, userAgent string
+	err = db.QueryRow(`
+		SELECT identifier, ip_address, user_agent
+		FROM auth_events
+		WHERE event_type = 'logout' AND user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, userID).Scan(&identifier, &ipAddress, &userAgent)
+	if err != nil {
+		t.Fatalf("failed to query auth event: %v", err)
+	}
+
+	if identifier != "logoutuser" {
+		t.Errorf("expected identifier logoutuser, got %s", identifier)
+	}
+	if ipAddress != "203.0.113.12" {
+		t.Errorf("expected ip address 203.0.113.12, got %s", ipAddress)
+	}
+	if userAgent != "test-agent" {
+		t.Errorf("expected user agent test-agent, got %s", userAgent)
+	}
+}
+
+func TestAuthEventsListReturnsJson(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewAdminHandler(db, nil)
+
+	_, err := db.Exec(`
+		INSERT INTO auth_events (id, event_type, created_at)
+		VALUES (gen_random_uuid(), 'login_success', now())
+	`)
+	if err != nil {
+		t.Fatalf("failed to create auth event: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/auth-events", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetAuthEvents(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if _, ok := response["events"]; !ok {
+		t.Fatalf("expected events field in response")
+	}
+}

--- a/backend/internal/handlers/auth_password_reset_test.go
+++ b/backend/internal/handlers/auth_password_reset_test.go
@@ -77,6 +77,15 @@ func TestRedeemPasswordResetToken(t *testing.T) {
 	if err != services.ErrPasswordResetTokenNotFound {
 		t.Errorf("expected token to be deleted, got %v", err)
 	}
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM auth_events WHERE event_type = 'password_reset' AND user_id = $1", userID).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to query auth event count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 password_reset auth event, got %d", count)
+	}
 }
 
 func TestRedeemPasswordResetTokenInvalidToken(t *testing.T) {

--- a/backend/internal/models/auth_event.go
+++ b/backend/internal/models/auth_event.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AuthEvent represents an authentication-related event for security auditing.
+type AuthEvent struct {
+	ID         uuid.UUID  `json:"id"`
+	UserID     *uuid.UUID `json:"user_id,omitempty"`
+	Username   *string    `json:"username,omitempty"`
+	Identifier string     `json:"identifier,omitempty"`
+	EventType  string     `json:"event_type"`
+	IPAddress  string     `json:"ip_address,omitempty"`
+	UserAgent  string     `json:"user_agent,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+// AuthEventCreate represents the fields required to log an auth event.
+type AuthEventCreate struct {
+	UserID     *uuid.UUID
+	Identifier string
+	EventType  string
+	IPAddress  string
+	UserAgent  string
+}
+
+// AuthEventLogsResponse represents the response for listing auth events.
+type AuthEventLogsResponse struct {
+	Events     []*AuthEvent `json:"events"`
+	HasMore    bool         `json:"has_more"`
+	NextCursor *string      `json:"next_cursor,omitempty"`
+}

--- a/backend/internal/services/auth_event.go
+++ b/backend/internal/services/auth_event.go
@@ -1,0 +1,40 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+// AuthEventService handles auth event logging.
+type AuthEventService struct {
+	db *sql.DB
+}
+
+// NewAuthEventService creates a new auth event service.
+func NewAuthEventService(db *sql.DB) *AuthEventService {
+	return &AuthEventService{db: db}
+}
+
+// LogEvent records an authentication-related event for auditing.
+func (s *AuthEventService) LogEvent(ctx context.Context, event *models.AuthEventCreate) error {
+	if event == nil {
+		return fmt.Errorf("auth event is required")
+	}
+	if event.EventType == "" {
+		return fmt.Errorf("auth event type is required")
+	}
+
+	query := `
+		INSERT INTO auth_events (user_id, identifier, event_type, ip_address, user_agent, created_at)
+		VALUES ($1, $2, $3, $4, $5, now())
+	`
+	_, err := s.db.ExecContext(ctx, query, event.UserID, event.Identifier, event.EventType, event.IPAddress, event.UserAgent)
+	if err != nil {
+		return fmt.Errorf("failed to insert auth event: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/testutil/testutil.go
+++ b/backend/internal/testutil/testutil.go
@@ -92,6 +92,7 @@ func CleanupTables(t *testing.T, db *sql.DB) {
 	// The order matters due to foreign key constraints - CASCADE handles this
 	_, err := db.Exec(`
 		TRUNCATE TABLE
+			auth_events,
 			audit_logs,
 			push_subscriptions,
 			notifications,

--- a/backend/migrations/017_create_auth_events_table.down.sql
+++ b/backend/migrations/017_create_auth_events_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS auth_events;

--- a/backend/migrations/017_create_auth_events_table.up.sql
+++ b/backend/migrations/017_create_auth_events_table.up.sql
@@ -1,0 +1,16 @@
+-- Create auth_events table for security auditing
+CREATE TABLE auth_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  identifier VARCHAR(100),
+  event_type VARCHAR(50) NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+-- Indexes for common lookups
+CREATE INDEX idx_auth_events_created_at ON auth_events(created_at DESC);
+CREATE INDEX idx_auth_events_user_id ON auth_events(user_id);
+CREATE INDEX idx_auth_events_event_type ON auth_events(event_type);
+CREATE INDEX idx_auth_events_identifier ON auth_events(identifier);


### PR DESCRIPTION
Summary:
- add auth_events table and auth event logging service
- log login success/failure, logout/logout-all, and password reset events
- expose admin auth-events endpoint and tests

Closes #204