### PR TITLE
Bug: Nested comment replies increment comment count by 2

### DIFF
--- a/frontend/src/components/comments/ReplyForm.svelte
+++ b/frontend/src/components/comments/ReplyForm.svelte
@@ -30,8 +30,11 @@
         content: content.trim(),
       });
       const reply = mapApiComment(response.comment);
+      const skipIncrement = commentStore.consumeSeenComment(postId, reply.id);
       commentStore.addReply(postId, parentCommentId, reply);
-      postStore.incrementCommentCount(postId, 1);
+      if (!skipIncrement) {
+        postStore.incrementCommentCount(postId, 1);
+      }
       content = '';
       dispatch('submit', reply);
     } catch (err) {


### PR DESCRIPTION
Summary:
- prevent reply submissions from double-incrementing comment counts when websocket already counted
- add ReplyForm test for seen-comment skip behavior

Closes #300