### PR TITLE
[High] Add authentication and rate limiting metrics

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -351,6 +351,7 @@ func (h *AdminHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.totpService.VerifyAdmin(r.Context(), session.UserID, req.Code); err != nil {
+		observability.RecordAuthTOTPVerification(r.Context(), "failure")
 		switch {
 		case errors.Is(err, services.ErrTOTPRequired):
 			writeError(r.Context(), w, http.StatusBadRequest, "TOTP_REQUIRED", "TOTP code required")
@@ -369,6 +370,8 @@ func (h *AdminHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	observability.RecordAuthTOTPVerification(r.Context(), "success")
 
 	response := models.TOTPVerifyResponse{
 		Message: "TOTP enabled",
@@ -1187,6 +1190,8 @@ func (h *AdminHandler) GeneratePasswordResetToken(w http.ResponseWriter, r *http
 		writeError(r.Context(), w, http.StatusInternalServerError, "TOKEN_GENERATION_FAILED", "Failed to generate password reset token")
 		return
 	}
+
+	observability.RecordAuthPasswordReset(r.Context(), "token_generated")
 
 	response := models.GeneratePasswordResetTokenResponse{
 		Token:     token.Token,

--- a/backend/internal/services/rate_limiter_test.go
+++ b/backend/internal/services/rate_limiter_test.go
@@ -12,7 +12,7 @@ func TestRateLimiterAllowsWithinLimit(t *testing.T) {
 	client := testutil.GetTestRedis(t)
 	defer testutil.CleanupRedis(t)
 	redisServer := testutil.GetMiniredisServer(t)
-	limiter := NewRateLimiter(client, "rate:test:", RateLimitConfig{Limit: 2, Window: time.Second})
+	limiter := NewRateLimiter(client, "rate:test:", RateLimitConfig{Limit: 2, Window: time.Second}, "test")
 
 	ctx := context.Background()
 	for i := 0; i < 2; i++ {

--- a/backend/internal/services/session_test.go
+++ b/backend/internal/services/session_test.go
@@ -81,7 +81,7 @@ func TestDeleteAllSessionsForUser(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if err := service.DeleteAllSessionsForUser(ctx, userID); err != nil {
+	if _, err := service.DeleteAllSessionsForUser(ctx, userID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- add auth + rate limit metric instruments and recorders in observability
- record login/register attempts, auth failures, sessions created/expired, TOTP verification, and password reset stages
- emit rate limit violation + lockout metrics from limiter/auth flows
- track session invalidation counts for logout/logout_all/password reset

Closes #419