### PR TITLE
Enhancement: Use section names instead of IDs in URL paths

### DIFF
--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -8,7 +8,7 @@
     sectionStore.setActiveSection(section);
     uiStore.setActiveView('feed');
     threadRouteStore.clearTarget();
-    pushPath(buildSectionHref(section.id));
+    pushPath(buildSectionHref(section.slug));
   }
 
   function handleAdminClick() {

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -9,16 +9,19 @@
   import { buildThreadHref } from '../services/routeNavigation';
   import LinkifiedText from './LinkifiedText.svelte';
   import { getImageLinkUrl } from '../services/linkUtils';
+  import { sections } from '../stores/sectionStore';
+  import { getSectionSlugById } from '../services/sectionSlug';
 
   export let post: Post;
 
   $: userReactions = new Set(post.viewerReactions ?? []);
+  $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
   let copiedLink = false;
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   async function copyThreadLink() {
     if (typeof window === 'undefined') return;
-    const url = new URL(buildThreadHref(post.sectionId, post.id), window.location.origin).toString();
+    const url = new URL(buildThreadHref(sectionSlug, post.id), window.location.origin).toString();
     let copied = false;
 
     if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -6,8 +6,8 @@ const { default: Nav } = await import('../Nav.svelte');
 
 beforeEach(() => {
   sectionStore.setSections([
-    { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
-    { id: 'section-2', name: 'Books', type: 'book', icon: '📚' },
+    { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+    { id: 'section-2', name: 'Books', type: 'book', icon: '📚', slug: 'books' },
   ]);
 });
 
@@ -23,6 +23,6 @@ describe('Nav', () => {
     expect(setActiveSpy).toHaveBeenCalled();
     const call = setActiveSpy.mock.calls[0]?.[0];
     expect(call?.id).toBe('section-2');
-    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/sections/section-2');
+    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/sections/books');
   });
 });

--- a/frontend/src/components/__tests__/SectionFeed.test.ts
+++ b/frontend/src/components/__tests__/SectionFeed.test.ts
@@ -27,14 +27,26 @@ afterEach(() => {
 
 describe('SectionFeed', () => {
   it('loads feed when active section changes', () => {
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     render(SectionFeed);
 
     expect(loadFeed).toHaveBeenCalledWith('section-1');
   });
 
   it('retry button calls loadFeed', async () => {
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     postStore.setError('boom');
 
     render(SectionFeed);
@@ -46,7 +58,13 @@ describe('SectionFeed', () => {
   });
 
   it('intersection observer triggers loadMorePosts', async () => {
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     render(SectionFeed);
 
     postStore.setPosts(
@@ -66,7 +84,13 @@ describe('SectionFeed', () => {
   });
 
   it('shows pagination error and allows retry when posts exist', async () => {
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     render(SectionFeed);
 
     postStore.setPosts(
@@ -88,7 +112,13 @@ describe('SectionFeed', () => {
 
   it('cleanup resets posts on destroy', () => {
     const resetSpy = vi.spyOn(postStore, 'reset');
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
 
     const { unmount } = render(SectionFeed);
     const observer = (globalThis as { __lastObserver?: { disconnect: () => void } }).__lastObserver;

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -31,6 +31,7 @@ function setActiveSection() {
     name: 'Music',
     type: 'music',
     icon: '🎵',
+    slug: 'music',
   });
 }
 

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -20,6 +20,7 @@
   import { api } from '../../services/api';
   import { buildProfileHref, handleProfileNavigation } from '../../services/profileNavigation';
   import { buildThreadHref, pushPath } from '../../services/routeNavigation';
+  import { getSectionSlug } from '../../services/sectionSlug';
   import type { Post } from '../../stores/postStore';
   import type { CommentResult, SearchResult } from '../../stores/searchStore';
 
@@ -101,10 +102,11 @@
     if (!post) return;
     const targetSection = $sections.find((section) => section.id === post.sectionId);
     const targetSectionId = targetSection?.id ?? post.sectionId;
+    const targetSectionSlug = targetSection ? getSectionSlug(targetSection) : post.sectionId;
     const switchingSection = targetSection && $activeSection?.id !== targetSection.id;
     uiStore.setActiveView('feed');
     threadRouteStore.setTarget(post.id, targetSectionId);
-    pushPath(buildThreadHref(targetSectionId, post.id));
+    pushPath(buildThreadHref(targetSectionSlug, post.id));
     if (switchingSection) {
       sectionStore.setActiveSection(targetSection);
     }

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -101,9 +101,9 @@ describe('SearchResults', () => {
     storeRefs.searchQuery.set('nice');
     storeRefs.lastSearchQuery.set('nice');
     storeRefs.sections.set([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
     ]);
-    storeRefs.activeSection.set({ id: 'section-1', name: 'Music' });
+    storeRefs.activeSection.set({ id: 'section-1', name: 'Music', slug: 'music' });
     storeRefs.searchResults.set([
       {
         type: 'comment',
@@ -132,9 +132,9 @@ describe('SearchResults', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');
     storeRefs.sections.set([
-      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬' },
+      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
     ]);
-    storeRefs.activeSection.set({ id: 'section-2', name: 'Movies' });
+    storeRefs.activeSection.set({ id: 'section-2', name: 'Movies', slug: 'movies' });
     storeRefs.searchResults.set([
       {
         type: 'post',
@@ -158,8 +158,8 @@ describe('SearchResults', () => {
     storeRefs.lastSearchQuery.set('mix');
     storeRefs.searchScope.set('global');
     storeRefs.sections.set([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
-      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬' },
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
     ]);
     storeRefs.searchResults.set([
       {

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -5,7 +5,7 @@ import {
   buildSectionHref,
   buildThreadHref,
   isAdminPath,
-  parseSectionId,
+  parseSectionSlug,
   parseThreadPostId,
 } from '../routeNavigation';
 
@@ -14,12 +14,12 @@ describe('routeNavigation', () => {
     expect(buildSectionHref('section-1')).toBe('/sections/section-1');
   });
 
-  it('parses section ids from section paths', () => {
-    expect(parseSectionId('/sections/section-1')).toBe('section-1');
-    expect(parseSectionId('/sections/section-1/extra')).toBe('section-1');
-    expect(parseSectionId('/sections/section-1/posts/post-1')).toBe('section-1');
-    expect(parseSectionId('/sections/')).toBeNull();
-    expect(parseSectionId('/admin')).toBeNull();
+  it('parses section slugs from section paths', () => {
+    expect(parseSectionSlug('/sections/music')).toBe('music');
+    expect(parseSectionSlug('/sections/music/extra')).toBe('music');
+    expect(parseSectionSlug('/sections/music/posts/post-1')).toBe('music');
+    expect(parseSectionSlug('/sections/')).toBeNull();
+    expect(parseSectionSlug('/admin')).toBeNull();
   });
 
   it('builds and parses thread hrefs', () => {
@@ -37,8 +37,8 @@ describe('routeNavigation', () => {
     expect(isAdminPath('/sections/section-1')).toBe(false);
   });
 
-  it('builds feed hrefs from section ids', () => {
-    expect(buildFeedHref('section-1')).toBe('/sections/section-1');
+  it('builds feed hrefs from section slugs', () => {
+    expect(buildFeedHref('music')).toBe('/sections/music');
     expect(buildFeedHref(null)).toBe('/');
     expect(buildFeedHref(undefined)).toBe('/');
   });

--- a/frontend/src/services/profileNavigation.ts
+++ b/frontend/src/services/profileNavigation.ts
@@ -3,6 +3,7 @@ import { activeSection } from '../stores/sectionStore';
 import { uiStore } from '../stores/uiStore';
 import { threadRouteStore } from '../stores/threadRouteStore';
 import { buildFeedHref, pushPath } from './routeNavigation';
+import { getSectionSlug } from './sectionSlug';
 
 const PROFILE_PATH_PREFIX = '/users/';
 
@@ -20,8 +21,9 @@ export function openUserProfile(userId: string): void {
 export function returnToFeed(): void {
   uiStore.setActiveView('feed');
   threadRouteStore.clearTarget();
-  const sectionId = get(activeSection)?.id ?? null;
-  pushPath(buildFeedHref(sectionId));
+  const section = get(activeSection);
+  const sectionSlug = section ? getSectionSlug(section) : null;
+  pushPath(buildFeedHref(sectionSlug));
 }
 
 export function handleProfileNavigation(event: MouseEvent, userId?: string | null): void {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -2,20 +2,27 @@ const SECTION_PATH_PREFIX = '/sections/';
 const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 
-export function buildSectionHref(sectionId: string): string {
-  return `${SECTION_PATH_PREFIX}${sectionId}`;
+export function buildSectionHref(sectionSlug: string): string {
+  return `${SECTION_PATH_PREFIX}${encodeURIComponent(sectionSlug)}`;
 }
 
-export function buildThreadHref(sectionId: string, postId: string): string {
-  return `${buildSectionHref(sectionId)}${THREAD_PATH_SEGMENT}${postId}`;
+export function buildThreadHref(sectionSlug: string, postId: string): string {
+  return `${buildSectionHref(sectionSlug)}${THREAD_PATH_SEGMENT}${postId}`;
 }
 
-export function parseSectionId(pathname: string): string | null {
+export function parseSectionSlug(pathname: string): string | null {
   if (!pathname.startsWith(SECTION_PATH_PREFIX)) {
     return null;
   }
-  const id = pathname.slice(SECTION_PATH_PREFIX.length).split('/')[0]?.trim();
-  return id ? id : null;
+  const slug = pathname.slice(SECTION_PATH_PREFIX.length).split('/')[0]?.trim();
+  if (!slug) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(slug);
+  } catch {
+    return slug;
+  }
 }
 
 export function parseThreadPostId(pathname: string): string | null {
@@ -23,8 +30,8 @@ export function parseThreadPostId(pathname: string): string | null {
     return null;
   }
   const remainder = pathname.slice(SECTION_PATH_PREFIX.length);
-  const [sectionId, segment, postId] = remainder.split('/');
-  if (!sectionId || segment !== THREAD_PATH_SEGMENT.slice(1, -1)) {
+  const [sectionSlug, segment, postId] = remainder.split('/');
+  if (!sectionSlug || segment !== THREAD_PATH_SEGMENT.slice(1, -1)) {
     return null;
   }
   const trimmed = postId?.trim();
@@ -39,8 +46,8 @@ export function isAdminPath(pathname: string): boolean {
   return pathname === ADMIN_PATH || pathname.startsWith(`${ADMIN_PATH}/`);
 }
 
-export function buildFeedHref(sectionId?: string | null): string {
-  return sectionId ? buildSectionHref(sectionId) : '/';
+export function buildFeedHref(sectionSlug?: string | null): string {
+  return sectionSlug ? buildSectionHref(sectionSlug) : '/';
 }
 
 export function pushPath(path: string): void {

--- a/frontend/src/services/sectionSlug.ts
+++ b/frontend/src/services/sectionSlug.ts
@@ -1,0 +1,35 @@
+import type { Section } from '../stores/sectionStore';
+
+const NON_SLUG_CHARS = /[^a-z0-9]+/g;
+const TRIM_HYPHENS = /^-+|-+$/g;
+
+export function slugifySectionName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(NON_SLUG_CHARS, '-')
+    .replace(TRIM_HYPHENS, '');
+}
+
+export function getSectionSlug(section: Pick<Section, 'name' | 'slug'>): string {
+  return section.slug || slugifySectionName(section.name);
+}
+
+export function findSectionByIdentifier(
+  sections: Section[],
+  identifier: string
+): Section | null {
+  const trimmed = identifier.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.toLowerCase();
+  return (
+    sections.find((section) => section.slug === normalized) ??
+    sections.find((section) => section.id === trimmed) ??
+    null
+  );
+}
+
+export function getSectionSlugById(sections: Section[], sectionId: string): string | null {
+  const match = sections.find((section) => section.id === sectionId);
+  return match ? getSectionSlug(match) : null;
+}

--- a/frontend/src/stores/__tests__/feedStore.test.ts
+++ b/frontend/src/stores/__tests__/feedStore.test.ts
@@ -82,14 +82,26 @@ describe('feedStore', () => {
     expect(apiGet).not.toHaveBeenCalled();
 
     postStore.setPosts([], null, false);
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     await loadMorePosts();
     expect(apiGet).not.toHaveBeenCalled();
   });
 
   it('loadMorePosts success appends posts', async () => {
     mapApiPost.mockImplementation((post: { id: string }) => mapPost(post.id));
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     postStore.setPosts([mapPost('post-0')], 'cursor-1', true);
 
     apiGet.mockResolvedValue({
@@ -106,7 +118,13 @@ describe('feedStore', () => {
   });
 
   it('loadMorePosts failure sets pagination error', async () => {
-    sectionStore.setActiveSection({ id: 'section-1', name: 'Music', type: 'music', icon: '🎵' });
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
     postStore.setPosts([mapPost('post-0')], 'cursor-1', true);
 
     apiGet.mockRejectedValue(new Error('boom'));

--- a/frontend/src/stores/__tests__/sectionStore.test.ts
+++ b/frontend/src/stores/__tests__/sectionStore.test.ts
@@ -39,7 +39,7 @@ describe('sectionStore', () => {
 
   it('loadSections failure keeps existing state', async () => {
     sectionStore.setSections([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
     ]);
 
     apiGet.mockRejectedValue(new Error('fail'));
@@ -54,16 +54,22 @@ describe('sectionStore', () => {
 
   it('setSections preserves active section when present', () => {
     sectionStore.setSections([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
-      { id: 'section-2', name: 'Books', type: 'book', icon: '📚' },
-      { id: 'section-3', name: 'General', type: 'general', icon: '💬' },
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-2', name: 'Books', type: 'book', icon: '📚', slug: 'books' },
+      { id: 'section-3', name: 'General', type: 'general', icon: '💬', slug: 'general' },
     ]);
-    sectionStore.setActiveSection({ id: 'section-2', name: 'Books', type: 'book', icon: '📚' });
+    sectionStore.setActiveSection({
+      id: 'section-2',
+      name: 'Books',
+      type: 'book',
+      icon: '📚',
+      slug: 'books',
+    });
 
     sectionStore.setSections([
-      { id: 'section-2', name: 'Books', type: 'book', icon: '📚' },
-      { id: 'section-3', name: 'General', type: 'general', icon: '💬' },
-      { id: 'section-4', name: 'Photos', type: 'photo', icon: '📷' },
+      { id: 'section-2', name: 'Books', type: 'book', icon: '📚', slug: 'books' },
+      { id: 'section-3', name: 'General', type: 'general', icon: '💬', slug: 'general' },
+      { id: 'section-4', name: 'Photos', type: 'photo', icon: '📷', slug: 'photos' },
     ]);
 
     const state = get(sectionStore);
@@ -71,11 +77,17 @@ describe('sectionStore', () => {
   });
 
   it('setSections selects first or null when active missing', () => {
-    sectionStore.setActiveSection({ id: 'section-99', name: 'Old', type: 'general', icon: '💬' });
+    sectionStore.setActiveSection({
+      id: 'section-99',
+      name: 'Old',
+      type: 'general',
+      icon: '💬',
+      slug: 'old',
+    });
 
     sectionStore.setSections([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵' },
-      { id: 'section-2', name: 'General', type: 'general', icon: '💬' },
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-2', name: 'General', type: 'general', icon: '💬', slug: 'general' },
     ]);
     let state = get(sectionStore);
     expect(state.activeSection?.id).toBe('section-2');
@@ -87,7 +99,13 @@ describe('sectionStore', () => {
 
   it('uses fallback icon for unknown type', () => {
     sectionStore.setSections([
-      { id: 'section-x', name: 'Unknown', type: 'unknown' as unknown as never, icon: '📁' },
+      {
+        id: 'section-x',
+        name: 'Unknown',
+        type: 'unknown' as unknown as never,
+        icon: '📁',
+        slug: 'unknown',
+      },
     ]);
 
     const state = get(sectionStore);

--- a/frontend/src/stores/sectionStore.ts
+++ b/frontend/src/stores/sectionStore.ts
@@ -1,11 +1,13 @@
 import { writable, derived } from 'svelte/store';
 import { api } from '../services/api';
+import { slugifySectionName } from '../services/sectionSlug';
 
 export interface Section {
   id: string;
   name: string;
   type: SectionType;
   icon: string;
+  slug: string;
 }
 
 export type SectionType = 'music' | 'photo' | 'event' | 'recipe' | 'book' | 'movie' | 'general';
@@ -60,6 +62,7 @@ function createSectionStore() {
         const mapped = ordered.map((section) => ({
           ...section,
           icon: sectionIcons[section.type] || '📁',
+          slug: slugifySectionName(section.name) || section.id,
         }));
         let active = null;
         if (state.activeSection) {
@@ -90,6 +93,7 @@ function createSectionStore() {
           name: section.name,
           type: section.type,
           icon: sectionIcons[section.type] || '📁',
+          slug: slugifySectionName(section.name) || section.id,
         }));
         const preferred =
           preferredSectionId && sections.length > 0


### PR DESCRIPTION
## Summary
- add slug helpers and store slug on sections for navigation
- switch routing to resolve section slugs (with UUID fallback) and redirect to canonical slug
- update link building + tests to use slugged section paths

Closes #351