### PR TITLE
Backend: Extend audit_logs table schema with metadata support

### DIFF
--- a/backend/migrations/019_add_target_user_metadata_to_audit_logs.down.sql
+++ b/backend/migrations/019_add_target_user_metadata_to_audit_logs.down.sql
@@ -1,0 +1,5 @@
+-- Remove target_user_id and metadata columns from audit_logs
+DROP INDEX IF EXISTS idx_audit_logs_target_user_id;
+ALTER TABLE audit_logs
+  DROP COLUMN IF EXISTS target_user_id,
+  DROP COLUMN IF EXISTS metadata;

--- a/backend/migrations/019_add_target_user_metadata_to_audit_logs.up.sql
+++ b/backend/migrations/019_add_target_user_metadata_to_audit_logs.up.sql
@@ -1,0 +1,7 @@
+-- Add target_user_id and metadata columns to audit_logs
+ALTER TABLE audit_logs
+  ADD COLUMN target_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN metadata JSONB;
+
+-- Create index for filtering by target_user_id
+CREATE INDEX idx_audit_logs_target_user_id ON audit_logs(target_user_id);


### PR DESCRIPTION
## Summary
- add target_user_id and metadata columns to audit_logs
- index target_user_id for filtering
- include reversible migration (up/down)

Closes #377