### PR TITLE
Bug: Login for unapproved users shows invalid credentials instead of awaiting approval

### DIFF
--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -164,12 +164,12 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	user, err := h.userService.LoginUser(r.Context(), &req)
 	if err != nil {
 		// Determine appropriate error code and status
-		switch err.Error() {
-		case "username is required":
+		switch {
+		case errors.Is(err, services.ErrUsernameRequired):
 			writeError(r.Context(), w, http.StatusBadRequest, "USERNAME_REQUIRED", err.Error())
-		case "password is required":
+		case errors.Is(err, services.ErrPasswordRequired):
 			writeError(r.Context(), w, http.StatusBadRequest, "PASSWORD_REQUIRED", err.Error())
-		case "user not approved":
+		case errors.Is(err, services.ErrUserNotApproved):
 			h.logAuthEvent(r.Context(), &models.AuthEventCreate{
 				Identifier: req.Username,
 				EventType:  "login_pending_approval",
@@ -177,7 +177,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 				UserAgent:  r.UserAgent(),
 			})
 			writeError(r.Context(), w, http.StatusForbidden, "USER_NOT_APPROVED", "Your account is awaiting admin approval.")
-		case "invalid username or password":
+		case errors.Is(err, services.ErrInvalidCredentials):
 			h.logAuthEvent(r.Context(), &models.AuthEventCreate{
 				Identifier: req.Username,
 				EventType:  "login_failure",

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
 )
 
 type stubAuthRateLimiter struct {
@@ -76,7 +77,7 @@ func TestLoginRateLimited(t *testing.T) {
 
 func TestLoginGenericErrorForInvalidCredentials(t *testing.T) {
 	handler := &AuthHandler{
-		userService: &stubAuthUserService{loginErr: errors.New("invalid username or password")},
+		userService: &stubAuthUserService{loginErr: services.ErrInvalidCredentials},
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"username":"TestUser","password":"Password123"}`))
@@ -102,7 +103,7 @@ func TestLoginGenericErrorForInvalidCredentials(t *testing.T) {
 
 func TestLoginUnapprovedUser(t *testing.T) {
 	handler := &AuthHandler{
-		userService: &stubAuthUserService{loginErr: errors.New("user not approved")},
+		userService: &stubAuthUserService{loginErr: services.ErrUserNotApproved},
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"username":"TestUser","password":"Password123"}`))


### PR DESCRIPTION
Summary:
- use typed login errors so unapproved accounts map consistently to USER_NOT_APPROVED
- surface approval-pending message as a neutral info state in the login UI
- update auth handler tests to cover the new error matching

Closes #301