### PR TITLE
Fix search scope switching auto-updates results

### DIFF
--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -5,6 +5,7 @@
     searchError,
     searchQuery,
     lastSearchQuery,
+    lastSearchScope,
     searchScope,
     activeSection,
     searchStore,
@@ -237,8 +238,9 @@
   $: normalizedQuery = $searchQuery.trim();
   $: hasQuery = normalizedQuery.length > 0;
   $: showResults = $lastSearchQuery && $lastSearchQuery === normalizedQuery;
-  $: isGlobalScope = $searchScope === 'global';
-  $: showParentSectionPill = $searchScope === 'global';
+  $: displayScope = showResults && $lastSearchScope ? $lastSearchScope : $searchScope;
+  $: isGlobalScope = displayScope === 'global';
+  $: showParentSectionPill = displayScope === 'global';
   $: sectionGroups = isGlobalScope ? buildSectionGroups($searchResults, $sections) : [];
 </script>
 
@@ -272,6 +274,11 @@
   {:else if !showResults}
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
       <p class="text-gray-500">Press Search to see results.</p>
+      {#if $lastSearchScope && $lastSearchScope !== $searchScope}
+        <p class="text-sm text-gray-400 mt-2">
+          Scope changed to {$searchScope === 'global' ? 'Everywhere' : 'current section'}.
+        </p>
+      {/if}
     </div>
   {:else}
     <div class="flex items-center justify-between text-sm text-gray-500">
@@ -280,7 +287,7 @@
         "{$lastSearchQuery}"
       </span>
       <span>
-        {#if $searchScope === 'global'}
+        {#if displayScope === 'global'}
           All sections
         {:else if $activeSection}
           {$activeSection.name}
@@ -289,6 +296,12 @@
         {/if}
       </span>
     </div>
+
+    {#if $lastSearchScope && $lastSearchScope !== $searchScope}
+      <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-700">
+        Scope changed to {$searchScope === 'global' ? 'Everywhere' : 'current section'}. Press Search to refresh.
+      </div>
+    {/if}
 
     {#if isGlobalScope}
       {#each sectionGroups as group}

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -11,6 +11,7 @@ const storeRefs: {
   searchError: ReturnType<typeof writable>;
   searchQuery: ReturnType<typeof writable>;
   lastSearchQuery: ReturnType<typeof writable>;
+  lastSearchScope: ReturnType<typeof writable>;
   searchScope: ReturnType<typeof writable>;
   activeSection: ReturnType<typeof writable>;
   sections: ReturnType<typeof writable>;
@@ -27,6 +28,7 @@ vi.mock('../../../stores', () => {
   storeRefs.searchError = writable<string | null>(null);
   storeRefs.searchQuery = writable('');
   storeRefs.lastSearchQuery = writable('');
+  storeRefs.lastSearchScope = writable<'section' | 'global' | null>(null);
   storeRefs.searchScope = writable<'section' | 'global'>('section');
   storeRefs.activeSection = writable<{ id: string; name: string } | null>(null);
   storeRefs.sections = writable([]);
@@ -51,6 +53,7 @@ beforeEach(() => {
   storeRefs.searchError.set(null);
   storeRefs.searchQuery.set('');
   storeRefs.lastSearchQuery.set('');
+  storeRefs.lastSearchScope.set(null);
   storeRefs.searchScope.set('section');
   storeRefs.activeSection.set(null);
   storeRefs.sections.set([]);
@@ -69,6 +72,7 @@ describe('SearchResults', () => {
   it('shows loading state', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');
+    storeRefs.lastSearchScope.set('section');
     storeRefs.isSearching.set(true);
     render(SearchResults);
     expect(screen.getByText('Searching...')).toBeInTheDocument();
@@ -77,6 +81,7 @@ describe('SearchResults', () => {
   it('shows error state', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');
+    storeRefs.lastSearchScope.set('section');
     storeRefs.searchError.set('boom');
     render(SearchResults);
     expect(screen.getByText('boom')).toBeInTheDocument();
@@ -85,6 +90,7 @@ describe('SearchResults', () => {
   it('shows no results state', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');
+    storeRefs.lastSearchScope.set('section');
     storeRefs.searchResults.set([]);
     render(SearchResults);
     expect(screen.getByText('No results for "hello".')).toBeInTheDocument();
@@ -93,6 +99,7 @@ describe('SearchResults', () => {
   it('hides results when query changes', () => {
     storeRefs.searchQuery.set('new');
     storeRefs.lastSearchQuery.set('old');
+    storeRefs.lastSearchScope.set('section');
     render(SearchResults);
     expect(screen.getByText('Press Search to see results.')).toBeInTheDocument();
   });
@@ -100,6 +107,7 @@ describe('SearchResults', () => {
   it('renders comment results', () => {
     storeRefs.searchQuery.set('nice');
     storeRefs.lastSearchQuery.set('nice');
+    storeRefs.lastSearchScope.set('section');
     storeRefs.sections.set([
       { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
     ]);
@@ -131,6 +139,7 @@ describe('SearchResults', () => {
   it('renders section label for post results', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');
+    storeRefs.lastSearchScope.set('section');
     storeRefs.sections.set([
       { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
     ]);
@@ -192,6 +201,7 @@ describe('SearchResults', () => {
   it('groups global search results by section', () => {
     storeRefs.searchQuery.set('mix');
     storeRefs.lastSearchQuery.set('mix');
+    storeRefs.lastSearchScope.set('global');
     storeRefs.searchScope.set('global');
     storeRefs.sections.set([
       { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },

--- a/frontend/src/stores/searchStore.test.ts
+++ b/frontend/src/stores/searchStore.test.ts
@@ -31,6 +31,7 @@ describe('searchStore', () => {
     const state = get(searchStore);
     expect(state.results).toHaveLength(0);
     expect(state.lastSearched).toBe('');
+    expect(state.lastSearchedScope).toBeNull();
   });
 
   it('searches within the active section by default', async () => {
@@ -85,6 +86,7 @@ describe('searchStore', () => {
     expect(state.results[0].type).toBe('post');
     expect(state.results[1].type).toBe('comment');
     expect(state.results[1].post?.id).toBe('post-1');
+    expect(state.lastSearchedScope).toBe('section');
   });
 
   it('searches globally when scope is global', async () => {
@@ -97,6 +99,9 @@ describe('searchStore', () => {
     const request = apiGet.mock.calls[0][0] as string;
     expect(request).toContain('scope=global');
     expect(request).not.toContain('section_id=');
+
+    const state = get(searchStore);
+    expect(state.lastSearchedScope).toBe('global');
   });
 
   it('sets error when searching section scope without active section', async () => {
@@ -122,6 +127,7 @@ describe('searchStore', () => {
     expect(state.isLoading).toBe(false);
     expect(state.error).toBeNull();
     expect(state.lastSearched).toBe('');
+    expect(state.lastSearchedScope).toBeNull();
   });
 
   it('clears section search when active section changes', async () => {
@@ -137,6 +143,7 @@ describe('searchStore', () => {
     expect(state.query).toBe('');
     expect(state.results).toHaveLength(0);
     expect(state.lastSearched).toBe('');
+    expect(state.lastSearchedScope).toBeNull();
     expect(state.error).toBeNull();
     expect(state.isLoading).toBe(false);
   });

--- a/frontend/src/stores/searchStore.ts
+++ b/frontend/src/stores/searchStore.ts
@@ -87,6 +87,7 @@ interface SearchState {
   isLoading: boolean;
   error: string | null;
   lastSearched: string;
+  lastSearchedScope: SearchScope | null;
 }
 
 function mapApiLink(link: ApiLink): Link {
@@ -147,6 +148,7 @@ function createSearchStore() {
     isLoading: false,
     error: null,
     lastSearched: '',
+    lastSearchedScope: null,
   });
   const { subscribe, update, set } = store;
   let requestToken = 0;
@@ -176,6 +178,7 @@ function createSearchStore() {
           isLoading: false,
           error: null,
           lastSearched: '',
+          lastSearchedScope: null,
         };
       });
     }
@@ -202,6 +205,7 @@ function createSearchStore() {
         isLoading: false,
         error: null,
         lastSearched: '',
+        lastSearchedScope: null,
       });
     },
     search: async () => {
@@ -216,6 +220,7 @@ function createSearchStore() {
           error: null,
           isLoading: false,
           lastSearched: '',
+          lastSearchedScope: null,
         }));
         return;
       }
@@ -276,6 +281,7 @@ function createSearchStore() {
           isLoading: false,
           error: null,
           lastSearched: query,
+          lastSearchedScope: scope,
         }));
       } catch (err) {
         if (currentToken !== requestToken) {
@@ -299,3 +305,4 @@ export const searchResults = derived(searchStore, ($searchStore) => $searchStore
 export const searchError = derived(searchStore, ($searchStore) => $searchStore.error);
 export const isSearching = derived(searchStore, ($searchStore) => $searchStore.isLoading);
 export const lastSearchQuery = derived(searchStore, ($searchStore) => $searchStore.lastSearched);
+export const lastSearchScope = derived(searchStore, ($searchStore) => $searchStore.lastSearchedScope);


### PR DESCRIPTION
## Summary
- track the scope used for the last successful search and use it to render results
- show a stale-scope banner when the user changes scope without re-running search
- add coverage for last-search scope behavior

## Testing
- not run (vitest not available in environment: `vitest: command not found`)

Closes #372