### PR TITLE
Bug: Superfluous section pill on parent post in scoped search results

### DIFF
--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -238,6 +238,7 @@
   $: hasQuery = normalizedQuery.length > 0;
   $: showResults = $lastSearchQuery && $lastSearchQuery === normalizedQuery;
   $: isGlobalScope = $searchScope === 'global';
+  $: showParentSectionPill = $searchScope === 'global';
   $: sectionGroups = isGlobalScope ? buildSectionGroups($searchResults, $sections) : [];
 </script>
 
@@ -488,7 +489,7 @@
               <div class="flex items-center justify-between text-xs text-gray-500 mb-2">
                 <div class="flex items-center gap-2">
                   <span>Parent post</span>
-                  {#if sectionName}
+                  {#if sectionName && showParentSectionPill}
                     <span class={sectionPillClass}>
                       {#if sectionIcon}
                         <span class={sectionPillIconClass} aria-hidden="true">{sectionIcon}</span>

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/svelte';
+import { render, screen, cleanup, within } from '@testing-library/svelte';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -151,6 +151,42 @@ describe('SearchResults', () => {
 
     render(SearchResults);
     expect(screen.getAllByText('Movies').length).toBeGreaterThan(0);
+  });
+
+  it('hides section pill on parent post in section scope', () => {
+    storeRefs.searchQuery.set('reply');
+    storeRefs.lastSearchQuery.set('reply');
+    storeRefs.sections.set([
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+    ]);
+    storeRefs.activeSection.set({ id: 'section-1', name: 'Music', slug: 'music' });
+    storeRefs.searchResults.set([
+      {
+        type: 'comment',
+        score: 1,
+        comment: {
+          id: 'comment-1',
+          postId: 'post-1',
+          sectionId: 'section-1',
+          content: 'Great track',
+          createdAt: '2025-01-03T00:00:00Z',
+          user: { id: 'user-2', username: 'Alex' },
+        },
+        post: {
+          id: 'post-1',
+          sectionId: 'section-1',
+          content: 'Music post',
+          createdAt: '2025-01-02T00:00:00Z',
+          userId: 'user-1',
+        },
+      },
+    ]);
+
+    render(SearchResults);
+    const parentLabel = screen.getByText('Parent post');
+    const parentHeader = parentLabel.parentElement;
+    expect(parentHeader).toBeTruthy();
+    expect(within(parentHeader as HTMLElement).queryByText('Music')).not.toBeInTheDocument();
   });
 
   it('groups global search results by section', () => {


### PR DESCRIPTION
## Summary
- hide the parent post section pill when search scope is a single section
- keep section pill behavior unchanged for global search grouping
- add a test covering the scoped parent post header

## Testing
- `npm run test -- --grep \"SearchResults\"` (fails: `vitest` not found)

Closes #373