### PR TITLE
Backend: Add audit events for user management actions

### DIFF
--- a/backend/internal/models/audit.go
+++ b/backend/internal/models/audit.go
@@ -9,7 +9,7 @@ import (
 // AuditLog represents an audit log entry for admin actions
 type AuditLog struct {
 	ID               uuid.UUID  `json:"id"`
-	AdminUserID      uuid.UUID  `json:"admin_user_id"`
+	AdminUserID      *uuid.UUID `json:"admin_user_id,omitempty"`
 	AdminUsername    string     `json:"admin_username,omitempty"`
 	Action           string     `json:"action"`
 	RelatedPostID    *uuid.UUID `json:"related_post_id,omitempty"`

--- a/backend/internal/services/audit.go
+++ b/backend/internal/services/audit.go
@@ -37,8 +37,10 @@ func (s *AuditService) LogAuditWithMetadata(
 	if action == "" {
 		return fmt.Errorf("audit action is required")
 	}
-	if adminUserID == uuid.Nil {
-		return fmt.Errorf("admin user id is required")
+
+	var adminUserValue interface{}
+	if adminUserID != uuid.Nil {
+		adminUserValue = adminUserID
 	}
 
 	var targetUserValue interface{}
@@ -57,7 +59,7 @@ func (s *AuditService) LogAuditWithMetadata(
 		INSERT INTO audit_logs (admin_user_id, action, related_user_id, target_user_id, metadata, created_at)
 		VALUES ($1, $2, $3, $4, $5, now())
 	`
-	_, err := s.exec.ExecContext(ctx, query, adminUserID, action, relatedUserValue, targetUserValue, metadataValue)
+	_, err := s.exec.ExecContext(ctx, query, adminUserValue, action, relatedUserValue, targetUserValue, metadataValue)
 	if err != nil {
 		return fmt.Errorf("failed to create audit log: %w", err)
 	}

--- a/backend/internal/services/user_audit_test.go
+++ b/backend/internal/services/user_audit_test.go
@@ -1,0 +1,146 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestRegisterUserCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	service := NewUserService(db)
+	req := &models.RegisterRequest{
+		Username: "auditreg",
+		Email:    "auditreg@example.com",
+		Password: "LongPassword1234",
+	}
+
+	user, err := service.RegisterUser(context.Background(), req)
+	if err != nil {
+		t.Fatalf("RegisterUser failed: %v", err)
+	}
+
+	var adminUserID uuid.NullUUID
+	var targetUserID uuid.UUID
+	var metadataBytes []byte
+	query := `
+		SELECT admin_user_id, target_user_id, metadata
+		FROM audit_logs
+		WHERE action = 'register_user' AND target_user_id = $1
+	`
+	if err := db.QueryRowContext(context.Background(), query, user.ID).Scan(&adminUserID, &targetUserID, &metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	if adminUserID.Valid {
+		t.Errorf("expected admin_user_id to be NULL for registration audit log")
+	}
+	if targetUserID != user.ID {
+		t.Errorf("expected target_user_id %s, got %s", user.ID, targetUserID)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["username"] != req.Username {
+		t.Errorf("expected metadata username %q, got %v", req.Username, metadata["username"])
+	}
+	if metadata["email"] != req.Email {
+		t.Errorf("expected metadata email %q, got %v", req.Email, metadata["email"])
+	}
+}
+
+func TestUpdateProfileCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.New()
+	_, err := db.Exec(`
+		INSERT INTO users (id, username, email, password_hash, bio, profile_picture_url, is_admin, approved_at, created_at)
+		VALUES ($1, 'auditprofile', 'auditprofile@example.com', '$2a$12$test', 'old bio', 'https://old.example.com/avatar.png', false, now(), now())
+	`, userID)
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	service := NewUserService(db)
+	newBio := "new bio"
+	newProfile := "https://new.example.com/avatar.png"
+	req := &models.UpdateUserRequest{
+		Bio:               &newBio,
+		ProfilePictureUrl: &newProfile,
+	}
+
+	if _, err := service.UpdateProfile(context.Background(), userID, req); err != nil {
+		t.Fatalf("UpdateProfile failed: %v", err)
+	}
+
+	var adminUserID uuid.NullUUID
+	var targetUserID uuid.UUID
+	var metadataBytes []byte
+	query := `
+		SELECT admin_user_id, target_user_id, metadata
+		FROM audit_logs
+		WHERE action = 'update_profile' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, userID).Scan(&adminUserID, &targetUserID, &metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	if adminUserID.Valid {
+		t.Errorf("expected admin_user_id to be NULL for profile update audit log")
+	}
+	if targetUserID != userID {
+		t.Errorf("expected target_user_id %s, got %s", userID, targetUserID)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	changedFields, ok := metadata["changed_fields"].([]interface{})
+	if !ok {
+		t.Fatalf("expected changed_fields list in metadata")
+	}
+	if len(changedFields) != 2 {
+		t.Errorf("expected 2 changed fields, got %d", len(changedFields))
+	}
+
+	changes, ok := metadata["changes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected changes map in metadata")
+	}
+
+	bioChange, ok := changes["bio"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected bio change metadata")
+	}
+	if bioChange["old"] != "old bio" {
+		t.Errorf("expected bio old value 'old bio', got %v", bioChange["old"])
+	}
+	if bioChange["new"] != newBio {
+		t.Errorf("expected bio new value %q, got %v", newBio, bioChange["new"])
+	}
+
+	profileChange, ok := changes["profile_picture_url"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected profile_picture_url change metadata")
+	}
+	if profileChange["old"] != "https://old.example.com/avatar.png" {
+		t.Errorf("expected profile old value 'https://old.example.com/avatar.png', got %v", profileChange["old"])
+	}
+	if profileChange["new"] != newProfile {
+		t.Errorf("expected profile new value %q, got %v", newProfile, profileChange["new"])
+	}
+}

--- a/backend/migrations/020_make_audit_admin_user_nullable.down.sql
+++ b/backend/migrations/020_make_audit_admin_user_nullable.down.sql
@@ -1,0 +1,11 @@
+-- Revert audit_logs admin_user_id to required
+ALTER TABLE audit_logs
+  DROP CONSTRAINT IF EXISTS audit_logs_admin_user_id_fkey;
+
+ALTER TABLE audit_logs
+  ALTER COLUMN admin_user_id SET NOT NULL;
+
+ALTER TABLE audit_logs
+  ADD CONSTRAINT audit_logs_admin_user_id_fkey
+  FOREIGN KEY (admin_user_id)
+  REFERENCES users(id);

--- a/backend/migrations/020_make_audit_admin_user_nullable.up.sql
+++ b/backend/migrations/020_make_audit_admin_user_nullable.up.sql
@@ -1,0 +1,12 @@
+-- Allow audit logs without admin users (e.g. registration/profile updates)
+ALTER TABLE audit_logs
+  ALTER COLUMN admin_user_id DROP NOT NULL;
+
+ALTER TABLE audit_logs
+  DROP CONSTRAINT IF EXISTS audit_logs_admin_user_id_fkey;
+
+ALTER TABLE audit_logs
+  ADD CONSTRAINT audit_logs_admin_user_id_fkey
+  FOREIGN KEY (admin_user_id)
+  REFERENCES users(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- log registration and profile update audit entries with metadata (changed fields + old/new values)
- add audit metadata for approve/reject to preserve target user id
- allow audit logs without admins and adjust audit log listing for nullable admins
- add tests for registration/profile audit logs and a migration to allow null admin_user_id

## Testing
- go test ./internal/services -run 'Test(RegisterUserCreatesAuditLog|UpdateProfileCreatesAuditLog)' -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #379