### PR TITLE
Bug: Loki fails to start due to shared_store config (backend OTLP logs fail)

### DIFF
--- a/loki.yml
+++ b/loki.yml
@@ -27,7 +27,6 @@ schema_config:
 
 compactor:
   working_directory: /loki/compactor
-  shared_store: filesystem
   retention_enabled: true
 
 limits_config:


### PR DESCRIPTION
Summary:
- remove deprecated compactor.shared_store from loki.yml to match Loki 3.x config
- allow Loki container to start so backend OTLP log export can resolve loki service

Closes #264