### PR TITLE
Frontend: Add audit log filtering by type, date, and user

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -330,6 +330,7 @@ func main() {
 
 	// Admin audit logs route
 	mux.Handle("/api/v1/admin/audit-logs", requireAdmin(http.HandlerFunc(adminHandler.GetAuditLogs)))
+	mux.Handle("/api/v1/admin/audit-logs/actions", requireAdmin(http.HandlerFunc(adminHandler.GetAuditLogActions)))
 	// Admin auth events route
 	mux.Handle("/api/v1/admin/auth-events", requireAdmin(http.HandlerFunc(adminHandler.GetAuthEvents)))
 

--- a/backend/internal/models/audit.go
+++ b/backend/internal/models/audit.go
@@ -28,3 +28,8 @@ type AuditLogsResponse struct {
 	HasMore    bool        `json:"has_more"`
 	NextCursor *string     `json:"next_cursor,omitempty"`
 }
+
+// AuditLogActionsResponse represents the response for listing audit log action types.
+type AuditLogActionsResponse struct {
+	Actions []string `json:"actions"`
+}

--- a/frontend/src/routes/AdminPanel.svelte
+++ b/frontend/src/routes/AdminPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import PendingUsers from '../components/admin/PendingUsers.svelte';
   import AuditLogs from '../components/admin/AuditLogs.svelte';
   import UserResetLinks from '../components/admin/UserResetLinks.svelte';
@@ -30,6 +31,15 @@
   ];
 
   let activeTab: AdminTab = 'pending';
+
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const tabParam = params.get('tab');
+    if (tabParam && tabs.some((tab) => tab.id === tabParam)) {
+      activeTab = tabParam as AdminTab;
+    }
+  });
 </script>
 
 <div class="admin-panel space-y-8">

--- a/frontend/src/routes/__tests__/AdminPanel.test.ts
+++ b/frontend/src/routes/__tests__/AdminPanel.test.ts
@@ -38,6 +38,9 @@ describe('AdminPanel', () => {
       if (endpoint === '/admin/users/approved') {
         return Promise.resolve([]);
       }
+      if (endpoint === '/admin/audit-logs/actions') {
+        return Promise.resolve({ actions: [] });
+      }
       if (endpoint.startsWith('/admin/audit-logs')) {
         return Promise.resolve({ logs: [], has_more: false });
       }


### PR DESCRIPTION
## Summary
- add audit log filtering support on the backend (actions/date/admin/target) plus actions list endpoint
- add audit log filters UI with URL-synced state and clear/reset controls
- update admin/audit log frontend tests and backend handler tests

## Testing
- go test ./internal/handlers -run AuditLogs -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- npm run test -- --grep AuditLogs (failed: vitest not found)

Closes #383