### PR TITLE
Bug: No sections listed after fresh setup, leaving UI with no navigable content

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,10 +17,10 @@
 
   let unauthRoute: 'login' | 'register' | 'reset' = 'login';
   let resetToken: string | null = null;
+  let sectionsLoadedForSession = false;
 
   onMount(() => {
     authStore.checkSession();
-    sectionStore.loadSections();
     websocketStore.init();
     pwaStore.init();
     syncRouteFromLocation();
@@ -49,6 +49,16 @@
     if (typeof window !== 'undefined') {
       window.history.replaceState(null, '', '/');
     }
+  }
+
+  $: if ($isAuthenticated && !sectionsLoadedForSession) {
+    sectionsLoadedForSession = true;
+    sectionStore.loadSections();
+  }
+
+  $: if (!$isAuthenticated && sectionsLoadedForSession) {
+    sectionsLoadedForSession = false;
+    sectionStore.setSections([]);
   }
 </script>
 


### PR DESCRIPTION
Summary:
- load sections only after authentication completes
- clear section state on logout to avoid stale empty list

Closes #270