### PR TITLE
Backend: Add audit events for settings and auth actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,9 @@ When recording audit logs, include the acting admin/user ID and map `target_user
 - `delete_comment`
 - `hard_delete_comment`
 - `restore_comment`
+- `enroll_mfa`
+- `enable_mfa`
+- `generate_password_reset_token`
 - `toggle_link_metadata`
 - `update_section`
 - `delete_section`


### PR DESCRIPTION
## Summary
- log admin audit entries for MFA enroll/enable, config toggles, and password reset token generation
- include metadata for config changes and MFA method
- add admin audit action names to AGENTS docs and extend handler tests

## Testing
- go test ./internal/handlers -run \"TestUpdateConfigAuditLog|TestGeneratePasswordResetToken|TestAdminTOTPEnrollAndVerify\" -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #381