### PR TITLE
Bug: Admin MFA one-time code prompt appears as error state

### DIFF
--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -79,7 +79,7 @@
       if (errorWithCode.code === 'TOTP_REQUIRED') {
         needsTotp = true;
         authStore.setMfaChallenge({ username: trimmedUsername });
-        error = 'Authentication code is required';
+        error = '';
       } else {
         error = e instanceof Error ? e.message : 'Login failed';
       }

--- a/frontend/src/routes/__tests__/Login.test.ts
+++ b/frontend/src/routes/__tests__/Login.test.ts
@@ -117,6 +117,7 @@ describe('Login', () => {
     );
 
     expect(await screen.findByPlaceholderText('6-digit authentication code')).toBeInTheDocument();
+    expect(screen.queryByText('Authentication code is required')).toBeNull();
 
     await fireEvent.input(screen.getByPlaceholderText('6-digit authentication code'), {
       target: { value: '123456' },


### PR DESCRIPTION
Summary:
- show MFA code prompt without error styling on initial challenge
- keep error messaging for invalid or missing codes

Closes #296