### PR TITLE
Security: Harden WebSocket origin validation (no Host header trust)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Server
 HTTP_PORT=8080
+# WebSocket origin allowlist (comma-separated hosts or origins)
+# Defaults to localhost:5173, 127.0.0.1:5173, and frontend:5173 when unset.
+WS_ORIGIN_ALLOWLIST=
 
 # PostgreSQL
 POSTGRES_HOST=postgres

--- a/.env.production.example
+++ b/.env.production.example
@@ -11,6 +11,9 @@ CLUBHOUSE_APP_DOMAIN=clubhouse.example.com
 CLUBHOUSE_GRAFANA_DOMAIN=grafana.example.com
 ACME_EMAIL=admin@example.com
 
+# WebSocket origin allowlist (comma-separated hosts or origins)
+WS_ORIGIN_ALLOWLIST=https://clubhouse.example.com
+
 # Images (optional overrides)
 # BACKEND_IMAGE=ghcr.io/your-org/clubhouse-backend:2026-01-22
 # FRONTEND_IMAGE=ghcr.io/your-org/clubhouse-frontend:2026-01-22

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -19,6 +19,7 @@ cp .env.production.example .env.production
 Required environment values:
 
 - `CLUBHOUSE_APP_DOMAIN`, `CLUBHOUSE_GRAFANA_DOMAIN`, `ACME_EMAIL`
+- `WS_ORIGIN_ALLOWLIST` (set to your frontend origin, e.g. `https://clubhouse.example.com`)
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
 - `REDIS_PASSWORD`
 - `GF_SECURITY_ADMIN_USER`, `GF_SECURITY_ADMIN_PASSWORD`, `GF_SERVER_ROOT_URL`


### PR DESCRIPTION
Summary:
- replace Host-based origin checks with an explicit allowlist (WS_ORIGIN_ALLOWLIST) and dev defaults
- log denied origins with sanitized values
- add origin allow/deny tests plus websocket test update and document new env vars

Tests:
- go test ./internal/handlers -run TestSameOrigin -v
- go test ./internal/handlers -run TestWebSocketSubscribeDispatchAndUnsubscribe -v

Closes #240