### PR TITLE
Bug: Login for unapproved users shows invalid credentials instead of awaiting approval

### DIFF
--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -169,7 +169,15 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			writeError(r.Context(), w, http.StatusBadRequest, "USERNAME_REQUIRED", err.Error())
 		case "password is required":
 			writeError(r.Context(), w, http.StatusBadRequest, "PASSWORD_REQUIRED", err.Error())
-		case "invalid username or password", "user not approved":
+		case "user not approved":
+			h.logAuthEvent(r.Context(), &models.AuthEventCreate{
+				Identifier: req.Username,
+				EventType:  "login_pending_approval",
+				IPAddress:  clientIP,
+				UserAgent:  r.UserAgent(),
+			})
+			writeError(r.Context(), w, http.StatusForbidden, "USER_NOT_APPROVED", "Your account is awaiting admin approval.")
+		case "invalid username or password":
 			h.logAuthEvent(r.Context(), &models.AuthEventCreate{
 				Identifier: req.Username,
 				EventType:  "login_failure",

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -247,7 +247,7 @@ func (s *UserService) LoginUser(ctx context.Context, req *models.LoginRequest) (
 
 	// Check if user is approved
 	if user.ApprovedAt == nil {
-		return nil, fmt.Errorf("invalid username or password")
+		return nil, fmt.Errorf("user not approved")
 	}
 
 	return user, nil

--- a/frontend/src/routes/__tests__/Login.test.ts
+++ b/frontend/src/routes/__tests__/Login.test.ts
@@ -140,4 +140,25 @@ describe('Login', () => {
       })
     );
   });
+
+  it('shows approval pending message when user is not approved', async () => {
+    const approvalError = new Error('Your account is awaiting admin approval.') as Error & {
+      code?: string;
+    };
+    approvalError.code = 'USER_NOT_APPROVED';
+
+    apiPost.mockRejectedValueOnce(approvalError);
+
+    render(Login, { onNavigate: vi.fn() });
+
+    await fireEvent.input(screen.getByLabelText('Username'), {
+      target: { value: 'sander' },
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText('Your account is awaiting admin approval.')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Summary:
- return a dedicated USER_NOT_APPROVED response when login succeeds but approval is pending
- adjust login handler tests and frontend login test for the approval message

Closes #294