### PR TITLE
Backend: Add audit helper with metadata support

### DIFF
--- a/backend/internal/services/audit.go
+++ b/backend/internal/services/audit.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+type auditExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+// AuditService handles audit log writes.
+type AuditService struct {
+	exec auditExecutor
+}
+
+// NewAuditService creates a new audit service.
+func NewAuditService(execer auditExecutor) *AuditService {
+	return &AuditService{exec: execer}
+}
+
+// LogAuditWithMetadata records an admin audit log with optional metadata.
+func (s *AuditService) LogAuditWithMetadata(
+	ctx context.Context,
+	action string,
+	adminUserID uuid.UUID,
+	targetUserID uuid.UUID,
+	metadata map[string]interface{},
+) error {
+	if s == nil || s.exec == nil {
+		return fmt.Errorf("audit service is not configured")
+	}
+	if action == "" {
+		return fmt.Errorf("audit action is required")
+	}
+	if adminUserID == uuid.Nil {
+		return fmt.Errorf("admin user id is required")
+	}
+
+	var targetUserValue interface{}
+	var relatedUserValue interface{}
+	if targetUserID != uuid.Nil {
+		targetUserValue = targetUserID
+		relatedUserValue = targetUserID
+	}
+
+	var metadataValue interface{}
+	if metadata != nil {
+		metadataValue = models.JSONMap(metadata)
+	}
+
+	query := `
+		INSERT INTO audit_logs (admin_user_id, action, related_user_id, target_user_id, metadata, created_at)
+		VALUES ($1, $2, $3, $4, $5, now())
+	`
+	_, err := s.exec.ExecContext(ctx, query, adminUserID, action, relatedUserValue, targetUserValue, metadataValue)
+	if err != nil {
+		return fmt.Errorf("failed to create audit log: %w", err)
+	}
+
+	return nil
+}
+
+// LogAudit records an admin audit log without metadata.
+func (s *AuditService) LogAudit(ctx context.Context, action string, adminUserID uuid.UUID, targetUserID uuid.UUID) error {
+	return s.LogAuditWithMetadata(ctx, action, adminUserID, targetUserID, nil)
+}

--- a/backend/internal/services/audit_test.go
+++ b/backend/internal/services/audit_test.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestLogAuditWithMetadata(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	adminID := testutil.CreateTestUser(t, db, "auditadmin", "auditadmin@test.com", true, true)
+	targetID := testutil.CreateTestUser(t, db, "audittarget", "audittarget@test.com", false, true)
+
+	metadata := map[string]interface{}{
+		"reason": "spam",
+		"count":  3,
+	}
+
+	service := NewAuditService(db)
+	err := service.LogAuditWithMetadata(
+		context.Background(),
+		"suspend_user",
+		uuid.MustParse(adminID),
+		uuid.MustParse(targetID),
+		metadata,
+	)
+	if err != nil {
+		t.Fatalf("LogAuditWithMetadata failed: %v", err)
+	}
+
+	var storedTargetID uuid.UUID
+	var storedRelatedID uuid.UUID
+	var metadataBytes []byte
+	err = db.QueryRowContext(
+		context.Background(),
+		`SELECT target_user_id, related_user_id, metadata FROM audit_logs WHERE admin_user_id = $1 AND action = 'suspend_user'`,
+		uuid.MustParse(adminID),
+	).Scan(&storedTargetID, &storedRelatedID, &metadataBytes)
+	if err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	if storedTargetID.String() != targetID {
+		t.Errorf("expected target_user_id %s, got %s", targetID, storedTargetID.String())
+	}
+	if storedRelatedID.String() != targetID {
+		t.Errorf("expected related_user_id %s, got %s", targetID, storedRelatedID.String())
+	}
+
+	var storedMetadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &storedMetadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if storedMetadata["reason"] != "spam" {
+		t.Errorf("expected metadata reason 'spam', got %v", storedMetadata["reason"])
+	}
+	if storedMetadata["count"] != float64(3) {
+		t.Errorf("expected metadata count 3, got %v", storedMetadata["count"])
+	}
+}

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -439,11 +439,8 @@ func (s *UserService) ApproveUser(ctx context.Context, userID uuid.UUID, adminUs
 	}
 
 	// Create audit log entry
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO audit_logs (admin_user_id, action, related_user_id, created_at)
-		VALUES ($1, 'approve_user', $2, now())
-	`, adminUserID, userID)
-	if err != nil {
+	auditService := NewAuditService(tx)
+	if err := auditService.LogAudit(ctx, "approve_user", adminUserID, userID); err != nil {
 		return nil, fmt.Errorf("failed to create audit log: %w", err)
 	}
 
@@ -493,11 +490,8 @@ func (s *UserService) RejectUser(ctx context.Context, userID uuid.UUID, adminUse
 	}
 
 	// Create audit log entry BEFORE deleting the user (FK constraint)
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO audit_logs (admin_user_id, action, related_user_id, created_at)
-		VALUES ($1, 'reject_user', $2, now())
-	`, adminUserID, userID)
-	if err != nil {
+	auditService := NewAuditService(tx)
+	if err := auditService.LogAudit(ctx, "reject_user", adminUserID, userID); err != nil {
 		return nil, fmt.Errorf("failed to create audit log: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- add audit service helper to record audit logs with metadata and target user
- use audit helper for admin user approvals/rejections
- add unit test coverage for metadata logging

## Testing
- go build ./...
- go test ./internal/services -run TestLogAuditWithMetadata -v

Closes #378