### PR TITLE
Observability: Add missing business metrics (reactions, deletes, notifications, link fetch)

### DIFF
--- a/backend/internal/handlers/links.go
+++ b/backend/internal/handlers/links.go
@@ -52,10 +52,17 @@ func (h *LinkHandler) PreviewLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	observability.RecordLinkMetadataFetchAttempt(r.Context(), 1)
 	metadata, err := linkmeta.FetchMetadata(r.Context(), trimmedURL)
 	if err != nil {
+		observability.RecordLinkMetadataFetchFailure(r.Context(), 1)
 		writeError(r.Context(), w, http.StatusBadGateway, "LINK_METADATA_FETCH_FAILED", "Failed to fetch link metadata")
 		return
+	}
+	if len(metadata) == 0 {
+		observability.RecordLinkMetadataFetchFailure(r.Context(), 1)
+	} else {
+		observability.RecordLinkMetadataFetchSuccess(r.Context(), 1)
 	}
 
 	if metadata == nil {

--- a/backend/internal/handlers/reaction.go
+++ b/backend/internal/handlers/reaction.go
@@ -87,6 +87,7 @@ func (h *ReactionHandler) AddReactionToPost(w http.ResponseWriter, r *http.Reque
 		UserID: reaction.UserID,
 		Emoji:  reaction.Emoji,
 	})
+	observability.RecordReactionAdded(publishCtx, "post")
 	cancel()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -155,6 +156,7 @@ func (h *ReactionHandler) RemoveReactionFromPost(w http.ResponseWriter, r *http.
 		UserID: userID,
 		Emoji:  emoji,
 	})
+	observability.RecordReactionRemoved(publishCtx, "post")
 	cancel()
 
 	w.WriteHeader(http.StatusNoContent)
@@ -215,6 +217,7 @@ func (h *ReactionHandler) AddReactionToComment(w http.ResponseWriter, r *http.Re
 		UserID:    reaction.UserID,
 		Emoji:     reaction.Emoji,
 	})
+	observability.RecordReactionAdded(publishCtx, "comment")
 	cancel()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -283,6 +286,7 @@ func (h *ReactionHandler) RemoveReactionFromComment(w http.ResponseWriter, r *ht
 		UserID:    userID,
 		Emoji:     emoji,
 	})
+	observability.RecordReactionRemoved(publishCtx, "comment")
 	cancel()
 
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -194,6 +194,10 @@ func (h *WebSocketHandler) writeLoop(ctx context.Context, wsConn *wsConnection) 
 			return
 		}
 
+		if strings.HasSuffix(msg.Channel, ":notifications") {
+			observability.RecordNotificationDelivered(ctx, "websocket", 1)
+		}
+
 		payload := []byte(msg.Payload)
 		if !json.Valid(payload) {
 			payload = h.wrapPayload(msg.Payload)

--- a/backend/internal/observability/metrics.go
+++ b/backend/internal/observability/metrics.go
@@ -19,6 +19,18 @@ type metrics struct {
 	websocketDisconnectsTotal metric.Int64Counter
 	postsCreated              metric.Int64Counter
 	commentsCreated           metric.Int64Counter
+	reactionsAdded            metric.Int64Counter
+	reactionsRemoved          metric.Int64Counter
+	postsDeleted              metric.Int64Counter
+	postsRestored             metric.Int64Counter
+	commentsDeleted           metric.Int64Counter
+	commentsRestored          metric.Int64Counter
+	notificationsCreated      metric.Int64Counter
+	notificationsDelivered    metric.Int64Counter
+	notificationsFailed       metric.Int64Counter
+	linkMetadataFetchAttempts metric.Int64Counter
+	linkMetadataFetchSuccess  metric.Int64Counter
+	linkMetadataFetchFailures metric.Int64Counter
 }
 
 var (
@@ -96,6 +108,114 @@ func initMetrics() error {
 			return
 		}
 
+		reactionsAdded, err := meter.Int64Counter(
+			"clubhouse.reactions.added",
+			metric.WithDescription("Number of reactions added"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		reactionsRemoved, err := meter.Int64Counter(
+			"clubhouse.reactions.removed",
+			metric.WithDescription("Number of reactions removed"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		postsDeleted, err := meter.Int64Counter(
+			"clubhouse.posts.deleted",
+			metric.WithDescription("Number of posts deleted"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		postsRestored, err := meter.Int64Counter(
+			"clubhouse.posts.restored",
+			metric.WithDescription("Number of posts restored"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		commentsDeleted, err := meter.Int64Counter(
+			"clubhouse.comments.deleted",
+			metric.WithDescription("Number of comments deleted"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		commentsRestored, err := meter.Int64Counter(
+			"clubhouse.comments.restored",
+			metric.WithDescription("Number of comments restored"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		notificationsCreated, err := meter.Int64Counter(
+			"clubhouse.notifications.created",
+			metric.WithDescription("Number of notifications created"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		notificationsDelivered, err := meter.Int64Counter(
+			"clubhouse.notifications.delivered",
+			metric.WithDescription("Number of notifications delivered"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		notificationsFailed, err := meter.Int64Counter(
+			"clubhouse.notifications.delivery_failed",
+			metric.WithDescription("Number of notification delivery failures"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		linkMetadataFetchAttempts, err := meter.Int64Counter(
+			"clubhouse.links.metadata.fetch.attempts",
+			metric.WithDescription("Number of link metadata fetch attempts"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		linkMetadataFetchSuccess, err := meter.Int64Counter(
+			"clubhouse.links.metadata.fetch.success",
+			metric.WithDescription("Number of successful link metadata fetches"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		linkMetadataFetchFailures, err := meter.Int64Counter(
+			"clubhouse.links.metadata.fetch.failures",
+			metric.WithDescription("Number of failed link metadata fetches"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
 		metricsInstance = &metrics{
 			httpRequestCount:          httpRequestCount,
 			httpRequestDuration:       httpRequestDuration,
@@ -104,6 +224,18 @@ func initMetrics() error {
 			websocketDisconnectsTotal: websocketDisconnectsTotal,
 			postsCreated:              postsCreated,
 			commentsCreated:           commentsCreated,
+			reactionsAdded:            reactionsAdded,
+			reactionsRemoved:          reactionsRemoved,
+			postsDeleted:              postsDeleted,
+			postsRestored:             postsRestored,
+			commentsDeleted:           commentsDeleted,
+			commentsRestored:          commentsRestored,
+			notificationsCreated:      notificationsCreated,
+			notificationsDelivered:    notificationsDelivered,
+			notificationsFailed:       notificationsFailed,
+			linkMetadataFetchAttempts: linkMetadataFetchAttempts,
+			linkMetadataFetchSuccess:  linkMetadataFetchSuccess,
+			linkMetadataFetchFailures: linkMetadataFetchFailures,
 		}
 	})
 
@@ -167,4 +299,130 @@ func RecordCommentCreated(ctx context.Context) {
 		return
 	}
 	m.commentsCreated.Add(ctx, 1)
+}
+
+// RecordReactionAdded increments the reaction added counter.
+func RecordReactionAdded(ctx context.Context, target string) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.reactionsAdded.Add(ctx, 1, metric.WithAttributes(attribute.String("target", target)))
+}
+
+// RecordReactionRemoved increments the reaction removed counter.
+func RecordReactionRemoved(ctx context.Context, target string) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.reactionsRemoved.Add(ctx, 1, metric.WithAttributes(attribute.String("target", target)))
+}
+
+// RecordPostDeleted increments the post deleted counter.
+func RecordPostDeleted(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.postsDeleted.Add(ctx, 1)
+}
+
+// RecordPostRestored increments the post restored counter.
+func RecordPostRestored(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.postsRestored.Add(ctx, 1)
+}
+
+// RecordCommentDeleted increments the comment deleted counter.
+func RecordCommentDeleted(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.commentsDeleted.Add(ctx, 1)
+}
+
+// RecordCommentRestored increments the comment restored counter.
+func RecordCommentRestored(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.commentsRestored.Add(ctx, 1)
+}
+
+// RecordNotificationsCreated increments the notification created counter.
+func RecordNotificationsCreated(ctx context.Context, notificationType string, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.notificationsCreated.Add(ctx, count, metric.WithAttributes(attribute.String("type", notificationType)))
+}
+
+// RecordNotificationDelivered increments the notification delivered counter.
+func RecordNotificationDelivered(ctx context.Context, channel string, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.notificationsDelivered.Add(ctx, count, metric.WithAttributes(attribute.String("channel", channel)))
+}
+
+// RecordNotificationDeliveryFailed increments the notification delivery failure counter.
+func RecordNotificationDeliveryFailed(ctx context.Context, channel string, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.notificationsFailed.Add(ctx, count, metric.WithAttributes(attribute.String("channel", channel)))
+}
+
+// RecordLinkMetadataFetchAttempt increments the link metadata fetch attempt counter.
+func RecordLinkMetadataFetchAttempt(ctx context.Context, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.linkMetadataFetchAttempts.Add(ctx, count)
+}
+
+// RecordLinkMetadataFetchSuccess increments the link metadata fetch success counter.
+func RecordLinkMetadataFetchSuccess(ctx context.Context, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.linkMetadataFetchSuccess.Add(ctx, count)
+}
+
+// RecordLinkMetadataFetchFailure increments the link metadata fetch failure counter.
+func RecordLinkMetadataFetchFailure(ctx context.Context, count int64) {
+	if count <= 0 {
+		return
+	}
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.linkMetadataFetchFailures.Add(ctx, count)
 }

--- a/backend/internal/services/comment.go
+++ b/backend/internal/services/comment.go
@@ -599,6 +599,7 @@ func (s *CommentService) DeleteComment(ctx context.Context, commentID uuid.UUID,
 	updatedComment.Links = comment.Links
 	updatedComment.ReactionCounts = comment.ReactionCounts
 	updatedComment.ViewerReactions = comment.ViewerReactions
+	observability.RecordCommentDeleted(ctx)
 
 	return &updatedComment, nil
 }
@@ -707,6 +708,7 @@ func (s *CommentService) RestoreComment(ctx context.Context, commentID uuid.UUID
 	}
 	restoredComment.ReactionCounts = counts
 	restoredComment.ViewerReactions = viewerReactions
+	observability.RecordCommentRestored(ctx)
 
 	return &restoredComment, nil
 }
@@ -813,6 +815,8 @@ func (s *CommentService) HardDeleteComment(ctx context.Context, commentID uuid.U
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
+	observability.RecordCommentDeleted(ctx)
+
 	return nil
 }
 
@@ -908,6 +912,7 @@ func (s *CommentService) AdminRestoreComment(ctx context.Context, commentID uuid
 	}
 	comment.ReactionCounts = counts
 	comment.ViewerReactions = viewerReactions
+	observability.RecordCommentRestored(ctx)
 
 	return &comment, nil
 }

--- a/backend/internal/services/link_metadata.go
+++ b/backend/internal/services/link_metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
 	linkmeta "github.com/sanderginn/clubhouse/internal/services/links"
 )
 
@@ -19,10 +20,13 @@ func fetchLinkMetadata(ctx context.Context, links []models.LinkRequest) []models
 
 	metadata := make([]models.JSONMap, len(links))
 	for i, link := range links {
+		observability.RecordLinkMetadataFetchAttempt(ctx, 1)
 		meta, err := linkmeta.FetchMetadata(ctx, link.URL)
 		if err != nil || len(meta) == 0 {
+			observability.RecordLinkMetadataFetchFailure(ctx, 1)
 			continue
 		}
+		observability.RecordLinkMetadataFetchSuccess(ctx, 1)
 		metadata[i] = models.JSONMap(meta)
 	}
 

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -427,6 +427,7 @@ func (s *PostService) DeletePost(ctx context.Context, postID uuid.UUID, userID u
 	updatedPost.Links = post.Links
 	updatedPost.ReactionCounts = post.ReactionCounts
 	updatedPost.ViewerReactions = post.ViewerReactions
+	observability.RecordPostDeleted(ctx)
 
 	return &updatedPost, nil
 }
@@ -512,6 +513,7 @@ func (s *PostService) RestorePost(ctx context.Context, postID uuid.UUID, userID 
 	}
 	post.ReactionCounts = counts
 	post.ViewerReactions = viewerReactions
+	observability.RecordPostRestored(ctx)
 
 	return &post, nil
 }
@@ -711,6 +713,8 @@ func (s *PostService) HardDeletePost(ctx context.Context, postID uuid.UUID, admi
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
+	observability.RecordPostDeleted(ctx)
+
 	return nil
 }
 
@@ -774,6 +778,7 @@ func (s *PostService) AdminRestorePost(ctx context.Context, postID uuid.UUID, ad
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch restored post: %w", err)
 	}
+	observability.RecordPostRestored(ctx)
 
 	return fullPost, nil
 }


### PR DESCRIPTION
Summary:
- add business counters for reactions, deletes/restores, notifications, and link metadata fetch
- record notification delivery outcomes for push and websocket channels
- instrument link metadata fetches in services and preview handler

Closes #233