### PR TITLE
Bug: Comment input label/placeholder duplicates 'Add a comment' text

### DIFF
--- a/frontend/src/components/comments/CommentForm.svelte
+++ b/frontend/src/components/comments/CommentForm.svelte
@@ -50,12 +50,12 @@
 </script>
 
 <form on:submit|preventDefault={handleSubmit} class="space-y-2">
-  <label class="sr-only" for="comment-content">Add a comment</label>
   <textarea
     id="comment-content"
     bind:value={content}
     on:keydown={handleKeyDown}
-    placeholder="Write a comment..."
+    aria-label="Add a comment"
+    placeholder="Add a comment..."
     rows="2"
     disabled={isSubmitting}
     class="w-full px-3 py-2 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:bg-gray-100"

--- a/frontend/src/components/comments/__tests__/CommentForm.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentForm.test.ts
@@ -47,7 +47,7 @@ describe('CommentForm', () => {
     createComment.mockResolvedValue({ comment: { id: 'comment-1' } });
 
     const { container } = render(CommentForm, { postId: 'post-1' });
-    const textarea = screen.getByPlaceholderText('Write a comment...');
+    const textarea = screen.getByLabelText('Add a comment');
 
     await fireEvent.input(textarea, { target: { value: 'Nice' } });
     const form = container.querySelector('form');
@@ -74,7 +74,7 @@ describe('CommentForm', () => {
     commentStore.markSeenComment('post-1', 'comment-1');
 
     const { container } = render(CommentForm, { postId: 'post-1' });
-    const textarea = screen.getByPlaceholderText('Write a comment...');
+    const textarea = screen.getByLabelText('Add a comment');
 
     await fireEvent.input(textarea, { target: { value: 'Nice' } });
     const form = container.querySelector('form');
@@ -88,7 +88,7 @@ describe('CommentForm', () => {
     createComment.mockRejectedValue(new Error('boom'));
 
     const { container } = render(CommentForm, { postId: 'post-1' });
-    const textarea = screen.getByPlaceholderText('Write a comment...');
+    const textarea = screen.getByLabelText('Add a comment');
     await fireEvent.input(textarea, { target: { value: 'Nice' } });
 
     const form = container.querySelector('form');


### PR DESCRIPTION
Summary:
- Replace the visible comment label with an aria-label and placeholder to avoid duplicated text.
- Update CommentForm tests to locate the textarea by its new accessible name.

Closes #277