### PR TITLE
Fix admin member name links

### DIFF
--- a/frontend/src/components/admin/UserResetLinks.svelte
+++ b/frontend/src/components/admin/UserResetLinks.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { api } from '../../services/api';
+  import { buildProfileHref, handleProfileNavigation } from '../../services/profileNavigation';
 
   interface AdminUser {
     id: string;
@@ -197,7 +198,14 @@
           <div class="flex flex-wrap items-start justify-between gap-4">
             <div>
               <div class="flex flex-wrap items-center gap-2">
-                <p class="text-lg font-semibold text-slate-900">{user.username}</p>
+                <a
+                  href={buildProfileHref(user.id)}
+                  on:click={(event) => handleProfileNavigation(event, user.id)}
+                  class="cursor-pointer text-lg font-semibold text-slate-900 transition hover:text-amber-700 hover:underline"
+                  aria-label={`View ${user.username}'s profile`}
+                >
+                  {user.username}
+                </a>
                 {#if user.is_admin}
                   <span class="rounded-full bg-indigo-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-indigo-600">
                     Admin

--- a/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
+++ b/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
@@ -46,7 +46,8 @@ describe('UserResetLinks', () => {
     await fireEvent.click(screen.getByText('Refresh'));
     await flushUsersLoad();
 
-    expect(await screen.findByText('lena')).toBeInTheDocument();
+    const profileLink = await screen.findByRole('link', { name: "View lena's profile" });
+    expect(profileLink).toHaveAttribute('href', '/users/user-1');
     expect(screen.getByText('lena@example.com')).toBeInTheDocument();
     if (typeof AbortController === 'undefined') {
       expect(apiGet).toHaveBeenCalledWith('/admin/users/approved');


### PR DESCRIPTION
## Summary
- make admin member names in Members section link to user profiles
- add hover styling and client-side navigation behavior
- update UserResetLinks test to assert profile link

## Testing
- not run (vitest not available locally)

Closes #366