### PR TITLE
Bug: Grafana logs show xychart plugin already registered on startup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -147,6 +147,7 @@ services:
     image: grafana/grafana:11.2.0
     container_name: clubhouse-grafana
     restart: unless-stopped
+    entrypoint: ["/bin/sh", "/etc/grafana/entrypoint.sh"]
     environment:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
@@ -155,6 +156,7 @@ services:
       GF_PLUGINS_PREINSTALL: ${GF_PLUGINS_PREINSTALL:-}
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./grafana/entrypoint.sh:/etc/grafana/entrypoint.sh:ro
       - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
   grafana:
     image: grafana/grafana:11.2.0
     container_name: clubhouse-grafana
+    entrypoint: ["/bin/sh", "/etc/grafana/entrypoint.sh"]
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
@@ -96,6 +97,7 @@ services:
       - "3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./grafana/entrypoint.sh:/etc/grafana/entrypoint.sh:ro
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
     networks:

--- a/grafana/entrypoint.sh
+++ b/grafana/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Grafana 11+ bundles xychart; remove stale external plugin to avoid double registration.
+if [ -d /var/lib/grafana/plugins/xychart ]; then
+  rm -rf /var/lib/grafana/plugins/xychart
+fi
+
+exec /run.sh "$@"


### PR DESCRIPTION
Summary:
- remove stale xychart plugin from Grafana data on container start
- add Grafana entrypoint wrapper to avoid duplicate plugin registration logs

Closes #265