### PR TITLE
Bug: Navigation does not update URL, causing refresh to reset view

### DIFF
--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import { sections, activeSection, sectionStore, uiStore, isAdmin, activeView, isAuthenticated } from '../stores';
+  import { buildAdminHref, buildSectionHref, pushPath } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
   import NotificationSettings from './NotificationSettings.svelte';
 
   function handleSectionClick(section: Section) {
     sectionStore.setActiveSection(section);
     uiStore.setActiveView('feed');
+    pushPath(buildSectionHref(section.id));
   }
 
   function handleAdminClick() {
     uiStore.setActiveView('admin');
+    pushPath(buildAdminHref());
   }
 </script>
 

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
 describe('Nav', () => {
   it('clicking section sets active section', async () => {
     const setActiveSpy = vi.spyOn(sectionStore, 'setActiveSection');
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
     render(Nav);
 
     const button = screen.getByText('Books');
@@ -22,5 +23,6 @@ describe('Nav', () => {
     expect(setActiveSpy).toHaveBeenCalled();
     const call = setActiveSpy.mock.calls[0]?.[0];
     expect(call?.id).toBe('section-2');
+    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/sections/section-2');
   });
 });

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAdminHref,
+  buildFeedHref,
+  buildSectionHref,
+  isAdminPath,
+  parseSectionId,
+} from '../routeNavigation';
+
+describe('routeNavigation', () => {
+  it('builds section hrefs', () => {
+    expect(buildSectionHref('section-1')).toBe('/sections/section-1');
+  });
+
+  it('parses section ids from section paths', () => {
+    expect(parseSectionId('/sections/section-1')).toBe('section-1');
+    expect(parseSectionId('/sections/section-1/extra')).toBe('section-1');
+    expect(parseSectionId('/sections/')).toBeNull();
+    expect(parseSectionId('/admin')).toBeNull();
+  });
+
+  it('builds admin hrefs and recognizes admin paths', () => {
+    expect(buildAdminHref()).toBe('/admin');
+    expect(isAdminPath('/admin')).toBe(true);
+    expect(isAdminPath('/admin/tools')).toBe(true);
+    expect(isAdminPath('/sections/section-1')).toBe(false);
+  });
+
+  it('builds feed hrefs from section ids', () => {
+    expect(buildFeedHref('section-1')).toBe('/sections/section-1');
+    expect(buildFeedHref(null)).toBe('/');
+    expect(buildFeedHref(undefined)).toBe('/');
+  });
+});

--- a/frontend/src/services/profileNavigation.ts
+++ b/frontend/src/services/profileNavigation.ts
@@ -1,4 +1,7 @@
+import { get } from 'svelte/store';
+import { activeSection } from '../stores/sectionStore';
 import { uiStore } from '../stores/uiStore';
+import { buildFeedHref, pushPath } from './routeNavigation';
 
 const PROFILE_PATH_PREFIX = '/users/';
 
@@ -9,16 +12,13 @@ export function buildProfileHref(userId: string): string {
 export function openUserProfile(userId: string): void {
   if (!userId) return;
   uiStore.openProfile(userId);
-  if (typeof window !== 'undefined') {
-    window.history.pushState(null, '', buildProfileHref(userId));
-  }
+  pushPath(buildProfileHref(userId));
 }
 
 export function returnToFeed(): void {
   uiStore.setActiveView('feed');
-  if (typeof window !== 'undefined') {
-    window.history.pushState(null, '', '/');
-  }
+  const sectionId = get(activeSection)?.id ?? null;
+  pushPath(buildFeedHref(sectionId));
 }
 
 export function handleProfileNavigation(event: MouseEvent, userId?: string | null): void {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -1,0 +1,36 @@
+const SECTION_PATH_PREFIX = '/sections/';
+const ADMIN_PATH = '/admin';
+
+export function buildSectionHref(sectionId: string): string {
+  return `${SECTION_PATH_PREFIX}${sectionId}`;
+}
+
+export function parseSectionId(pathname: string): string | null {
+  if (!pathname.startsWith(SECTION_PATH_PREFIX)) {
+    return null;
+  }
+  const id = pathname.slice(SECTION_PATH_PREFIX.length).split('/')[0]?.trim();
+  return id ? id : null;
+}
+
+export function buildAdminHref(): string {
+  return ADMIN_PATH;
+}
+
+export function isAdminPath(pathname: string): boolean {
+  return pathname === ADMIN_PATH || pathname.startsWith(`${ADMIN_PATH}/`);
+}
+
+export function buildFeedHref(sectionId?: string | null): string {
+  return sectionId ? buildSectionHref(sectionId) : '/';
+}
+
+export function pushPath(path: string): void {
+  if (typeof window === 'undefined') return;
+  window.history.pushState(null, '', path);
+}
+
+export function replacePath(path: string): void {
+  if (typeof window === 'undefined') return;
+  window.history.replaceState(null, '', path);
+}

--- a/frontend/src/stores/sectionStore.ts
+++ b/frontend/src/stores/sectionStore.ts
@@ -81,7 +81,7 @@ function createSectionStore() {
     setActiveSection: (section: Section | null) =>
       update((state) => ({ ...state, activeSection: section })),
     setLoading: (isLoading: boolean) => update((state) => ({ ...state, isLoading })),
-    loadSections: async () => {
+    loadSections: async (preferredSectionId?: string | null) => {
       update((state) => ({ ...state, isLoading: true }));
       try {
         const response = await api.get<{ sections: ApiSection[] }>('/sections');
@@ -91,10 +91,14 @@ function createSectionStore() {
           type: section.type,
           icon: sectionIcons[section.type] || '📁',
         }));
+        const preferred =
+          preferredSectionId && sections.length > 0
+            ? sections.find((section) => section.id === preferredSectionId) ?? null
+            : null;
         update((state) => ({
           ...state,
           sections,
-          activeSection: sections[0] ?? null,
+          activeSection: preferred ?? sections[0] ?? null,
           isLoading: false,
         }));
       } catch {


### PR DESCRIPTION
Summary:
- Sync section/admin navigation with URL updates
- Restore view state from URL on refresh and popstate
- Add route parsing tests

Closes #317