### PR TITLE
Prometheus: Add HTTP and API alerting rules

### DIFF
--- a/prometheus/alerts/http-alerts.yml
+++ b/prometheus/alerts/http-alerts.yml
@@ -1,11 +1,27 @@
 groups:
   - name: http-alerts
     rules:
-      - alert: ClubhouseAPIDown
-        expr: up{job="clubhouse"} == 0
+      - alert: HighHTTPErrorRate
+        expr: sum(rate(clubhouse_http_server_request_count{http_response_status_code=~"5.."}[5m])) / sum(rate(clubhouse_http_server_request_count[5m])) > 0.01
         for: 2m
         labels:
           severity: critical
         annotations:
-          summary: "Clubhouse API is down"
-          description: "Prometheus has not scraped the Clubhouse API for 2 minutes."
+          summary: "High HTTP error rate (> 1%)"
+      - alert: HighHTTPLatency
+        expr: histogram_quantile(0.95, rate(clubhouse_http_server_request_duration_ms_bucket[5m])) > 1000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "95th percentile latency > 1s"
+      - alert: ClubhouseDown
+        expr: up{job="clubhouse"} == 0
+        for: 1m
+        labels:
+          severity: critical
+      - alert: UnusuallyHighRequestRate
+        expr: sum(rate(clubhouse_http_server_request_count[1m])) > 1000
+        for: 2m
+        labels:
+          severity: warning


### PR DESCRIPTION
## Summary
- add HTTP/API alerting rules for error rate, latency, downtime, and high request rate
- replace the previous single API-down alert with the expanded rule set

Closes #433