### PR TITLE
Bug: Feed pagination/infinite scroll does not limit or load more posts

### DIFF
--- a/frontend/src/components/SectionFeed.svelte
+++ b/frontend/src/components/SectionFeed.svelte
@@ -25,7 +25,13 @@
       observer = new IntersectionObserver(
         (entries) => {
           const entry = entries[0];
-          if (entry?.isIntersecting && $hasMorePosts && !isLoadingMore && !$isLoadingPosts) {
+          if (
+            entry?.isIntersecting &&
+            $hasMorePosts &&
+            !isLoadingMore &&
+            !$isLoadingPosts &&
+            !$postsError
+          ) {
             handleLoadMore();
           }
         },
@@ -87,7 +93,7 @@
         <span>Loading posts...</span>
       </div>
     </div>
-  {:else if $postsError}
+  {:else if $postsError && $posts.length === 0}
     <div class="bg-red-50 border border-red-200 rounded-lg p-4 text-center">
       <p class="text-red-600">{$postsError}</p>
       <button
@@ -133,6 +139,15 @@
           </svg>
           <span class="text-sm">Loading more...</span>
         </div>
+      </div>
+    {/if}
+
+    {#if $postsError}
+      <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-700">
+        <p>Could not load more posts. {$postsError}</p>
+        <button on:click={handleLoadMore} class="mt-2 text-xs text-amber-800 underline hover:no-underline">
+          Try again
+        </button>
       </div>
     {/if}
 

--- a/frontend/src/components/SectionFeed.svelte
+++ b/frontend/src/components/SectionFeed.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { activeSection, posts, isLoadingPosts, postsError, hasMorePosts, postStore } from '../stores';
+  import {
+    activeSection,
+    posts,
+    isLoadingPosts,
+    postsError,
+    postsPaginationError,
+    hasMorePosts,
+    postStore,
+  } from '../stores';
   import { loadFeed, loadMorePosts } from '../stores/feedStore';
   import PostCard from './PostCard.svelte';
 
@@ -30,7 +38,7 @@
             $hasMorePosts &&
             !isLoadingMore &&
             !$isLoadingPosts &&
-            !$postsError
+            !$postsPaginationError
           ) {
             handleLoadMore();
           }
@@ -142,10 +150,13 @@
       </div>
     {/if}
 
-    {#if $postsError}
+    {#if $postsPaginationError}
       <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-700">
-        <p>Could not load more posts. {$postsError}</p>
-        <button on:click={handleLoadMore} class="mt-2 text-xs text-amber-800 underline hover:no-underline">
+        <p>Could not load more posts. {$postsPaginationError}</p>
+        <button
+          on:click={handleLoadMore}
+          class="mt-2 text-xs text-amber-800 underline hover:no-underline"
+        >
           Try again
         </button>
       </div>

--- a/frontend/src/components/__tests__/SectionFeed.test.ts
+++ b/frontend/src/components/__tests__/SectionFeed.test.ts
@@ -76,7 +76,7 @@ describe('SectionFeed', () => {
       'cursor-1',
       true
     );
-    postStore.setError('Rate limit exceeded');
+    postStore.setPaginationError('Rate limit exceeded');
     await tick();
 
     expect(screen.getByText(/Could not load more posts/i)).toBeInTheDocument();

--- a/frontend/src/components/__tests__/SectionFeed.test.ts
+++ b/frontend/src/components/__tests__/SectionFeed.test.ts
@@ -65,6 +65,27 @@ describe('SectionFeed', () => {
     expect(loadMorePosts).toHaveBeenCalled();
   });
 
+  it('shows pagination error and allows retry when posts exist', async () => {
+    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    render(SectionFeed);
+
+    postStore.setPosts(
+      [
+        { id: 'post-1', userId: 'user-1', sectionId: 'section-1', content: 'hello', createdAt: 'now' },
+      ],
+      'cursor-1',
+      true
+    );
+    postStore.setError('Rate limit exceeded');
+    await tick();
+
+    expect(screen.getByText(/Could not load more posts/i)).toBeInTheDocument();
+    const button = screen.getByText('Try again');
+    await fireEvent.click(button);
+
+    expect(loadMorePosts).toHaveBeenCalled();
+  });
+
   it('cleanup resets posts on destroy', () => {
     const resetSpy = vi.spyOn(postStore, 'reset');
     sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });

--- a/frontend/src/stores/__tests__/feedStore.test.ts
+++ b/frontend/src/stores/__tests__/feedStore.test.ts
@@ -52,6 +52,21 @@ describe('feedStore', () => {
     expect(state.isLoading).toBe(false);
   });
 
+  it('loadFeed reads meta cursor when present', async () => {
+    mapApiPost.mockImplementation((post: { id: string }) => mapPost(post.id));
+    apiGet.mockResolvedValue({
+      data: { posts: [{ id: 'post-1' }] },
+      meta: { cursor: 'cursor-2', has_more: true },
+    });
+
+    await loadFeed('section-1');
+    const state = get(postStore);
+
+    expect(state.posts).toHaveLength(1);
+    expect(state.cursor).toBe('cursor-2');
+    expect(state.hasMore).toBe(true);
+  });
+
   it('loadFeed failure sets error and stops loading', async () => {
     apiGet.mockRejectedValue(new Error('fail'));
 
@@ -90,7 +105,7 @@ describe('feedStore', () => {
     expect(state.cursor).toBe(null);
   });
 
-  it('loadMorePosts failure sets error', async () => {
+  it('loadMorePosts failure sets pagination error', async () => {
     sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
     postStore.setPosts([mapPost('post-0')], 'cursor-1', true);
 
@@ -98,7 +113,7 @@ describe('feedStore', () => {
 
     await loadMorePosts();
     const state = get(postStore);
-    expect(state.error).toBe('boom');
+    expect(state.paginationError).toBe('boom');
     expect(state.isLoading).toBe(false);
   });
 });

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -29,6 +29,15 @@ describe('postStore', () => {
     expect(state.error).toBeNull();
   });
 
+  it('setLoading clears error when starting a request', () => {
+    postStore.setError('boom');
+    postStore.setLoading(true);
+
+    const state = get(postStore);
+    expect(state.isLoading).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
   it('addPost prepends', () => {
     postStore.setPosts([basePost], null, true);
     postStore.addPost({ ...basePost, id: 'post-2' });

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -27,6 +27,7 @@ describe('postStore', () => {
     expect(state.hasMore).toBe(false);
     expect(state.isLoading).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.paginationError).toBeNull();
   });
 
   it('setLoading clears error when starting a request', () => {
@@ -36,6 +37,7 @@ describe('postStore', () => {
     const state = get(postStore);
     expect(state.isLoading).toBe(true);
     expect(state.error).toBeNull();
+    expect(state.paginationError).toBeNull();
   });
 
   it('addPost prepends', () => {
@@ -75,6 +77,7 @@ describe('postStore', () => {
     expect(state.cursor).toBe('cursor-2');
     expect(state.hasMore).toBe(false);
     expect(state.isLoading).toBe(false);
+    expect(state.paginationError).toBeNull();
   });
 
   it('removePost removes by id', () => {
@@ -116,5 +119,6 @@ describe('postStore', () => {
     expect(state.cursor).toBeNull();
     expect(state.hasMore).toBe(true);
     expect(state.error).toBeNull();
+    expect(state.paginationError).toBeNull();
   });
 });

--- a/frontend/src/stores/feedStore.ts
+++ b/frontend/src/stores/feedStore.ts
@@ -4,23 +4,51 @@ import { postStore } from './postStore';
 import { activeSection } from './sectionStore';
 import { mapApiPost, type ApiPost } from './postMapper';
 
+const FEED_PAGE_SIZE = 20;
+
 interface FeedResponse {
-  posts: ApiPost[];
-  has_more: boolean;
-  next_cursor?: string;
+  data?: {
+    posts?: ApiPost[];
+  };
+  posts?: ApiPost[];
+  has_more?: boolean;
+  next_cursor?: string | null;
+  meta?: {
+    cursor?: string | null;
+    has_more?: boolean;
+    hasMore?: boolean;
+    next_cursor?: string | null;
+    nextCursor?: string | null;
+  };
+}
+
+function extractFeedMeta(response: FeedResponse): { cursor: string | null; hasMore: boolean } {
+  const meta = response.meta ?? {};
+  const cursor =
+    response.next_cursor ??
+    meta.cursor ??
+    meta.next_cursor ??
+    meta.nextCursor ??
+    null;
+  const hasMore = response.has_more ?? meta.has_more ?? meta.hasMore ?? false;
+  return { cursor, hasMore };
+}
+
+function extractFeedPosts(response: FeedResponse): ApiPost[] {
+  return response.data?.posts ?? response.posts ?? [];
 }
 
 export async function loadFeed(sectionId: string): Promise<void> {
-  postStore.setLoading(true);
   postStore.reset();
+  postStore.setLoading(true);
+  postStore.setPaginationError(null);
 
   try {
-    const response = await api.get<FeedResponse>(
-      `/sections/${sectionId}/feed?limit=20`
-    );
+    const response = await api.get<FeedResponse>(`/sections/${sectionId}/feed?limit=${FEED_PAGE_SIZE}`);
 
-    const posts = (response.posts || []).map(mapApiPost);
-    postStore.setPosts(posts, response.next_cursor || null, response.has_more);
+    const posts = extractFeedPosts(response).map(mapApiPost);
+    const { cursor, hasMore } = extractFeedMeta(response);
+    postStore.setPosts(posts, cursor, hasMore);
   } catch (err) {
     postStore.setError(err instanceof Error ? err.message : 'Failed to load feed');
   }
@@ -35,15 +63,19 @@ export async function loadMorePosts(): Promise<void> {
   }
 
   postStore.setLoading(true);
+  postStore.setPaginationError(null);
 
   try {
     const response = await api.get<FeedResponse>(
-      `/sections/${section.id}/feed?limit=20&cursor=${state.cursor}`
+      `/sections/${section.id}/feed?limit=${FEED_PAGE_SIZE}&cursor=${state.cursor}`
     );
 
-    const posts = (response.posts || []).map(mapApiPost);
-    postStore.appendPosts(posts, response.next_cursor || null, response.has_more);
+    const posts = extractFeedPosts(response).map(mapApiPost);
+    const { cursor, hasMore } = extractFeedMeta(response);
+    postStore.appendPosts(posts, cursor, hasMore);
   } catch (err) {
-    postStore.setError(err instanceof Error ? err.message : 'Failed to load more posts');
+    postStore.setPaginationError(
+      err instanceof Error ? err.message : 'Failed to load more posts'
+    );
   }
 }

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -45,6 +45,7 @@ interface PostState {
   posts: Post[];
   isLoading: boolean;
   error: string | null;
+  paginationError: string | null;
   cursor: string | null;
   hasMore: boolean;
 }
@@ -54,6 +55,7 @@ function createPostStore() {
     posts: [],
     isLoading: false,
     error: null,
+    paginationError: null,
     cursor: null,
     hasMore: true,
   });
@@ -68,6 +70,7 @@ function createPostStore() {
         hasMore,
         isLoading: false,
         error: null,
+        paginationError: null,
       })),
     addPost: (post: Post) =>
       update((state) => {
@@ -110,6 +113,7 @@ function createPostStore() {
           hasMore,
           isLoading: false,
           error: null,
+          paginationError: null,
         };
       }),
     removePost: (postId: string) =>
@@ -181,13 +185,18 @@ function createPostStore() {
         ...state,
         isLoading,
         error: isLoading ? null : state.error,
+        paginationError: isLoading ? null : state.paginationError,
       })),
-    setError: (error: string | null) => update((state) => ({ ...state, error, isLoading: false })),
+    setError: (error: string | null) =>
+      update((state) => ({ ...state, error, isLoading: false, paginationError: null })),
+    setPaginationError: (error: string | null) =>
+      update((state) => ({ ...state, paginationError: error, isLoading: false })),
     reset: () =>
       set({
         posts: [],
         isLoading: false,
         error: null,
+        paginationError: null,
         cursor: null,
         hasMore: true,
       }),
@@ -199,4 +208,5 @@ export const postStore = createPostStore();
 export const posts = derived(postStore, ($postStore) => $postStore.posts);
 export const isLoadingPosts = derived(postStore, ($postStore) => $postStore.isLoading);
 export const postsError = derived(postStore, ($postStore) => $postStore.error);
+export const postsPaginationError = derived(postStore, ($postStore) => $postStore.paginationError);
 export const hasMorePosts = derived(postStore, ($postStore) => $postStore.hasMore);

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -109,6 +109,7 @@ function createPostStore() {
           cursor,
           hasMore,
           isLoading: false,
+          error: null,
         };
       }),
     removePost: (postId: string) =>
@@ -175,7 +176,12 @@ function createPostStore() {
           };
         }),
       })),
-    setLoading: (isLoading: boolean) => update((state) => ({ ...state, isLoading })),
+    setLoading: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoading,
+        error: isLoading ? null : state.error,
+      })),
     setError: (error: string | null) => update((state) => ({ ...state, error, isLoading: false })),
     reset: () =>
       set({


### PR DESCRIPTION
Summary:
- show pagination errors under the feed and allow retry
- pause auto-pagination when an error is present
- clear feed errors on new pagination requests

Tests:
- not run (vitest not available in environment)

Closes #308