### PR TITLE
Bug: Duplicate error message when notifications permission denied

### DIFF
--- a/frontend/src/components/NotificationSettings.svelte
+++ b/frontend/src/components/NotificationSettings.svelte
@@ -9,6 +9,7 @@
 
   let isLoading = false;
   let error = '';
+  const permissionDeniedMessage = 'Notifications blocked. Enable notifications in your browser settings.';
 
   async function handleToggle() {
     isLoading = true;
@@ -26,7 +27,7 @@
           // Check if permission was denied
           const permission = get(pushPermission);
           if (permission === 'denied') {
-            error = 'Permission denied. Please enable notifications in your browser settings.';
+            error = permissionDeniedMessage;
           } else {
             error = 'Failed to enable notifications. Please try again.';
           }
@@ -103,13 +104,9 @@
       {/if}
     </button>
 
-    {#if error}
-      <p class="px-3 mt-1 text-xs text-red-600">{error}</p>
-    {/if}
-
-    {#if $pushPermission === 'denied'}
-      <p class="px-3 mt-1 text-xs text-gray-500">
-        To enable, allow notifications in your browser settings.
+    {#if error || $pushPermission === 'denied'}
+      <p class="px-3 mt-1 text-xs text-red-600">
+        {error || permissionDeniedMessage}
       </p>
     {/if}
   {/if}

--- a/frontend/src/components/__tests__/NotificationSettings.test.ts
+++ b/frontend/src/components/__tests__/NotificationSettings.test.ts
@@ -141,7 +141,9 @@ describe('NotificationSettings', () => {
       _setMockState({ pushPermission: 'denied' });
       render(NotificationSettings);
 
-      expect(screen.getByText('To enable, allow notifications in your browser settings.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Notifications blocked. Enable notifications in your browser settings.')
+      ).toBeInTheDocument();
     });
 
     it('should disable the button when permission is denied', () => {
@@ -184,6 +186,22 @@ describe('NotificationSettings', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Failed to disable notifications. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    it('should show a single denied message when permission is denied after subscribe attempt', async () => {
+      _setMockState({ isPushSubscribed: false, pushPermission: 'denied' });
+      (pwaStore.subscribeToPush as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+      render(NotificationSettings);
+
+      const button = screen.getByRole('button');
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        const messages = screen.getAllByText(
+          'Notifications blocked. Enable notifications in your browser settings.'
+        );
+        expect(messages).toHaveLength(1);
       });
     });
   });


### PR DESCRIPTION
Summary:
- show a single, consistent permission-denied message in NotificationSettings
- collapse denied helper text into the error line for consistent styling
- add coverage to ensure the denied message is not duplicated

Tests:
- npm run test -- --grep NotificationSettings (fails: vitest: command not found)