### PR TITLE
Bug: Header navbar rubber-bands instead of staying fixed

### DIFF
--- a/frontend/src/components/Header.svelte
+++ b/frontend/src/components/Header.svelte
@@ -10,7 +10,7 @@
   }
 </script>
 
-<header class="bg-white border-b border-gray-200 sticky top-0 z-40">
+<header class="fixed top-0 left-0 right-0 z-40 bg-white border-b border-gray-200">
   <div class="flex items-center justify-between h-16 px-4">
     <div class="flex items-center gap-4">
       <button

--- a/frontend/src/components/Layout.svelte
+++ b/frontend/src/components/Layout.svelte
@@ -34,7 +34,7 @@
 <div class="min-h-screen bg-gray-50">
   <Header />
 
-  <div class="flex">
+  <div class="flex pt-16">
     <Sidebar />
 
     <main class="flex-1 lg:ml-64">


### PR DESCRIPTION
Summary:
- Make the header fixed so it stays pinned during scroll.
- Add top padding to the main layout so content clears the fixed header.

Closes #263