### PR TITLE
Tests: Add PostService unit coverage (create/delete/restore)

### DIFF
--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -1,0 +1,233 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestCreatePostWithoutLinks(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	disableLinkMetadata(t)
+
+	userID := testutil.CreateTestUser(t, db, "postuser", "postuser@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Test Section", "general")
+
+	service := NewPostService(db)
+	req := &models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Hello world",
+	}
+
+	post, err := service.CreatePost(context.Background(), req, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("CreatePost failed: %v", err)
+	}
+
+	if post.Content != "Hello world" {
+		t.Errorf("expected content 'Hello world', got %s", post.Content)
+	}
+	if post.SectionID.String() != sectionID {
+		t.Errorf("expected section_id %s, got %s", sectionID, post.SectionID.String())
+	}
+	if len(post.Links) != 0 {
+		t.Errorf("expected no links, got %d", len(post.Links))
+	}
+}
+
+func TestCreatePostWithLinks(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	disableLinkMetadata(t)
+
+	userID := testutil.CreateTestUser(t, db, "postlinkuser", "postlinkuser@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Links Section", "general")
+
+	service := NewPostService(db)
+	req := &models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Check this out",
+		Links: []models.LinkRequest{
+			{URL: "https://example.com"},
+		},
+	}
+
+	post, err := service.CreatePost(context.Background(), req, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("CreatePost failed: %v", err)
+	}
+
+	if len(post.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(post.Links))
+	}
+	if post.Links[0].URL != "https://example.com" {
+		t.Errorf("expected link url https://example.com, got %s", post.Links[0].URL)
+	}
+
+	var metadataIsNull bool
+	err = db.QueryRow(`SELECT metadata IS NULL FROM links WHERE post_id = $1`, post.ID).Scan(&metadataIsNull)
+	if err != nil {
+		t.Fatalf("failed to query link metadata: %v", err)
+	}
+	if !metadataIsNull {
+		t.Errorf("expected metadata to be NULL when link metadata is disabled")
+	}
+}
+
+func TestDeletePostOwner(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "deleteowner", "deleteowner@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Delete Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Owner post")
+
+	service := NewPostService(db)
+	post, err := service.DeletePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), false)
+	if err != nil {
+		t.Fatalf("DeletePost failed: %v", err)
+	}
+
+	if post.DeletedAt == nil {
+		t.Fatalf("expected deleted_at to be set")
+	}
+	if post.DeletedByUserID == nil || post.DeletedByUserID.String() != userID {
+		t.Errorf("expected deleted_by_user_id %s, got %v", userID, post.DeletedByUserID)
+	}
+}
+
+func TestDeletePostAdmin(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "deleteuser", "deleteuser@test.com", false, true)
+	adminID := testutil.CreateTestUser(t, db, "deleteadmin", "deleteadmin@test.com", true, true)
+	sectionID := testutil.CreateTestSection(t, db, "Admin Delete Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Admin delete post")
+
+	service := NewPostService(db)
+	post, err := service.DeletePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(adminID), true)
+	if err != nil {
+		t.Fatalf("DeletePost failed: %v", err)
+	}
+
+	if post.DeletedAt == nil {
+		t.Fatalf("expected deleted_at to be set")
+	}
+	if post.DeletedByUserID == nil || post.DeletedByUserID.String() != adminID {
+		t.Errorf("expected deleted_by_user_id %s, got %v", adminID, post.DeletedByUserID)
+	}
+}
+
+func TestRestorePostOwner(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "restoreowner", "restoreowner@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Restore Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Restore post")
+
+	service := NewPostService(db)
+	_, err := service.DeletePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), false)
+	if err != nil {
+		t.Fatalf("DeletePost failed: %v", err)
+	}
+
+	post, err := service.RestorePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), false)
+	if err != nil {
+		t.Fatalf("RestorePost failed: %v", err)
+	}
+
+	if post.DeletedAt != nil {
+		t.Fatalf("expected deleted_at to be cleared")
+	}
+	if post.DeletedByUserID != nil {
+		t.Fatalf("expected deleted_by_user_id to be cleared")
+	}
+}
+
+func TestAdminRestorePostCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "adminrestoreuser", "adminrestoreuser@test.com", false, true)
+	adminID := testutil.CreateTestUser(t, db, "adminrestore", "adminrestore@test.com", true, true)
+	sectionID := testutil.CreateTestSection(t, db, "Admin Restore Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Admin restore post")
+
+	service := NewPostService(db)
+	_, err := service.DeletePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), false)
+	if err != nil {
+		t.Fatalf("DeletePost failed: %v", err)
+	}
+
+	_, err = service.AdminRestorePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(adminID))
+	if err != nil {
+		t.Fatalf("AdminRestorePost failed: %v", err)
+	}
+
+	var count int
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_logs
+		WHERE admin_user_id = $1 AND action = 'restore_post' AND related_post_id = $2
+	`, adminID, postID).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 audit log entry, got %d", count)
+	}
+}
+
+func TestHardDeletePostCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "harddeleteuser", "harddeleteuser@test.com", false, true)
+	adminID := testutil.CreateTestUser(t, db, "harddeleteadmin", "harddeleteadmin@test.com", true, true)
+	sectionID := testutil.CreateTestSection(t, db, "Hard Delete Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Hard delete post")
+
+	service := NewPostService(db)
+	if err := service.HardDeletePost(context.Background(), uuid.MustParse(postID), uuid.MustParse(adminID)); err != nil {
+		t.Fatalf("HardDeletePost failed: %v", err)
+	}
+
+	var postCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM posts WHERE id = $1`, postID).Scan(&postCount); err != nil {
+		t.Fatalf("failed to query post: %v", err)
+	}
+	if postCount != 0 {
+		t.Errorf("expected post to be deleted, found %d rows", postCount)
+	}
+
+	var auditCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_logs
+		WHERE admin_user_id = $1 AND action = 'hard_delete_post'
+	`, adminID).Scan(&auditCount); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+	if auditCount != 1 {
+		t.Errorf("expected 1 audit log entry, got %d", auditCount)
+	}
+}
+
+func disableLinkMetadata(t *testing.T) {
+	t.Helper()
+	config := GetConfigService()
+	current := config.GetConfig().LinkMetadataEnabled
+	disabled := false
+	config.UpdateConfig(&disabled)
+	t.Cleanup(func() {
+		config.UpdateConfig(&current)
+	})
+}


### PR DESCRIPTION
Summary:
- add PostService unit tests for create, soft delete, restore
- cover admin audit log creation for restore and hard delete
- disable link metadata fetch in tests to avoid network calls

Closes #236