### PR TITLE
Backend: MFA requirement config and login enforcement

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -68,6 +68,16 @@ func main() {
 	}
 	defer dbConn.Close()
 
+	if err := services.InitConfigService(ctx, dbConn); err != nil {
+		observability.LogError(ctx, observability.ErrorLog{
+			Message:    "failed to initialize config service",
+			Code:       "CONFIG_INIT_FAILED",
+			StatusCode: http.StatusInternalServerError,
+			Err:        err,
+		})
+		os.Exit(1)
+	}
+
 	userService := services.NewUserService(dbConn)
 	adminExists, err := userService.AdminExists(ctx)
 	if err != nil {

--- a/backend/internal/handlers/links_test.go
+++ b/backend/internal/handlers/links_test.go
@@ -83,10 +83,14 @@ func TestPreviewLinkSuccess(t *testing.T) {
 func TestPreviewLinkDisabled(t *testing.T) {
 	configService := services.GetConfigService()
 	disabled := false
-	configService.UpdateConfig(&disabled)
+	if _, err := configService.UpdateConfig(context.Background(), &disabled, nil); err != nil {
+		t.Fatalf("failed to disable link metadata: %v", err)
+	}
 	defer func() {
 		enabled := true
-		configService.UpdateConfig(&enabled)
+		if _, err := configService.UpdateConfig(context.Background(), &enabled, nil); err != nil {
+			t.Fatalf("failed to re-enable link metadata: %v", err)
+		}
 	}()
 
 	handler := NewLinkHandler()
@@ -133,7 +137,9 @@ func TestPreviewLinkInvalidBody(t *testing.T) {
 
 func TestPreviewLinkRequestTooLarge(t *testing.T) {
 	enabled := true
-	services.GetConfigService().UpdateConfig(&enabled)
+	if _, err := services.GetConfigService().UpdateConfig(context.Background(), &enabled, nil); err != nil {
+		t.Fatalf("failed to enable link metadata: %v", err)
+	}
 
 	handler := NewLinkHandler()
 	largeURL := "https://example.com/" + strings.Repeat("a", int(maxJSONBodyBytes)+1024)

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -67,8 +67,9 @@ type CSRFTokenResponse struct {
 
 // ErrorResponse represents a standard error response
 type ErrorResponse struct {
-	Error string `json:"error"`
-	Code  string `json:"code"`
+	Error       string `json:"error"`
+	Code        string `json:"code"`
+	MFARequired bool   `json:"mfa_required,omitempty"`
 }
 
 // PendingUser represents a user pending admin approval

--- a/backend/internal/services/config.go
+++ b/backend/internal/services/config.go
@@ -1,18 +1,23 @@
 package services
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"sync"
 )
 
 // Config holds application configuration that can be toggled at runtime
 type Config struct {
 	LinkMetadataEnabled bool `json:"linkMetadataEnabled"`
+	MFARequired         bool `json:"mfaRequired"`
 }
 
 // ConfigService provides thread-safe access to runtime configuration
 type ConfigService struct {
 	mu     sync.RWMutex
 	config Config
+	db     *sql.DB
 }
 
 // Global config service instance
@@ -25,10 +30,21 @@ func GetConfigService() *ConfigService {
 		globalConfigService = &ConfigService{
 			config: Config{
 				LinkMetadataEnabled: true, // Enabled by default
+				MFARequired:         false,
 			},
 		}
 	})
 	return globalConfigService
+}
+
+// InitConfigService wires the config service to the database and loads persisted config.
+func InitConfigService(ctx context.Context, db *sql.DB) error {
+	service := GetConfigService()
+	service.mu.Lock()
+	service.db = db
+	service.mu.Unlock()
+
+	return service.loadFromDB(ctx)
 }
 
 // GetConfig returns a copy of the current configuration
@@ -39,15 +55,29 @@ func (s *ConfigService) GetConfig() Config {
 }
 
 // UpdateConfig updates the configuration with the provided values
-func (s *ConfigService) UpdateConfig(linkMetadataEnabled *bool) Config {
+func (s *ConfigService) UpdateConfig(ctx context.Context, linkMetadataEnabled *bool, mfaRequired *bool) (Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	updated := s.config
 	if linkMetadataEnabled != nil {
-		s.config.LinkMetadataEnabled = *linkMetadataEnabled
+		updated.LinkMetadataEnabled = *linkMetadataEnabled
+	}
+	if mfaRequired != nil {
+		updated.MFARequired = *mfaRequired
 	}
 
-	return s.config
+	if s.db != nil {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if err := s.persistConfig(ctx, updated); err != nil {
+			return s.config, err
+		}
+	}
+
+	s.config = updated
+	return s.config, nil
 }
 
 // IsLinkMetadataEnabled returns whether link metadata fetching is enabled
@@ -55,4 +85,72 @@ func (s *ConfigService) IsLinkMetadataEnabled() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.config.LinkMetadataEnabled
+}
+
+// IsMFARequired returns whether MFA enrollment is required for all users.
+func (s *ConfigService) IsMFARequired() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config.MFARequired
+}
+
+// ResetConfigServiceForTests resets the config service to defaults and clears the database handle.
+func ResetConfigServiceForTests() {
+	service := GetConfigService()
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	service.db = nil
+	service.config = Config{
+		LinkMetadataEnabled: true,
+		MFARequired:         false,
+	}
+}
+
+func (s *ConfigService) loadFromDB(ctx context.Context) error {
+	s.mu.RLock()
+	db := s.db
+	defaults := s.config
+	s.mu.RUnlock()
+	if db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var config Config
+	err := db.QueryRowContext(ctx, `
+		SELECT link_metadata_enabled, mfa_required
+		FROM admin_config
+		WHERE id = 1
+	`).Scan(&config.LinkMetadataEnabled, &config.MFARequired)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			if err := s.persistConfig(ctx, defaults); err != nil {
+				return err
+			}
+			s.mu.Lock()
+			s.config = defaults
+			s.mu.Unlock()
+			return nil
+		}
+		return err
+	}
+
+	s.mu.Lock()
+	s.config = config
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *ConfigService) persistConfig(ctx context.Context, config Config) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO admin_config (id, link_metadata_enabled, mfa_required)
+		VALUES (1, $1, $2)
+		ON CONFLICT (id) DO UPDATE
+		SET link_metadata_enabled = EXCLUDED.link_metadata_enabled,
+			mfa_required = EXCLUDED.mfa_required,
+			updated_at = now()
+	`, config.LinkMetadataEnabled, config.MFARequired)
+	return err
 }

--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -348,8 +348,12 @@ func disableLinkMetadata(t *testing.T) {
 	config := GetConfigService()
 	current := config.GetConfig().LinkMetadataEnabled
 	disabled := false
-	config.UpdateConfig(&disabled)
+	if _, err := config.UpdateConfig(context.Background(), &disabled, nil); err != nil {
+		t.Fatalf("failed to disable link metadata: %v", err)
+	}
 	t.Cleanup(func() {
-		config.UpdateConfig(&current)
+		if _, err := config.UpdateConfig(context.Background(), &current, nil); err != nil {
+			t.Fatalf("failed to restore link metadata: %v", err)
+		}
 	})
 }

--- a/backend/internal/testutil/testutil.go
+++ b/backend/internal/testutil/testutil.go
@@ -92,6 +92,7 @@ func CleanupTables(t *testing.T, db *sql.DB) {
 	// The order matters due to foreign key constraints - CASCADE handles this
 	_, err := db.Exec(`
 		TRUNCATE TABLE
+			admin_config,
 			mfa_backup_codes,
 			auth_events,
 			audit_logs,

--- a/backend/migrations/022_create_admin_config_table.down.sql
+++ b/backend/migrations/022_create_admin_config_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS admin_config;

--- a/backend/migrations/022_create_admin_config_table.up.sql
+++ b/backend/migrations/022_create_admin_config_table.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS admin_config (
+    id SMALLINT PRIMARY KEY,
+    link_metadata_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    mfa_required BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO admin_config (id)
+VALUES (1)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- add persisted admin config with mfa_required and bootstrap loading
- enforce MFA-required logins with explicit setup-required error flag
- extend admin audit logging/tests and add admin_config migration

## Testing
- go test ./internal/handlers -run 'TestLoginMFASetupRequired|TestUpdateConfigAuditLogMFARequired|TestUpdateConfigPersistsToDB' -v (DB tests skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #391