### PR TITLE
Fix: Add admin approved users endpoint for reset links

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -271,6 +271,7 @@ func main() {
 
 	// Admin routes (protected by RequireAdmin middleware)
 	mux.Handle("/api/v1/admin/users", requireAdmin(http.HandlerFunc(adminHandler.ListPendingUsers)))
+	mux.Handle("/api/v1/admin/users/approved", requireAdmin(http.HandlerFunc(adminHandler.ListApprovedUsers)))
 	mux.Handle("/api/v1/admin/users/", requireAdminCSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/approve") {
 			adminHandler.ApproveUser(w, r)

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -75,6 +75,16 @@ type PendingUser struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// ApprovedUser represents an approved user for admin listings
+type ApprovedUser struct {
+	ID         uuid.UUID `json:"id"`
+	Username   string    `json:"username"`
+	Email      string    `json:"email"`
+	IsAdmin    bool      `json:"is_admin"`
+	ApprovedAt time.Time `json:"approved_at"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 // ApproveUserResponse represents the response from approving a user
 type ApproveUserResponse struct {
 	ID       uuid.UUID `json:"id"`


### PR DESCRIPTION
Summary:
- add /api/v1/admin/users/approved route + handler for approved user listing
- add user service + model for approved user payload
- add handler test coverage for approved users listing

Tests:
- go test ./internal/handlers -run TestListApprovedUsers -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #245