### PR TITLE
Frontend: Improve audit log display with full context

### DIFF
--- a/backend/internal/models/audit.go
+++ b/backend/internal/models/audit.go
@@ -15,6 +15,10 @@ type AuditLog struct {
 	RelatedPostID    *uuid.UUID `json:"related_post_id,omitempty"`
 	RelatedCommentID *uuid.UUID `json:"related_comment_id,omitempty"`
 	RelatedUserID    *uuid.UUID `json:"related_user_id,omitempty"`
+	RelatedUsername  string     `json:"related_username,omitempty"`
+	TargetUserID     *uuid.UUID `json:"target_user_id,omitempty"`
+	TargetUsername   string     `json:"target_username,omitempty"`
+	Metadata         JSONMap    `json:"metadata,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 }
 

--- a/frontend/src/components/admin/AuditLogs.svelte
+++ b/frontend/src/components/admin/AuditLogs.svelte
@@ -4,12 +4,16 @@
 
   interface AuditLog {
     id: string;
-    admin_user_id: string;
-    admin_username: string;
+    admin_user_id?: string | null;
+    admin_username?: string | null;
     action: string;
     related_post_id?: string | null;
     related_comment_id?: string | null;
     related_user_id?: string | null;
+    related_username?: string | null;
+    target_user_id?: string | null;
+    target_username?: string | null;
+    metadata?: Record<string, unknown> | null;
     created_at: string;
   }
 
@@ -32,16 +36,131 @@
     hard_delete_comment: 'Deleted comment',
     restore_post: 'Restored post',
     restore_comment: 'Restored comment',
+    delete_post: 'Deleted post',
+    delete_comment: 'Deleted comment',
+    toggle_link_metadata: 'Toggled link metadata',
+    register_user: 'Registered user',
+    update_profile: 'Updated profile',
+    suspend_user: 'Suspended user',
+    unsuspend_user: 'Unsuspended user',
+    enroll_mfa: 'Enrolled MFA',
+    enable_mfa: 'Enabled MFA',
+    generate_password_reset_token: 'Generated password reset token',
   };
 
+  const userActions = new Set([
+    'approve_user',
+    'reject_user',
+    'suspend_user',
+    'unsuspend_user',
+    'register_user',
+    'update_profile',
+    'enroll_mfa',
+    'enable_mfa',
+    'generate_password_reset_token',
+  ]);
+
   const formatAction = (action: string) => actionLabels[action] ?? action.replace(/_/g, ' ');
-  const formatDate = (value: string) => new Date(value).toLocaleString();
+  const formatDate = (value: string) =>
+    new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+
+  const getMetadataValue = (metadata: Record<string, unknown> | null | undefined, key: string) => {
+    if (!metadata) return null;
+    const value = metadata[key];
+    return value === undefined || value === null ? null : value;
+  };
+
+  const isUserAction = (action: string) => userActions.has(action);
+
+  const resolveUserLabel = (log: AuditLog) => {
+    if (log.target_username) return log.target_username;
+    if (log.related_username) return log.related_username;
+    const metadataUsername = getMetadataValue(log.metadata, 'username');
+    if (typeof metadataUsername === 'string' && metadataUsername.trim() !== '') {
+      return metadataUsername;
+    }
+    const metadataEmail = getMetadataValue(log.metadata, 'email');
+    if (typeof metadataEmail === 'string' && metadataEmail.trim() !== '') {
+      return metadataEmail;
+    }
+    return null;
+  };
+
+  const resolveUserLabelByID = (log: AuditLog, userID: string) => {
+    if (log.admin_user_id && log.admin_user_id === userID) {
+      return log.admin_username ?? null;
+    }
+    if (log.target_user_id && log.target_user_id === userID && log.target_username) {
+      return log.target_username;
+    }
+    if (log.related_user_id && log.related_user_id === userID && log.related_username) {
+      return log.related_username;
+    }
+    return null;
+  };
+
+  const formatLogTitle = (log: AuditLog) => {
+    const base = formatAction(log.action);
+    if (!isUserAction(log.action)) {
+      return base;
+    }
+    const userLabel = resolveUserLabel(log);
+    return userLabel ? `${base} ${userLabel}` : base;
+  };
 
   const formatRelated = (log: AuditLog) => {
-    if (log.related_user_id) return `User · ${log.related_user_id.slice(0, 8)}…`;
-    if (log.related_post_id) return `Post · ${log.related_post_id.slice(0, 8)}…`;
-    if (log.related_comment_id) return `Comment · ${log.related_comment_id.slice(0, 8)}…`;
-    return 'System';
+    const parts: string[] = [];
+    const userLabel = resolveUserLabel(log);
+    if (userLabel) {
+      parts.push(`User · ${userLabel}`);
+    } else if (log.related_user_id) {
+      parts.push(`User · ${log.related_user_id.slice(0, 8)}…`);
+    } else if (log.target_user_id) {
+      parts.push(`User · ${log.target_user_id.slice(0, 8)}…`);
+    }
+
+    if (log.related_post_id) parts.push(`Post · ${log.related_post_id.slice(0, 8)}…`);
+    if (log.related_comment_id) parts.push(`Comment · ${log.related_comment_id.slice(0, 8)}…`);
+
+    return parts.length > 0 ? parts.join(' · ') : 'System';
+  };
+
+  const formatMetadataSummary = (log: AuditLog) => {
+    const metadata = log.metadata ?? {};
+    const details: string[] = [];
+
+    if (log.action === 'toggle_link_metadata') {
+      const setting = getMetadataValue(metadata, 'setting');
+      const oldValue = getMetadataValue(metadata, 'old_value');
+      const newValue = getMetadataValue(metadata, 'new_value');
+      if (setting !== null && oldValue !== null && newValue !== null) {
+        details.push(`${setting}: ${oldValue} → ${newValue}`);
+      }
+    }
+
+    const excerpt = getMetadataValue(metadata, 'content_excerpt');
+    if (typeof excerpt === 'string' && excerpt.trim() !== '') {
+      details.push(`Excerpt: ${excerpt}`);
+    }
+
+    const changedFields = getMetadataValue(metadata, 'changed_fields');
+    if (Array.isArray(changedFields) && changedFields.length > 0) {
+      details.push(`Updated fields: ${changedFields.join(', ')}`);
+    }
+
+    const deletedBy = getMetadataValue(metadata, 'deleted_by_user_id');
+    if (typeof deletedBy === 'string' && deletedBy.trim() !== '') {
+      const userLabel = resolveUserLabelByID(log, deletedBy);
+      details.push(`Deleted by ${userLabel ?? `${deletedBy.slice(0, 8)}…`}`);
+    }
+
+    const restoredBy = getMetadataValue(metadata, 'restored_by_user_id');
+    if (typeof restoredBy === 'string' && restoredBy.trim() !== '') {
+      const userLabel = resolveUserLabelByID(log, restoredBy);
+      details.push(`Restored by ${userLabel ?? `${restoredBy.slice(0, 8)}…`}`);
+    }
+
+    return details;
   };
 
   const loadLogs = async ({ reset = false }: { reset?: boolean } = {}) => {
@@ -106,18 +225,34 @@
   {:else}
     <div class="mt-6 space-y-4">
       {#each logs as log (log.id)}
+        {@const summary = formatMetadataSummary(log)}
         <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="space-y-2">
-              <p class="text-sm font-semibold text-slate-900">{formatAction(log.action)}</p>
+              <p class="text-sm font-semibold text-slate-900">{formatLogTitle(log)}</p>
               <p class="text-xs text-slate-500">
-                {log.admin_username} · {formatRelated(log)}
+                {log.admin_username || 'System'} · {formatRelated(log)}
               </p>
+              {#if summary.length > 0}
+                <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                  {#each summary as detail}
+                    <span class="rounded-full bg-slate-100 px-3 py-1">{detail}</span>
+                  {/each}
+                </div>
+              {/if}
             </div>
             <div class="text-xs font-mono uppercase tracking-widest text-slate-400">
               {formatDate(log.created_at)}
             </div>
           </div>
+          <details class="mt-4 rounded-xl border border-slate-100 bg-slate-50 p-3 text-xs text-slate-600">
+            <summary class="cursor-pointer select-none text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Metadata
+            </summary>
+            <pre class="mt-3 whitespace-pre-wrap break-words font-mono text-[11px] text-slate-500">
+{JSON.stringify(log.metadata ?? {}, null, 2)}
+            </pre>
+          </details>
         </div>
       {/each}
     </div>

--- a/frontend/src/components/admin/__tests__/AuditLogs.test.ts
+++ b/frontend/src/components/admin/__tests__/AuditLogs.test.ts
@@ -29,6 +29,8 @@ describe('AuditLogs', () => {
           admin_user_id: 'admin-1',
           admin_username: 'sander',
           action: 'approve_user',
+          target_user_id: 'user-1',
+          target_username: 'johndoe',
           created_at: '2024-01-01T00:00:00Z',
         },
       ],
@@ -40,7 +42,7 @@ describe('AuditLogs', () => {
     await tick();
 
     expect(apiGet).toHaveBeenCalledWith('/admin/audit-logs');
-    expect(screen.getByText('Approved user')).toBeInTheDocument();
+    expect(screen.getByText('Approved user johndoe')).toBeInTheDocument();
     expect(screen.getByText(/sander/i)).toBeInTheDocument();
   });
 
@@ -52,6 +54,8 @@ describe('AuditLogs', () => {
           admin_user_id: 'admin-1',
           admin_username: 'sander',
           action: 'approve_user',
+          target_user_id: 'user-1',
+          target_username: 'johndoe',
           created_at: '2024-01-01T00:00:00Z',
         },
       ],
@@ -66,6 +70,8 @@ describe('AuditLogs', () => {
           admin_user_id: 'admin-1',
           admin_username: 'sander',
           action: 'reject_user',
+          target_user_id: 'user-2',
+          target_username: 'janedoe',
           created_at: '2024-01-02T00:00:00Z',
         },
       ],
@@ -88,6 +94,6 @@ describe('AuditLogs', () => {
     await tick();
 
     expect(apiGet).toHaveBeenCalledWith('/admin/audit-logs?cursor=cursor-1');
-    expect(screen.getByText('Rejected user')).toBeInTheDocument();
+    expect(screen.getByText('Rejected user janedoe')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- include audit log metadata and target/related usernames in admin audit log responses
- enrich audit log rows with username-based titles, metadata badges, and expandable JSON
- standardize audit timestamps and add frontend coverage for username display

## Testing
- go test ./internal/handlers -run TestGetAuditLogs -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- npm run test -- --grep "AuditLogs" (failed: vitest not found)
- npm run check (failed: svelte-check not found)

Closes #382
