### PR TITLE
[Medium] Migrate update_post/update_comment audit logging to audit service

### DIFF
--- a/backend/internal/handlers/comment_test.go
+++ b/backend/internal/handlers/comment_test.go
@@ -351,12 +351,12 @@ func TestUpdateCommentSuccess(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT user_id").WithArgs(commentID).
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(userID))
+	mock.ExpectQuery("SELECT c.user_id, c.content, c.post_id, p.section_id").WithArgs(commentID).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "content", "post_id", "section_id"}).AddRow(userID, "Original comment", postID, sectionID))
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE comments").WithArgs("Updated comment", commentID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO audit_logs").WithArgs(userID, commentID, userID).
+	mock.ExpectExec("INSERT INTO audit_logs").WithArgs(userID, "update_comment", userID, userID, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -463,9 +463,9 @@ func TestUpdateCommentForbidden(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT user_id").
+	mock.ExpectQuery("SELECT c.user_id, c.content, c.post_id, p.section_id").
 		WithArgs(commentID).
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(uuid.New()))
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "content", "post_id", "section_id"}).AddRow(uuid.New(), "Original comment", uuid.New(), uuid.New()))
 
 	req, err := http.NewRequest(http.MethodPatch, "/api/v1/comments/"+commentID.String(), bytes.NewReader(body))
 	if err != nil {

--- a/backend/internal/handlers/post_test.go
+++ b/backend/internal/handlers/post_test.go
@@ -755,12 +755,12 @@ func TestUpdatePostSuccess(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT user_id").WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(userID))
+	mock.ExpectQuery("SELECT user_id, content, section_id").WithArgs(postID).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "content", "section_id"}).AddRow(userID, "Original content", sectionID))
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE posts").WithArgs("Updated content", postID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO audit_logs").WithArgs(userID, postID, userID).
+	mock.ExpectExec("INSERT INTO audit_logs").WithArgs(userID, "update_post", userID, userID, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -869,9 +869,9 @@ func TestUpdatePostForbidden(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT user_id").
+	mock.ExpectQuery("SELECT user_id, content, section_id").
 		WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).AddRow(uuid.New()))
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "content", "section_id"}).AddRow(uuid.New(), "Original content", uuid.New()))
 
 	req, err := http.NewRequest(http.MethodPatch, "/api/v1/posts/"+postID.String(), bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
## Summary
- replace update_post/update_comment raw audit inserts with AuditService.LogAuditWithMetadata
- add audit metadata (content excerpts, previous content, link flags, ids)
- extend service and handler tests to cover audit metadata and new query expectations

Closes #424