### PR TITLE
Bug: WebSocket section updates not delivered between clients

### DIFF
--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -194,23 +194,23 @@ func (h *WebSocketHandler) readLoop(ctx context.Context, wsConn *wsConnection) {
 		observability.RecordWebsocketMessageReceived(spanCtx, messageType)
 		switch msg.Type {
 		case wsSubscribe:
-			var data subscribePayload
-			if err := json.Unmarshal(msg.Data, &data); err != nil {
+			sectionIDs, err := parseSubscribePayload(msg)
+			if err != nil {
 				span.RecordError(err)
 				observability.RecordWebsocketError(spanCtx, "invalid_payload", messageType)
 				span.End()
 				continue
 			}
-			h.addSubscriptions(spanCtx, wsConn, data.SectionIDs, messageType)
+			h.addSubscriptions(spanCtx, wsConn, sectionIDs, messageType)
 		case wsUnsubscribe:
-			var data subscribePayload
-			if err := json.Unmarshal(msg.Data, &data); err != nil {
+			sectionIDs, err := parseSubscribePayload(msg)
+			if err != nil {
 				span.RecordError(err)
 				observability.RecordWebsocketError(spanCtx, "invalid_payload", messageType)
 				span.End()
 				continue
 			}
-			h.removeSubscriptions(spanCtx, wsConn, data.SectionIDs, messageType)
+			h.removeSubscriptions(spanCtx, wsConn, sectionIDs, messageType)
 		case wsPing:
 			// Ping messages are no-ops but still traced/metriced.
 		default:
@@ -472,16 +472,46 @@ func truncateString(value string, max int) string {
 }
 
 type wsMessage struct {
-	Type string          `json:"type"`
-	Data json.RawMessage `json:"data"`
+	Type            string          `json:"type"`
+	Data            json.RawMessage `json:"data"`
+	SectionIDs      []string        `json:"sectionIds"`
+	SectionIDsSnake []string        `json:"section_ids"`
 }
 
 type subscribePayload struct {
-	SectionIDs []string `json:"sectionIds"`
+	SectionIDs      []string `json:"sectionIds"`
+	SectionIDsSnake []string `json:"section_ids"`
+}
+
+func parseSubscribePayload(msg wsMessage) ([]string, error) {
+	if len(msg.Data) == 0 {
+		return mergeSectionIDs(msg.SectionIDs, msg.SectionIDsSnake), nil
+	}
+
+	var data subscribePayload
+	if err := json.Unmarshal(msg.Data, &data); err != nil {
+		return nil, err
+	}
+
+	return mergeSectionIDs(data.SectionIDs, data.SectionIDsSnake), nil
 }
 
 func formatChannel(format string, id any) string {
 	return fmt.Sprintf(format, id)
+}
+
+func mergeSectionIDs(primary, secondary []string) []string {
+	if len(primary) == 0 {
+		return secondary
+	}
+	if len(secondary) == 0 {
+		return primary
+	}
+
+	combined := make([]string, 0, len(primary)+len(secondary))
+	combined = append(combined, primary...)
+	combined = append(combined, secondary...)
+	return combined
 }
 
 func sectionChannels(sectionIDs []string) []string {

--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -510,16 +510,37 @@ func formatChannel(format string, id any) string {
 
 func mergeSectionIDs(primary, secondary []string) []string {
 	if len(primary) == 0 {
-		return secondary
+		return uniqueSectionIDs(secondary)
 	}
 	if len(secondary) == 0 {
-		return primary
+		return uniqueSectionIDs(primary)
 	}
 
 	combined := make([]string, 0, len(primary)+len(secondary))
 	combined = append(combined, primary...)
 	combined = append(combined, secondary...)
-	return combined
+	return uniqueSectionIDs(combined)
+}
+
+func uniqueSectionIDs(sectionIDs []string) []string {
+	if len(sectionIDs) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(sectionIDs))
+	unique := make([]string, 0, len(sectionIDs))
+	for _, id := range sectionIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
 }
 
 func sectionChannels(sectionIDs []string) []string {

--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -493,7 +493,15 @@ func parseSubscribePayload(msg wsMessage) ([]string, error) {
 		return nil, err
 	}
 
-	return mergeSectionIDs(data.SectionIDs, data.SectionIDsSnake), nil
+	combined := mergeSectionIDs(data.SectionIDs, data.SectionIDsSnake)
+	topLevel := mergeSectionIDs(msg.SectionIDs, msg.SectionIDsSnake)
+	if len(combined) == 0 {
+		return topLevel, nil
+	}
+	if len(topLevel) == 0 {
+		return combined, nil
+	}
+	return mergeSectionIDs(combined, topLevel), nil
 }
 
 func formatChannel(format string, id any) string {

--- a/backend/internal/handlers/websocket_test.go
+++ b/backend/internal/handlers/websocket_test.go
@@ -168,6 +168,66 @@ func TestWebSocketSubscribeDispatchAndUnsubscribe(t *testing.T) {
 	}
 }
 
+func TestWebSocketSubscribeDispatchSnakeCase(t *testing.T) {
+	redisClient := testutil.GetTestRedis(t)
+	t.Cleanup(func() {
+		testutil.CleanupRedis(t)
+		_ = redisClient.Close()
+	})
+
+	handler := NewWebSocketHandler(redisClient)
+	userID := uuid.New()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(createTestUserContext(r.Context(), userID, "wsuser", false))
+		handler.HandleWS(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	origin := server.URL
+	t.Setenv("WS_ORIGIN_ALLOWLIST", origin)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Origin": []string{origin}})
+	if err != nil {
+		t.Fatalf("failed to dial websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	sectionID := "section-456"
+	subscribe := mustMarshal(t, wsMessage{
+		Type: wsSubscribe,
+		Data: mustMarshal(t, map[string][]string{"section_ids": {sectionID}}),
+	})
+	if err := conn.WriteMessage(websocket.TextMessage, subscribe); err != nil {
+		t.Fatalf("failed to send subscribe: %v", err)
+	}
+	waitForSubscription(t, redisClient, formatChannel(sectionPrefix, sectionID), 1)
+
+	event := wsEvent{
+		Type:      "comment_added",
+		Data:      map[string]string{"id": "comment-1"},
+		Timestamp: time.Now().UTC(),
+	}
+	eventBytes := mustMarshal(t, event)
+	if err := redisClient.Publish(context.Background(), formatChannel(sectionPrefix, sectionID), eventBytes).Err(); err != nil {
+		t.Fatalf("failed to publish event: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("failed to read message: %v", err)
+	}
+
+	var got wsEvent
+	if err := json.Unmarshal(msg, &got); err != nil {
+		t.Fatalf("failed to unmarshal event: %v", err)
+	}
+	if got.Type != event.Type {
+		t.Fatalf("expected event type %q, got %q", event.Type, got.Type)
+	}
+}
+
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 	bytes, err := json.Marshal(v)


### PR DESCRIPTION
Summary:
- accept snake_case or top-level section IDs in websocket subscribe/unsubscribe messages
- add coverage for snake_case subscribe payloads

Closes #312