### PR TITLE
Enhancement: Reorganize sections (rename Photos to Series, reorder)

### DIFF
--- a/backend/internal/services/section.go
+++ b/backend/internal/services/section.go
@@ -18,7 +18,20 @@ func NewSectionService(db *sql.DB) *SectionService {
 }
 
 func (s *SectionService) ListSections(ctx context.Context) ([]models.Section, error) {
-	query := `SELECT id, name, type FROM sections ORDER BY name ASC`
+	query := `
+		SELECT id, name, type
+		FROM sections
+		ORDER BY CASE type
+			WHEN 'general' THEN 1
+			WHEN 'music' THEN 2
+			WHEN 'movie' THEN 3
+			WHEN 'series' THEN 4
+			WHEN 'recipe' THEN 5
+			WHEN 'book' THEN 6
+			WHEN 'event' THEN 7
+			ELSE 100
+		END,
+		name ASC`
 
 	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {

--- a/backend/migrations/002_create_sections_table.up.sql
+++ b/backend/migrations/002_create_sections_table.up.sql
@@ -11,10 +11,10 @@ CREATE INDEX idx_sections_type ON sections(type);
 
 -- Insert default sections
 INSERT INTO sections (name, type) VALUES
+  ('General', 'general'),
   ('Music', 'music'),
-  ('Photos', 'photo'),
-  ('Events', 'event'),
+  ('Movies', 'movie'),
+  ('Series', 'series'),
   ('Recipes', 'recipe'),
   ('Books', 'book'),
-  ('Movies', 'movie'),
-  ('General', 'general');
+  ('Events', 'event');

--- a/backend/migrations/020_rename_photo_section_to_series.down.sql
+++ b/backend/migrations/020_rename_photo_section_to_series.down.sql
@@ -1,0 +1,6 @@
+-- Revert Series section back to Photos and photo type
+UPDATE sections
+SET name = 'Photos',
+    type = 'photo'
+WHERE type = 'series'
+   OR name = 'Series';

--- a/backend/migrations/020_rename_photo_section_to_series.up.sql
+++ b/backend/migrations/020_rename_photo_section_to_series.up.sql
@@ -1,0 +1,6 @@
+-- Rename Photos section to Series and update type
+UPDATE sections
+SET name = 'Series',
+    type = 'series'
+WHERE type = 'photo'
+   OR name = 'Photos';

--- a/frontend/src/stores/__tests__/sectionStore.test.ts
+++ b/frontend/src/stores/__tests__/sectionStore.test.ts
@@ -69,7 +69,7 @@ describe('sectionStore', () => {
     sectionStore.setSections([
       { id: 'section-2', name: 'Books', type: 'book', icon: '📚', slug: 'books' },
       { id: 'section-3', name: 'General', type: 'general', icon: '💬', slug: 'general' },
-      { id: 'section-4', name: 'Photos', type: 'photo', icon: '📷', slug: 'photos' },
+      { id: 'section-4', name: 'Series', type: 'series', icon: '📺', slug: 'series' },
     ]);
 
     const state = get(sectionStore);

--- a/frontend/src/stores/sectionStore.ts
+++ b/frontend/src/stores/sectionStore.ts
@@ -10,11 +10,11 @@ export interface Section {
   slug: string;
 }
 
-export type SectionType = 'music' | 'photo' | 'event' | 'recipe' | 'book' | 'movie' | 'general';
+export type SectionType = 'music' | 'series' | 'event' | 'recipe' | 'book' | 'movie' | 'general';
 
 const sectionIcons: Record<SectionType, string> = {
   music: '🎵',
-  photo: '📷',
+  series: '📺',
   event: '📅',
   recipe: '🍳',
   book: '📚',
@@ -34,17 +34,36 @@ interface SectionState {
   isLoading: boolean;
 }
 
-function isGeneralSection(section: { type?: SectionType; name?: string }): boolean {
+const sectionOrder: SectionType[] = [
+  'general',
+  'music',
+  'movie',
+  'series',
+  'recipe',
+  'book',
+  'event',
+];
+
+function getSectionOrderIndex(section: { type?: SectionType; name?: string }): number {
   if (section.type) {
-    return section.type === 'general';
+    const index = sectionOrder.indexOf(section.type);
+    if (index !== -1) return index;
   }
-  return section.name?.toLowerCase() === 'general';
+  if (section.name?.toLowerCase() === 'general') {
+    return sectionOrder.indexOf('general');
+  }
+  return 100;
 }
 
 function orderSections<T extends { type?: SectionType; name?: string }>(sections: T[]): T[] {
-  const general = sections.filter((section) => isGeneralSection(section));
-  const rest = sections.filter((section) => !isGeneralSection(section));
-  return [...general, ...rest];
+  return [...sections].sort((a, b) => {
+    const aIndex = getSectionOrderIndex(a);
+    const bIndex = getSectionOrderIndex(b);
+    if (aIndex !== bIndex) return aIndex - bIndex;
+    const aName = a.name?.toLowerCase() ?? '';
+    const bName = b.name?.toLowerCase() ?? '';
+    return aName.localeCompare(bName);
+  });
 }
 
 function createSectionStore() {


### PR DESCRIPTION
## Summary
- rename Photos section to Series in a reversible migration and update default section seeds
- order sections by the requested type order in the backend list query
- update frontend section types, icons, and ordering for Series

## Testing
- go build ./...
- go test ./internal/services -v
- npm run check (fails: svelte-check not found)
- npm run test -- --grep "sectionStore" (fails: vitest not found)

Closes #369