### PR TITLE
Bug: Link previews missing after page reload

### DIFF
--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -99,4 +99,37 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.url).toBe('https://example.com/photo.png');
     expect(post.links?.[0].metadata?.image).toBe('https://cdn.example.com/photo.png');
   });
+
+  it('normalizes snake_case metadata and JSON strings', () => {
+    const rawMetadata = JSON.stringify({
+      site_name: 'Example Site',
+      title: 'Example Title',
+      description: 'Example Description',
+      image_url: 'https://cdn.example.com/image.png',
+      embed_url: 'https://example.com/embed',
+      duration: '180',
+    });
+
+    const post = mapApiPost({
+      id: 'post-5',
+      user_id: 'user-5',
+      section_id: 'section-5',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-5',
+          url: 'https://example.com',
+          metadata: rawMetadata,
+        },
+      ],
+    });
+
+    expect(post.links?.[0].metadata?.provider).toBe('Example Site');
+    expect(post.links?.[0].metadata?.title).toBe('Example Title');
+    expect(post.links?.[0].metadata?.description).toBe('Example Description');
+    expect(post.links?.[0].metadata?.image).toBe('https://cdn.example.com/image.png');
+    expect(post.links?.[0].metadata?.embedUrl).toBe('https://example.com/embed');
+    expect(post.links?.[0].metadata?.duration).toBe(180);
+  });
 });

--- a/frontend/src/stores/commentMapper.ts
+++ b/frontend/src/stores/commentMapper.ts
@@ -1,5 +1,5 @@
 import type { Link } from './postStore';
-import type { ApiLink, ApiUser } from './postMapper';
+import { normalizeLinkMetadata, type ApiLink, type ApiUser } from './postMapper';
 import type { Comment } from './commentStore';
 
 export interface ApiComment {
@@ -27,18 +27,7 @@ export function mapApiComment(apiComment: ApiComment): Comment {
     links: apiComment.links?.map((link): Link => ({
       id: link.id,
       url: link.url,
-      metadata: link.metadata
-        ? {
-            url: link.metadata.url ?? link.url,
-            provider: link.metadata.provider,
-            title: link.metadata.title,
-            description: link.metadata.description,
-            image: link.metadata.image,
-            author: link.metadata.author,
-            duration: link.metadata.duration,
-            embedUrl: link.metadata.embedUrl,
-          }
-        : undefined,
+      metadata: normalizeLinkMetadata(link.metadata, link.url),
     })),
     user: apiComment.user
       ? {

--- a/frontend/src/stores/searchStore.ts
+++ b/frontend/src/stores/searchStore.ts
@@ -1,6 +1,7 @@
 import { writable, derived, get } from 'svelte/store';
 import { api } from '../services/api';
 import { activeSection } from './sectionStore';
+import { normalizeLinkMetadata } from './postMapper';
 import type { Post, Link } from './postStore';
 
 export type SearchScope = 'section' | 'global';
@@ -36,7 +37,7 @@ interface ApiUser {
 interface ApiLink {
   id?: string;
   url: string;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> | string | null;
 }
 
 interface ApiPost {
@@ -87,24 +88,10 @@ interface SearchState {
 }
 
 function mapApiLink(link: ApiLink): Link {
-  const metadata = link.metadata ?? {};
-  const hasMetadata = Object.keys(metadata).length > 0;
-
   return {
     id: link.id,
     url: link.url,
-    metadata: hasMetadata
-      ? {
-          url: (metadata.url as string) ?? link.url,
-          provider: metadata.provider as string | undefined,
-          title: metadata.title as string | undefined,
-          description: metadata.description as string | undefined,
-          image: metadata.image as string | undefined,
-          author: metadata.author as string | undefined,
-          duration: metadata.duration as number | undefined,
-          embedUrl: metadata.embedUrl as string | undefined,
-        }
-      : undefined,
+    metadata: normalizeLinkMetadata(link.metadata, link.url),
   };
 }
 


### PR DESCRIPTION
Summary:
- Normalize link metadata from API responses to handle snake_case keys and JSON strings.
- Use shared metadata mapping across posts, comments, and search results.
- Add coverage for snake_case metadata parsing in post mapper tests.

Closes #305