### PR TITLE
Bug: Password reset link routes to login instead of reset screen

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -45,7 +45,12 @@
   function syncRouteFromLocation() {
     if (typeof window === 'undefined') return;
     const path = window.location.pathname;
-    if (path === '/reset' || path.startsWith('/reset/')) {
+    if (
+      path === '/reset' ||
+      path.startsWith('/reset/') ||
+      path === '/reset-password' ||
+      path.startsWith('/reset-password/')
+    ) {
       unauthRoute = 'reset';
       const url = new URL(window.location.href);
       resetToken = url.searchParams.get('token');

--- a/frontend/src/components/admin/UserResetLinks.svelte
+++ b/frontend/src/components/admin/UserResetLinks.svelte
@@ -79,7 +79,7 @@
   };
 
   const buildResetLink = (token: string) => {
-    const path = '/reset-password';
+    const path = '/reset';
     if (typeof window === 'undefined') {
       return `${path}?token=${encodeURIComponent(token)}`;
     }


### PR DESCRIPTION
Summary:
- route admin-generated reset links to /reset
- allow /reset-password links to open reset flow for existing links

Closes #295