### PR TITLE
Bug: Link previews missing after page reload

### DIFF
--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -54,4 +54,28 @@ describe('mapApiPost', () => {
     expect(post.user).toBeUndefined();
     expect(post.links).toBeUndefined();
   });
+
+  it('maps metadata even when url is missing', () => {
+    const post = mapApiPost({
+      id: 'post-3',
+      user_id: 'user-3',
+      section_id: 'section-3',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-2',
+          url: 'https://example.com',
+          metadata: {
+            provider: 'example',
+            title: 'Example',
+            description: 'Desc',
+          },
+        },
+      ],
+    });
+
+    expect(post.links?.[0].metadata?.url).toBe('https://example.com');
+    expect(post.links?.[0].metadata?.title).toBe('Example');
+  });
 });

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -41,22 +41,27 @@ export function mapApiPost(apiPost: ApiPost): Post {
     userId: apiPost.user_id,
     sectionId: apiPost.section_id,
     content: apiPost.content,
-    links: apiPost.links?.map((l): Link => ({
-      id: l.id,
-      url: l.url,
-      metadata: l.metadata?.url
-        ? {
-            url: l.metadata.url,
-            provider: l.metadata.provider,
-            title: l.metadata.title,
-            description: l.metadata.description,
-            image: l.metadata.image,
-            author: l.metadata.author,
-            duration: l.metadata.duration,
-            embedUrl: l.metadata.embedUrl,
-          }
-        : undefined,
-    })),
+    links: apiPost.links?.map((l): Link => {
+      const metadata = l.metadata;
+      const hasMetadata = metadata && Object.keys(metadata).length > 0;
+
+      return {
+        id: l.id,
+        url: l.url,
+        metadata: hasMetadata
+          ? {
+              url: metadata.url ?? l.url,
+              provider: metadata.provider,
+              title: metadata.title,
+              description: metadata.description,
+              image: metadata.image,
+              author: metadata.author,
+              duration: metadata.duration,
+              embedUrl: metadata.embedUrl,
+            }
+          : undefined,
+      };
+    }),
     user: apiPost.user
       ? {
           id: apiPost.user.id,


### PR DESCRIPTION
Summary:
- map link metadata even when the backend metadata payload lacks a url
- add coverage for link metadata without url

Tests:
- npm run test -- --grep "mapApiPost" (failed: vitest not found)

Closes #298