### PR TITLE
[Medium] Add missing metrics (search, cache, uploads, admin actions)

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -137,6 +137,7 @@ func (h *AdminHandler) ApproveUser(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	observability.RecordAdminAction(r.Context(), "approve_user")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -204,6 +205,7 @@ func (h *AdminHandler) PromoteUser(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
+	observability.RecordAdminAction(r.Context(), "promote_user")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -253,6 +255,7 @@ func (h *AdminHandler) RejectUser(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	observability.RecordAdminAction(r.Context(), "reject_user")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -309,6 +312,7 @@ func (h *AdminHandler) EnrollTOTP(w http.ResponseWriter, r *http.Request) {
 	h.logAdminAudit(r.Context(), "enroll_mfa", session.UserID, map[string]interface{}{
 		"method": "totp",
 	})
+	observability.RecordAdminAction(r.Context(), "enroll_mfa")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -379,6 +383,7 @@ func (h *AdminHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 	h.logAdminAudit(r.Context(), "enable_mfa", session.UserID, map[string]interface{}{
 		"method": "totp",
 	})
+	observability.RecordAdminAction(r.Context(), "enable_mfa")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -429,6 +434,7 @@ func (h *AdminHandler) HardDeletePost(w http.ResponseWriter, r *http.Request) {
 		ID:      postID,
 		Message: "Post permanently deleted",
 	}
+	observability.RecordAdminAction(r.Context(), "hard_delete_post")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -479,6 +485,7 @@ func (h *AdminHandler) HardDeleteComment(w http.ResponseWriter, r *http.Request)
 		ID:      commentID,
 		Message: "Comment permanently deleted",
 	}
+	observability.RecordAdminAction(r.Context(), "hard_delete_comment")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -531,6 +538,7 @@ func (h *AdminHandler) AdminRestorePost(w http.ResponseWriter, r *http.Request) 
 	response := models.RestorePostResponse{
 		Post: *post,
 	}
+	observability.RecordAdminAction(r.Context(), "restore_post")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -583,6 +591,7 @@ func (h *AdminHandler) AdminRestoreComment(w http.ResponseWriter, r *http.Reques
 	response := models.RestoreCommentResponse{
 		Comment: *comment,
 	}
+	observability.RecordAdminAction(r.Context(), "restore_comment")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -666,6 +675,7 @@ func (h *AdminHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 			"old_value": previousConfig.LinkMetadataEnabled,
 			"new_value": config.LinkMetadataEnabled,
 		})
+		observability.RecordAdminAction(r.Context(), "toggle_link_metadata")
 	}
 	if mfaRequired != nil && previousConfig.MFARequired != config.MFARequired {
 		h.logAdminAudit(r.Context(), "toggle_mfa_requirement", uuid.Nil, map[string]interface{}{
@@ -673,6 +683,7 @@ func (h *AdminHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 			"old_value": previousConfig.MFARequired,
 			"new_value": config.MFARequired,
 		})
+		observability.RecordAdminAction(r.Context(), "toggle_mfa_requirement")
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1218,6 +1229,7 @@ func (h *AdminHandler) GeneratePasswordResetToken(w http.ResponseWriter, r *http
 		ExpiresAt: token.ExpiresAt,
 	}
 	h.logAdminAudit(r.Context(), "generate_password_reset_token", req.UserID, nil)
+	observability.RecordAdminAction(r.Context(), "generate_password_reset_token")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -926,6 +926,7 @@ func (h *AdminHandler) GetAuditLogs(w http.ResponseWriter, r *http.Request) {
 		HasMore:    hasMore,
 		NextCursor: nextCursor,
 	}
+	observability.RecordAdminAuditLogView(r.Context())
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/handlers/comment.go
+++ b/backend/internal/handlers/comment.go
@@ -178,6 +178,7 @@ func (h *CommentHandler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	observability.RecordCommentUpdated(r.Context())
 
 	response := models.UpdateCommentResponse{
 		Comment: *comment,

--- a/backend/internal/handlers/post.go
+++ b/backend/internal/handlers/post.go
@@ -173,6 +173,7 @@ func (h *PostHandler) UpdatePost(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	observability.RecordPostUpdated(r.Context())
 
 	response := models.UpdatePostResponse{
 		Post: *post,

--- a/backend/internal/handlers/search.go
+++ b/backend/internal/handlers/search.go
@@ -89,7 +89,6 @@ func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
 	searchStart := time.Now()
 	meaningful, err := h.searchService.IsQueryMeaningful(r.Context(), q)
 	if err != nil {
-		observability.RecordSearchFailure(r.Context(), scope, "query_check_failed")
 		writeError(r.Context(), w, http.StatusInternalServerError, "SEARCH_FAILED", "Failed to search")
 		return
 	}
@@ -103,11 +102,10 @@ func (h *SearchHandler) Search(w http.ResponseWriter, r *http.Request) {
 
 	results, err := h.searchService.Search(r.Context(), q, scope, sectionID, limit, userID)
 	if err != nil {
-		observability.RecordSearchFailure(r.Context(), scope, "search_failed")
 		writeError(r.Context(), w, http.StatusInternalServerError, "SEARCH_FAILED", "Failed to search")
 		return
 	}
-	observability.RecordSearchRequest(r.Context(), scope, len(results) > 0, time.Since(searchStart))
+	observability.RecordSearchQuery(r.Context(), scope, len(results), time.Since(searchStart))
 
 	response := models.SearchResponse{Results: results}
 	w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/handlers/section.go
+++ b/backend/internal/handlers/section.go
@@ -78,6 +78,7 @@ func (h *SectionHandler) GetSection(w http.ResponseWriter, r *http.Request) {
 		writeError(r.Context(), w, http.StatusInternalServerError, "GET_SECTION_FAILED", "Failed to get section")
 		return
 	}
+	observability.RecordSectionView(r.Context(), sectionID.String())
 
 	response := models.GetSectionResponse{
 		Section: *section,

--- a/backend/internal/handlers/uploads.go
+++ b/backend/internal/handlers/uploads.go
@@ -73,14 +73,14 @@ func (h *UploadHandler) UploadDir() string {
 // UploadImage handles POST /api/v1/uploads.
 func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		observability.RecordUploadFailure(r.Context(), "method_not_allowed")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
 		return
 	}
 
 	userID, err := middleware.GetUserIDFromContext(r.Context())
 	if err != nil || userID == uuid.Nil {
-		observability.RecordUploadFailure(r.Context(), "unauthorized")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Authentication required")
 		return
 	}
@@ -88,11 +88,11 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxBytes+uploadFormOverhead)
 	if err := r.ParseMultipartForm(h.maxBytes); err != nil {
 		if isRequestBodyTooLarge(err) {
-			observability.RecordUploadFailure(r.Context(), "file_too_large")
+			observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "FILE_TOO_LARGE", "Image exceeds the upload size limit")
 			return
 		}
-		observability.RecordUploadFailure(r.Context(), "invalid_request")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid upload payload")
 		return
 	}
@@ -105,18 +105,18 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	file, header, err := r.FormFile("file")
 	if err != nil {
 		if errors.Is(err, http.ErrMissingFile) {
-			observability.RecordUploadFailure(r.Context(), "file_required")
+			observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 			writeError(r.Context(), w, http.StatusBadRequest, "FILE_REQUIRED", "Select an image to upload")
 			return
 		}
-		observability.RecordUploadFailure(r.Context(), "invalid_request")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid upload payload")
 		return
 	}
 	defer file.Close()
 
 	if header.Size > h.maxBytes {
-		observability.RecordUploadFailure(r.Context(), "file_too_large")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "FILE_TOO_LARGE", "Image exceeds the upload size limit")
 		return
 	}
@@ -124,12 +124,12 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	sniffBuffer := make([]byte, 512)
 	n, err := io.ReadFull(file, sniffBuffer)
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
-		observability.RecordUploadFailure(r.Context(), "file_read_failed")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Unable to read uploaded file")
 		return
 	}
 	if n == 0 {
-		observability.RecordUploadFailure(r.Context(), "file_empty")
+		observability.RecordUploadAttempt(r.Context(), "failure", "", 0)
 		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Uploaded file is empty")
 		return
 	}
@@ -138,14 +138,14 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	mediaType, _, _ := mime.ParseMediaType(contentType)
 	resolvedExt, ok := h.allowedTypes[mediaType]
 	if !ok {
-		observability.RecordUploadFailure(r.Context(), "invalid_type")
+		observability.RecordUploadAttempt(r.Context(), "failure", mediaType, 0)
 		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_FILE_TYPE", "Only image uploads are supported")
 		return
 	}
 
 	userDir := filepath.Join(h.uploadDir, userID.String())
 	if err := os.MkdirAll(userDir, 0o755); err != nil {
-		observability.RecordUploadFailure(r.Context(), "store_failed")
+		observability.RecordUploadAttempt(r.Context(), "failure", mediaType, 0)
 		writeError(r.Context(), w, http.StatusInternalServerError, "UPLOAD_FAILED", "Failed to store image")
 		return
 	}
@@ -154,18 +154,18 @@ func (h *UploadHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	filePath := filepath.Join(userDir, fileName)
 	if err := writeUploadFile(filePath, sniffBuffer[:n], file, h.maxBytes); err != nil {
 		if errors.Is(err, errUploadTooLarge) {
-			observability.RecordUploadFailure(r.Context(), "file_too_large")
+			observability.RecordUploadAttempt(r.Context(), "failure", mediaType, 0)
 			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "FILE_TOO_LARGE", "Image exceeds the upload size limit")
 			return
 		}
-		observability.RecordUploadFailure(r.Context(), "store_failed")
+		observability.RecordUploadAttempt(r.Context(), "failure", mediaType, 0)
 		writeError(r.Context(), w, http.StatusInternalServerError, "UPLOAD_FAILED", "Failed to store image")
 		return
 	}
 
 	url := fmt.Sprintf("/api/v1/uploads/%s/%s", userID.String(), fileName)
 	observability.LogInfo(r.Context(), "image uploaded", "user_id", userID.String(), "path", fileName)
-	observability.RecordUploadSuccess(r.Context(), header.Size, mediaType)
+	observability.RecordUploadAttempt(r.Context(), "success", mediaType, header.Size)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/services/csrf.go
+++ b/backend/internal/services/csrf.go
@@ -67,12 +67,12 @@ func (s *CSRFService) ValidateToken(ctx context.Context, token string, sessionID
 	value, err := s.redis.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
-			observability.RecordCacheMiss(ctx, "csrf", "validate")
+			observability.RecordCacheMiss(ctx, "csrf")
 			return ErrCSRFTokenNotFound
 		}
 		return fmt.Errorf("failed to get CSRF token from Redis: %w", err)
 	}
-	observability.RecordCacheHit(ctx, "csrf", "validate")
+	observability.RecordCacheHit(ctx, "csrf")
 
 	// Verify the token is for this session and user
 	expectedValue := fmt.Sprintf("%s:%s", sessionID, userID.String())

--- a/backend/internal/services/password_reset.go
+++ b/backend/internal/services/password_reset.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
+	"github.com/sanderginn/clubhouse/internal/observability"
 )
 
 const (
@@ -88,10 +89,12 @@ func (s *PasswordResetService) GetToken(ctx context.Context, token string) (*Pas
 	tokenJSON, err := s.redis.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
+			observability.RecordCacheMiss(ctx, "password_reset", "get")
 			return nil, ErrPasswordResetTokenNotFound
 		}
 		return nil, fmt.Errorf("failed to get password reset token from Redis: %w", err)
 	}
+	observability.RecordCacheHit(ctx, "password_reset", "get")
 
 	var resetToken PasswordResetToken
 	if err := json.Unmarshal([]byte(tokenJSON), &resetToken); err != nil {
@@ -142,6 +145,7 @@ func (s *PasswordResetService) ClaimToken(ctx context.Context, token string) (*P
 	result, err := s.redis.Eval(ctx, script, []string{key}).Result()
 	if err != nil {
 		if err == redis.Nil {
+			observability.RecordCacheMiss(ctx, "password_reset", "claim")
 			return nil, ErrPasswordResetTokenNotFound
 		}
 		return nil, fmt.Errorf("failed to execute atomic claim-token script: %w", err)
@@ -149,12 +153,15 @@ func (s *PasswordResetService) ClaimToken(ctx context.Context, token string) (*P
 
 	resultStr, ok := result.(string)
 	if !ok {
+		observability.RecordCacheMiss(ctx, "password_reset", "claim")
 		return nil, ErrPasswordResetTokenNotFound
 	}
 
 	if resultStr == "" {
+		observability.RecordCacheHit(ctx, "password_reset", "claim")
 		return nil, ErrPasswordResetTokenAlreadyUsed
 	}
+	observability.RecordCacheHit(ctx, "password_reset", "claim")
 
 	var resetToken PasswordResetToken
 	if err := json.Unmarshal([]byte(resultStr), &resetToken); err != nil {

--- a/backend/internal/services/rate_limiter.go
+++ b/backend/internal/services/rate_limiter.go
@@ -93,6 +93,11 @@ func (l *RateLimiter) Allow(ctx context.Context, key string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if current <= 1 {
+		observability.RecordCacheMiss(ctx, "rate_limit")
+	} else {
+		observability.RecordCacheHit(ctx, "rate_limit")
+	}
 
 	if current > l.limit {
 		observability.RecordRateLimitViolation(ctx, l.limitType)

--- a/backend/internal/services/session.go
+++ b/backend/internal/services/session.go
@@ -87,14 +87,14 @@ func (s *SessionService) GetSession(ctx context.Context, sessionID string) (*Ses
 	sessionJSON, err := s.redis.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
-			observability.RecordCacheMiss(ctx, "session", "get")
+			observability.RecordCacheMiss(ctx, "session")
 			observability.RecordAuthSessionExpired(ctx, "timeout", 1)
 			observability.RecordAuthFailure(ctx, "expired_session")
 			return nil, ErrSessionNotFound
 		}
 		return nil, fmt.Errorf("failed to get session from Redis: %w", err)
 	}
-	observability.RecordCacheHit(ctx, "session", "get")
+	observability.RecordCacheHit(ctx, "session")
 
 	var session Session
 	if err := json.Unmarshal([]byte(sessionJSON), &session); err != nil {

--- a/backend/internal/services/session.go
+++ b/backend/internal/services/session.go
@@ -87,12 +87,14 @@ func (s *SessionService) GetSession(ctx context.Context, sessionID string) (*Ses
 	sessionJSON, err := s.redis.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
+			observability.RecordCacheMiss(ctx, "session", "get")
 			observability.RecordAuthSessionExpired(ctx, "timeout", 1)
 			observability.RecordAuthFailure(ctx, "expired_session")
 			return nil, ErrSessionNotFound
 		}
 		return nil, fmt.Errorf("failed to get session from Redis: %w", err)
 	}
+	observability.RecordCacheHit(ctx, "session", "get")
 
 	var session Session
 	if err := json.Unmarshal([]byte(sessionJSON), &session); err != nil {


### PR DESCRIPTION
## Summary
- add metrics for search requests, cache hit/miss, uploads, and admin actions
- instrument search, upload, admin handlers plus session/csrf/password reset services
- extend observability metrics registry with new counters/histograms

Closes #422