### PR TITLE
Re-evaluate observability retention policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ clubhouse/
 - **All three OTel signals**: traces, metrics, logs
 - **Trace every request** (no sampling for small scale)
 - **Direct OTLP export** to Grafana Stack
-- **Retention** follows service configs (see `tempo.yml`, `prometheus.yml`, and Loki defaults)
+- **Retention** follows service configs (see `tempo.yml`, `prometheus.yml`, and `loki.yml`)
 
 ## Common Tasks
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1056,9 +1056,9 @@ If disabled:
 - **Exporters:** OTLP to Grafana Loki
 
 ### Retention & Storage
-- **Traces:** Tempo local config uses `compacted_block_retention: 10m` (see `tempo.yml`)
-- **Metrics:** Prometheus uses default retention unless overridden (scrape interval: 15s in `prometheus.yml`)
-- **Logs:** Loki uses its default local config unless overridden
+- **Traces:** 7 days (Tempo `compacted_block_retention: 168h` in `tempo.yml`) to keep recent incident context without growing trace storage too fast.
+- **Metrics:** 30 days (Prometheus `--storage.tsdb.retention.time=30d` in `docker-compose*.yml`) for short-term trends and capacity checks.
+- **Logs:** 14 days (Loki `limits_config.retention_period: 336h` in `loki.yml`) to cover typical debugging windows while keeping disk bounded.
 
 ### Local Development
 ```yaml

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -109,8 +109,9 @@ services:
     image: grafana/loki:3.0.1
     container_name: clubhouse-loki
     restart: unless-stopped
-    command: -config.file=/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/loki.yml
     volumes:
+      - ./loki.yml:/etc/loki/loki.yml:ro
       - loki_data:/loki
     networks:
       - clubhouse
@@ -122,6 +123,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,11 @@ services:
   loki:
     image: grafana/loki:3.0.1
     container_name: clubhouse-loki
-    command: -config.file=/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/loki.yml
     ports:
       - "3100:3100"
     volumes:
+      - ./loki.yml:/etc/loki/loki.yml
       - loki_data:/loki
     networks:
       - clubhouse
@@ -55,6 +56,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
     ports:
       - "9090:9090"
     volumes:

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -185,6 +185,7 @@ The backup/restore scripts source `.env.production` automatically when present.
 - Traces: OTLP gRPC -> Tempo (`OTEL_EXPORTER_OTLP_ENDPOINT=tempo:4317`)
 - Logs: OTLP HTTP -> Loki (`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://loki:3100/otlp/v1/logs`)
 - Metrics: `/metrics` scraped by Prometheus
+- Retention: 7 days of traces (`tempo.yml`), 14 days of logs (`loki.yml`), and 30 days of metrics (`--storage.tsdb.retention.time=30d`)
 
 Grafana dashboards are provisioned from `grafana/dashboards`.
 

--- a/loki.yml
+++ b/loki.yml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  shared_store: filesystem
+  retention_enabled: true
+
+limits_config:
+  retention_period: 336h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/tempo.yml
+++ b/tempo.yml
@@ -16,7 +16,7 @@ ingester:
 
 compactor:
   compaction:
-    compacted_block_retention: 10m
+    compacted_block_retention: 168h
 
 storage:
   trace:


### PR DESCRIPTION
Summary:
- set explicit retention windows for traces, metrics, and logs
- add Loki config file and wire it into compose
- update docs to match the new retention defaults

Closes #207