### PR TITLE
Bug: Post creation rejects URL-only posts

### DIFF
--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -789,7 +789,7 @@ func validateCreatePostInput(req *models.CreatePostRequest) error {
 		return fmt.Errorf("section_id is required")
 	}
 
-	if strings.TrimSpace(req.Content) == "" {
+	if strings.TrimSpace(req.Content) == "" && len(req.Links) == 0 {
 		return fmt.Errorf("content is required")
 	}
 

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -74,6 +74,7 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 
 	// Create post ID
 	postID := uuid.New()
+	trimmedContent := strings.TrimSpace(req.Content)
 
 	linkMetadata := fetchLinkMetadata(ctx, req.Links)
 
@@ -94,7 +95,7 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 	`
 
 	var post models.Post
-	err = tx.QueryRowContext(ctx, query, postID, userID, sectionID, req.Content).
+	err = tx.QueryRowContext(ctx, query, postID, userID, sectionID, trimmedContent).
 		Scan(&post.ID, &post.UserID, &post.SectionID, &post.Content, &post.CreatedAt)
 
 	if err != nil {
@@ -789,11 +790,12 @@ func validateCreatePostInput(req *models.CreatePostRequest) error {
 		return fmt.Errorf("section_id is required")
 	}
 
-	if strings.TrimSpace(req.Content) == "" && len(req.Links) == 0 {
+	trimmedContent := strings.TrimSpace(req.Content)
+	if trimmedContent == "" && len(req.Links) == 0 {
 		return fmt.Errorf("content is required")
 	}
 
-	if len(req.Content) > 5000 {
+	if len(trimmedContent) > 5000 {
 		return fmt.Errorf("content must be less than 5000 characters")
 	}
 

--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -92,7 +92,7 @@ func TestCreatePostWithLinksNoContent(t *testing.T) {
 	service := NewPostService(db)
 	req := &models.CreatePostRequest{
 		SectionID: sectionID,
-		Content:   "",
+		Content:   "   ",
 		Links: []models.LinkRequest{
 			{URL: "https://example.com"},
 		},


### PR DESCRIPTION
Summary:
- allow URL-only posts by requiring content only when no links are provided
- add service tests for URL-only posts and empty content without links

Tests:
- go test ./internal/services -run TestCreatePost -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #297