### PR TITLE
Bug: Previous section stays highlighted in sidebar when navigating to Moderation

### DIFF
--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -27,10 +27,10 @@
           <button
             on:click={() => handleSectionClick(section)}
             class="w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
-              {$activeSection?.id === section.id
+              {$activeView === 'feed' && $activeSection?.id === section.id
               ? 'bg-primary text-white'
               : 'text-gray-700 hover:bg-gray-100'}"
-            aria-current={$activeSection?.id === section.id ? 'page' : undefined}
+            aria-current={$activeView === 'feed' && $activeSection?.id === section.id ? 'page' : undefined}
           >
             <span class="text-lg" aria-hidden="true">{section.icon}</span>
             <span>{section.name}</span>


### PR DESCRIPTION
## Summary
- Only highlight section entries when the feed view is active.
- Prevent section highlight from persisting on admin/profile routes.

## Testing
- `npm run check` (fails locally: `svelte-check` not found)

Closes #347