### PR TITLE
Enhancement: Replace link prompt with inline input

### DIFF
--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -172,6 +172,30 @@ describe('PostForm', () => {
     expect(screen.queryByText('Example')).not.toBeInTheDocument();
   });
 
+  it('adds a link via the inline input', async () => {
+    setAuthenticated();
+    setActiveSection();
+    previewLink.mockResolvedValue({
+      metadata: {
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    });
+
+    render(PostForm);
+
+    const addLinkButton = screen.getByLabelText('Add link');
+    await fireEvent.click(addLinkButton);
+
+    const linkInput = screen.getByLabelText('Link URL');
+    await fireEvent.input(linkInput, { target: { value: 'example.com' } });
+    await fireEvent.keyDown(linkInput, { key: 'Enter' });
+    await tick();
+
+    expect(previewLink).toHaveBeenCalledWith('https://example.com');
+    expect(screen.getByText('Example')).toBeInTheDocument();
+  });
+
   it('handles file attachments', async () => {
     setAuthenticated();
     setActiveSection();


### PR DESCRIPTION
Summary:
- replace the prompt-based link entry with an inline URL field and validation
- normalize missing schemes to https and trigger previews after submission
- add coverage for inline link entry in PostForm tests

Tests:
- npm run test -- --grep "PostForm" (fails: vitest not found in this environment)

Closes #261