### PR TITLE
Bug: Auth form errors persist after correcting input

### DIFF
--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -29,6 +29,12 @@
     return (value as TotpChallengeResponse).mfa_required === true;
   };
 
+  function clearError() {
+    if (error) {
+      error = '';
+    }
+  }
+
   async function handleSubmit() {
     error = '';
     const trimmedUsername = username.trim();
@@ -120,6 +126,7 @@
               autocomplete="one-time-code"
               required
               bind:value={totpCode}
+              on:input={clearError}
               class="appearance-none rounded-md relative block w-full px-3 py-2 border border-indigo-200 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
               placeholder="6-digit authentication code"
             />
@@ -139,6 +146,7 @@
               autocomplete="username"
               required
               bind:value={username}
+              on:input={clearError}
               class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
               placeholder="Username"
             />
@@ -152,6 +160,7 @@
               autocomplete="current-password"
               required
               bind:value={password}
+              on:input={clearError}
               class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
               placeholder="Password"
             />

--- a/frontend/src/routes/Register.svelte
+++ b/frontend/src/routes/Register.svelte
@@ -8,6 +8,15 @@
   let success = '';
   let isLoading = false;
 
+  function clearMessages() {
+    if (error) {
+      error = '';
+    }
+    if (success) {
+      success = '';
+    }
+  }
+
   async function handleSubmit() {
     error = '';
     success = '';
@@ -99,6 +108,7 @@
             autocomplete="username"
             required
             bind:value={username}
+            on:input={clearMessages}
             class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
             placeholder="Username"
           />
@@ -111,6 +121,7 @@
             type="password"
             required
             bind:value={password}
+            on:input={clearMessages}
             aria-describedby="password-help"
             class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
             placeholder="Password"
@@ -127,6 +138,7 @@
             type="password"
             required
             bind:value={confirmPassword}
+            on:input={clearMessages}
             class="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
             placeholder="Confirm password"
           />

--- a/frontend/src/routes/__tests__/Login.test.ts
+++ b/frontend/src/routes/__tests__/Login.test.ts
@@ -69,6 +69,20 @@ describe('Login', () => {
     expect(apiPost).not.toHaveBeenCalled();
   });
 
+  it('clears validation errors when the user edits fields', async () => {
+    render(Login, { onNavigate: vi.fn() });
+
+    await fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(screen.getByText('Username and password are required')).toBeInTheDocument();
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'sander' },
+    });
+
+    expect(screen.queryByText('Username and password are required')).toBeNull();
+  });
+
   it('prompts for TOTP when MFA is required', async () => {
     const totpError = new Error('TOTP required') as Error & { code?: string };
     totpError.code = 'TOTP_REQUIRED';

--- a/frontend/src/routes/__tests__/Register.test.ts
+++ b/frontend/src/routes/__tests__/Register.test.ts
@@ -64,6 +64,29 @@ describe('Register', () => {
     expect(apiPost).not.toHaveBeenCalled();
   });
 
+  it('clears validation errors when the user edits fields', async () => {
+    render(Register, { onNavigate: vi.fn() });
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'newuser' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'short' },
+    });
+    await fireEvent.input(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'short' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(screen.getByText('Password must be at least 12 characters')).toBeInTheDocument();
+
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'longpassword12' },
+    });
+
+    expect(screen.queryByText('Password must be at least 12 characters')).toBeNull();
+  });
+
   it('shows a validation message when passwords do not match', async () => {
     render(Register, { onNavigate: vi.fn() });
 


### PR DESCRIPTION
Summary:
- Clear auth form error and success messages on field edits.
- Add tests to verify validation messages disappear on input.

Closes #268