### PR TITLE
Bug: Moderation pending users view stuck 'Loading pending users...' with console error

### DIFF
--- a/frontend/src/components/admin/PendingUsers.svelte
+++ b/frontend/src/components/admin/PendingUsers.svelte
@@ -41,10 +41,11 @@
     }
 
     try {
-      pendingUsers = await api.get<PendingUser[]>(
+      const response = await api.get<PendingUser[] | null>(
         '/admin/users',
         controller ? { signal: controller.signal } : undefined
       );
+      pendingUsers = Array.isArray(response) ? response : [];
     } catch (error) {
       if (pendingUsersAbortController !== controller) {
         return;

--- a/frontend/src/components/admin/UserResetLinks.svelte
+++ b/frontend/src/components/admin/UserResetLinks.svelte
@@ -55,10 +55,11 @@
     }
 
     try {
-      users = await api.get<AdminUser[]>(
+      const response = await api.get<AdminUser[] | null>(
         '/admin/users/approved',
         controller ? { signal: controller.signal } : undefined
       );
+      users = Array.isArray(response) ? response : [];
     } catch (error) {
       if (usersAbortController !== controller) {
         return;

--- a/frontend/src/components/admin/__tests__/PendingUsers.test.ts
+++ b/frontend/src/components/admin/__tests__/PendingUsers.test.ts
@@ -156,4 +156,14 @@ describe('PendingUsers', () => {
 
     expect(await screen.findByText('Request timed out. Please try again.')).toBeInTheDocument();
   });
+
+  it('treats a null response as no pending users', async () => {
+    apiGet.mockResolvedValue(null);
+
+    render(PendingUsers);
+    await fireEvent.click(screen.getByText('Refresh'));
+    await flushPendingUsersLoad();
+
+    expect(await screen.findByText('All caught up. No pending approvals right now.')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
+++ b/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
@@ -91,4 +91,14 @@ describe('UserResetLinks', () => {
     expect(screen.getByText('Copy link')).toBeInTheDocument();
     expect(screen.getByText(/Single-use link/)).toBeInTheDocument();
   });
+
+  it('treats a null response as no approved users', async () => {
+    apiGet.mockResolvedValue(null);
+
+    render(UserResetLinks);
+    await fireEvent.click(screen.getByText('Refresh'));
+    await flushUsersLoad();
+
+    expect(await screen.findByText('No approved members yet.')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Summary:
- Handle null admin user list responses as empty arrays to prevent pending view crashes.
- Add component tests covering null responses for pending and approved users lists.

Closes #272