### PR TITLE
Enhancement: Add reaction tooltips listing reacting users

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -566,6 +566,20 @@ Auth: Required
 Response: {}
 ```
 
+**List Reactions for Post**
+```
+GET /posts/{postId}/reactions
+Auth: Required
+Response: { reactions: [ { emoji, users: [ { id, username, profilePictureUrl } ] } ] }
+```
+
+**List Reactions for Comment**
+```
+GET /comments/{commentId}/reactions
+Auth: Required
+Response: { reactions: [ { emoji, users: [ { id, username, profilePictureUrl } ] } ] }
+```
+
 #### Search
 
 **Global Search**

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -207,6 +207,10 @@ func main() {
 			// POST /api/v1/comments/{id}/reactions
 			reactionAuthHandler := requireAuthCSRF(http.HandlerFunc(reactionHandler.AddReactionToComment))
 			reactionAuthHandler.ServeHTTP(w, r)
+		} else if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/reactions") {
+			// GET /api/v1/comments/{id}/reactions
+			reactionAuthHandler := requireAuth(http.HandlerFunc(reactionHandler.GetCommentReactions))
+			reactionAuthHandler.ServeHTTP(w, r)
 		} else if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {
 			// DELETE /api/v1/comments/{id}/reactions/{emoji}
 			reactionAuthHandler := requireAuthCSRF(http.HandlerFunc(reactionHandler.RemoveReactionFromComment))
@@ -228,6 +232,7 @@ func main() {
 		restorePost:            postHandler.RestorePost,
 		addReactionToPost:      reactionHandler.AddReactionToPost,
 		removeReactionFromPost: reactionHandler.RemoveReactionFromPost,
+		getReactions:           reactionHandler.GetPostReactions,
 		getPost:                postHandler.GetPost,
 		deletePost:             postHandler.DeletePost,
 	})

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -14,6 +14,7 @@ type postRouteDeps struct {
 	restorePost            http.HandlerFunc
 	addReactionToPost      http.HandlerFunc
 	removeReactionFromPost http.HandlerFunc
+	getReactions           http.HandlerFunc
 	getPost                http.HandlerFunc
 	deletePost             http.HandlerFunc
 }
@@ -38,6 +39,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {
 			// DELETE /api/v1/posts/{id}/reactions/{emoji}
 			requireAuthCSRF(http.HandlerFunc(deps.removeReactionFromPost)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/reactions") {
+			// GET /api/v1/posts/{id}/reactions
+			requireAuth(http.HandlerFunc(deps.getReactions)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodDelete && isPostIDPath(r.URL.Path) {

--- a/backend/internal/handlers/reaction_list_test.go
+++ b/backend/internal/handlers/reaction_list_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestGetPostReactions(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "reactionlistuser1", "reactionlist1@test.com", false, true)
+	user2ID := testutil.CreateTestUser(t, db, "reactionlistuser2", "reactionlist2@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Reactions Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test post")
+
+	_, err := db.Exec(`
+		INSERT INTO reactions (id, user_id, post_id, emoji, created_at)
+		VALUES ($1, $2, $3, $4, now()), ($5, $6, $7, $8, now())
+	`,
+		uuid.New(), userID, postID, "👍",
+		uuid.New(), user2ID, postID, "👍",
+	)
+	if err != nil {
+		t.Fatalf("failed to create reactions: %v", err)
+	}
+
+	handler := NewReactionHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/reactions", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetPostReactions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.GetReactionsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Reactions) != 1 {
+		t.Fatalf("expected 1 reaction group, got %d", len(response.Reactions))
+	}
+
+	group := response.Reactions[0]
+	if group.Emoji != "👍" {
+		t.Fatalf("expected emoji 👍, got %s", group.Emoji)
+	}
+	if len(group.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(group.Users))
+	}
+}
+
+func TestGetCommentReactions(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "reactionlistuser3", "reactionlist3@test.com", false, true)
+	user2ID := testutil.CreateTestUser(t, db, "reactionlistuser4", "reactionlist4@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Reactions Section 2", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test post")
+	commentID := testutil.CreateTestComment(t, db, userID, postID, "Test comment")
+
+	_, err := db.Exec(`
+		INSERT INTO reactions (id, user_id, comment_id, emoji, created_at)
+		VALUES ($1, $2, $3, $4, now()), ($5, $6, $7, $8, now())
+	`,
+		uuid.New(), userID, commentID, "🔥",
+		uuid.New(), user2ID, commentID, "🔥",
+	)
+	if err != nil {
+		t.Fatalf("failed to create reactions: %v", err)
+	}
+
+	handler := NewReactionHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/comments/"+commentID+"/reactions", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetCommentReactions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.GetReactionsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Reactions) != 1 {
+		t.Fatalf("expected 1 reaction group, got %d", len(response.Reactions))
+	}
+
+	group := response.Reactions[0]
+	if group.Emoji != "🔥" {
+		t.Fatalf("expected emoji 🔥, got %s", group.Emoji)
+	}
+	if len(group.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(group.Users))
+	}
+}

--- a/backend/internal/models/reaction.go
+++ b/backend/internal/models/reaction.go
@@ -17,6 +17,24 @@ type Reaction struct {
 	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
+// ReactionUser represents a minimal user payload for reaction tooltips.
+type ReactionUser struct {
+	ID                uuid.UUID `json:"id"`
+	Username          string    `json:"username"`
+	ProfilePictureUrl *string   `json:"profile_picture_url,omitempty"`
+}
+
+// ReactionGroup represents users grouped by emoji.
+type ReactionGroup struct {
+	Emoji string         `json:"emoji"`
+	Users []ReactionUser `json:"users"`
+}
+
+// GetReactionsResponse represents the response for listing reactions on a post or comment.
+type GetReactionsResponse struct {
+	Reactions []ReactionGroup `json:"reactions"`
+}
+
 // CreateReactionRequest represents the request body for creating a reaction
 type CreateReactionRequest struct {
 	Emoji string `json:"emoji"`

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -202,6 +202,7 @@
           reactionCounts={post.reactionCounts ?? {}}
           userReactions={userReactions}
           onToggle={toggleReaction}
+          postId={post.id}
         />
       </div>
 

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -582,6 +582,7 @@
                         reactionCounts={comment.reactionCounts ?? {}}
                         userReactions={new Set(comment.viewerReactions ?? [])}
                         onToggle={(emoji) => toggleCommentReaction(comment, emoji)}
+                        commentId={comment.id}
                       />
                     </div>
                   </div>

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -322,6 +322,7 @@
                   reactionCounts={comment.reactionCounts ?? {}}
                   userReactions={getUserReactions(comment)}
                   onToggle={(emoji) => toggleCommentReaction(comment.id, emoji)}
+                  commentId={comment.id}
                 />
               </div>
 
@@ -417,6 +418,7 @@
                             reactionCounts={reply.reactionCounts ?? {}}
                             userReactions={getUserReactions(reply)}
                             onToggle={(emoji) => toggleCommentReaction(reply.id, emoji)}
+                            commentId={reply.id}
                           />
                         </div>
                       </div>

--- a/frontend/src/components/reactions/ReactionBar.svelte
+++ b/frontend/src/components/reactions/ReactionBar.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
   import EmojiPicker from './EmojiPicker.svelte';
+  import { api } from '../../services/api';
+  import type { ApiReactionGroup, ApiReactionUser } from '../../services/api';
 
   export let reactionCounts: Record<string, number> = {};
   export let userReactions: Set<string> = new Set();
   export let onToggle: (emoji: string) => Promise<void> | void;
+  export let postId: string | null = null;
+  export let commentId: string | null = null;
 
   let showPicker = false;
   let pendingEmoji: string | null = null;
+  let showTooltip = false;
+  let tooltipLoading = false;
+  let tooltipError: string | null = null;
+  let tooltipReactions: ApiReactionGroup[] = [];
+  let lastCountsKey = '';
+  let tooltipTimeout: ReturnType<typeof setTimeout> | null = null;
 
   $: orderedReactions = Object.entries(reactionCounts).sort((a, b) => b[1] - a[1]);
+  $: countsKey = orderedReactions
+    .map(([emoji, count]) => `${emoji}:${count}`)
+    .join('|');
+  $: tooltipReady = !!postId || !!commentId;
 
   async function handleToggle(emoji: string) {
     if (pendingEmoji) return;
@@ -19,25 +33,134 @@
       pendingEmoji = null;
     }
   }
+
+  function hideTooltip() {
+    showTooltip = false;
+    tooltipTimeout && clearTimeout(tooltipTimeout);
+    tooltipTimeout = null;
+  }
+
+  function normalizeUsers(users: ApiReactionUser[]): ApiReactionUser[] {
+    const seen = new Set<string>();
+    const unique: ApiReactionUser[] = [];
+    for (const user of users) {
+      if (!seen.has(user.id)) {
+        seen.add(user.id);
+        unique.push(user);
+      }
+    }
+    return unique;
+  }
+
+  function normalizeGroups(groups: ApiReactionGroup[]): ApiReactionGroup[] {
+    return groups
+      .map((group) => ({
+        emoji: group.emoji,
+        users: normalizeUsers(group.users ?? []),
+      }))
+      .filter((group) => group.users.length > 0);
+  }
+
+  async function loadTooltipData(force = false) {
+    if (!tooltipReady) return;
+    if (!force && tooltipReactions.length > 0 && countsKey === lastCountsKey) return;
+    tooltipLoading = true;
+    tooltipError = null;
+    try {
+      const response = postId
+        ? await api.getPostReactions(postId)
+        : await api.getCommentReactions(commentId ?? '');
+      tooltipReactions = normalizeGroups(response.reactions ?? []);
+      lastCountsKey = countsKey;
+    } catch (error) {
+      tooltipError =
+        error instanceof Error ? error.message : 'Failed to load reactions';
+    } finally {
+      tooltipLoading = false;
+    }
+  }
+
+  function showTooltipWithDelay() {
+    if (!tooltipReady || orderedReactions.length === 0) return;
+    if (tooltipTimeout) {
+      clearTimeout(tooltipTimeout);
+    }
+    tooltipTimeout = setTimeout(async () => {
+      showTooltip = true;
+      await loadTooltipData();
+    }, 150);
+  }
 </script>
 
 <div class="flex flex-wrap items-center gap-2">
-  {#each orderedReactions as [emoji, count]}
-    <button
-      type="button"
-      disabled={pendingEmoji !== null}
-      class={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition ${
-        userReactions.has(emoji)
-          ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-          : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'
-      } ${pendingEmoji === emoji ? 'opacity-50 cursor-wait' : ''}`}
-      on:click={() => handleToggle(emoji)}
-      aria-label={`React with ${emoji}`}
-    >
-      <span>{emoji}</span>
-      <span>{count}</span>
-    </button>
-  {/each}
+  <div
+    class="relative"
+    role="group"
+    on:mouseenter={showTooltipWithDelay}
+    on:mouseleave={hideTooltip}
+    on:focusin={showTooltipWithDelay}
+    on:focusout={hideTooltip}
+  >
+    <div class="flex flex-wrap items-center gap-2">
+      {#each orderedReactions as [emoji, count]}
+        <button
+          type="button"
+          disabled={pendingEmoji !== null}
+          class={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition ${
+            userReactions.has(emoji)
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'
+          } ${pendingEmoji === emoji ? 'opacity-50 cursor-wait' : ''}`}
+          on:click={() => handleToggle(emoji)}
+          aria-label={`React with ${emoji}`}
+        >
+          <span>{emoji}</span>
+          <span>{count}</span>
+        </button>
+      {/each}
+    </div>
+
+    {#if showTooltip && tooltipReady && orderedReactions.length > 0}
+      <div
+        class="absolute left-0 top-full z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 text-xs shadow-lg"
+        role="tooltip"
+      >
+        {#if tooltipLoading}
+          <p class="text-gray-500">Loading reactions...</p>
+        {:else if tooltipError}
+          <p class="text-red-500">{tooltipError}</p>
+        {:else if tooltipReactions.length === 0}
+          <p class="text-gray-500">No reactions yet.</p>
+        {:else}
+          <div class="space-y-2">
+            {#each tooltipReactions as reaction}
+              <div>
+                <div class="font-medium text-gray-700">{reaction.emoji}</div>
+                <div class="mt-1 flex flex-wrap gap-2">
+                  {#each reaction.users as user}
+                    <div class="flex items-center gap-2">
+                      {#if user.profile_picture_url}
+                        <img
+                          src={user.profile_picture_url}
+                          alt={user.username}
+                          class="h-5 w-5 rounded-full object-cover"
+                        />
+                      {:else}
+                        <div class="h-5 w-5 rounded-full bg-gray-200 flex items-center justify-center text-[10px] text-gray-500">
+                          {user.username?.charAt(0).toUpperCase() || '?'}
+                        </div>
+                      {/if}
+                      <span class="text-gray-600">{user.username}</span>
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
 
   <div class="relative">
     <button

--- a/frontend/src/components/reactions/__tests__/ReactionBar.test.ts
+++ b/frontend/src/components/reactions/__tests__/ReactionBar.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, screen, cleanup } from '@testing-library/svelte';
 
+vi.mock('../../../services/api', () => ({
+  api: {
+    getPostReactions: vi.fn().mockResolvedValue({
+      reactions: [
+        {
+          emoji: '👍',
+          users: [
+            { id: 'user-1', username: 'sander', profile_picture_url: null },
+          ],
+        },
+      ],
+    }),
+    getCommentReactions: vi.fn().mockResolvedValue({ reactions: [] }),
+  },
+}));
+
 const { default: ReactionBar } = await import('../ReactionBar.svelte');
 
 afterEach(() => {
@@ -37,5 +53,23 @@ describe('ReactionBar', () => {
     await fireEvent.click(emojiButton);
 
     expect(onToggle).toHaveBeenCalledWith('👍');
+  });
+
+  it('loads tooltip reactions on hover', async () => {
+    vi.useFakeTimers();
+    const onToggle = vi.fn();
+    render(ReactionBar, {
+      reactionCounts: { '👍': 1 },
+      userReactions: new Set<string>(),
+      onToggle,
+      postId: 'post-1',
+    });
+
+    const tooltipTarget = screen.getByRole('group');
+    await fireEvent.mouseEnter(tooltipTarget);
+    await vi.runAllTimersAsync();
+
+    expect(await screen.findByText('sander')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -392,6 +392,7 @@
                   reactionCounts={comment.reactionCounts ?? {}}
                   userReactions={new Set(comment.viewerReactions ?? [])}
                   onToggle={(emoji) => toggleCommentReaction(comment, emoji)}
+                  commentId={comment.id}
                 />
               </div>
             </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -26,6 +26,17 @@ interface ApiResponse<T> {
   };
 }
 
+export interface ApiReactionUser {
+  id: string;
+  username: string;
+  profile_picture_url?: string | null;
+}
+
+export interface ApiReactionGroup {
+  emoji: string;
+  users: ApiReactionUser[];
+}
+
 class ApiClient {
   private csrfToken: string | null = null;
   private csrfTokenPromise: Promise<string | null> | null = null;
@@ -230,12 +241,20 @@ class ApiClient {
     await this.post(`/posts/${postId}/reactions`, { emoji });
   }
 
+  async getPostReactions(postId: string): Promise<{ reactions: ApiReactionGroup[] }> {
+    return this.get(`/posts/${postId}/reactions`);
+  }
+
   async removePostReaction(postId: string, emoji: string): Promise<void> {
     await this.delete(`/posts/${postId}/reactions/${encodeURIComponent(emoji)}`);
   }
 
   async addCommentReaction(commentId: string, emoji: string): Promise<void> {
     await this.post(`/comments/${commentId}/reactions`, { emoji });
+  }
+
+  async getCommentReactions(commentId: string): Promise<{ reactions: ApiReactionGroup[] }> {
+    return this.get(`/comments/${commentId}/reactions`);
   }
 
   async removeCommentReaction(commentId: string, emoji: string): Promise<void> {


### PR DESCRIPTION
Closes #315 

Summary:
- add reaction list endpoints for posts/comments with grouped user payloads
- load reaction user lists on hover in ReactionBar and surface tooltips
- update reaction call sites and add backend/frontend tests

Tests:
- go test ./internal/handlers -run TestGetPostReactions -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- frontend-checks (svelte-check + vitest)