### PR TITLE
Bug: Postgres init logs warn about missing locales on Alpine

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -73,7 +73,7 @@ services:
       - clubhouse
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16
     container_name: clubhouse-postgres
     restart: unless-stopped
     environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 services:
   # Test PostgreSQL Database
   postgres-test:
-    image: postgres:16-alpine
+    image: postgres:16
     container_name: clubhouse-postgres-test
     environment:
       POSTGRES_USER: clubhouse_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16
     container_name: clubhouse-postgres
     environment:
       POSTGRES_USER: clubhouse


### PR DESCRIPTION
Summary:
- switch postgres image to Debian-based postgres:16 in dev, test, and prod compose files to avoid locale warnings

Closes #266