### PR TITLE
[Low] Add success logging (LogInfo) for CRUD operations

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,6 +139,11 @@ func (h *AdminHandler) ApproveUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	observability.LogInfo(r.Context(), "user approved",
+		"user_id", userID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(approveResponse); err != nil {
@@ -205,6 +211,11 @@ func (h *AdminHandler) PromoteUser(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	observability.LogInfo(r.Context(), "user promoted",
+		"user_id", userID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(promoteResponse); err != nil {
@@ -253,6 +264,11 @@ func (h *AdminHandler) RejectUser(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	observability.LogInfo(r.Context(), "user rejected",
+		"user_id", userID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -430,6 +446,11 @@ func (h *AdminHandler) HardDeletePost(w http.ResponseWriter, r *http.Request) {
 		Message: "Post permanently deleted",
 	}
 
+	observability.LogInfo(r.Context(), "post hard deleted",
+		"post_id", postID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -479,6 +500,11 @@ func (h *AdminHandler) HardDeleteComment(w http.ResponseWriter, r *http.Request)
 		ID:      commentID,
 		Message: "Comment permanently deleted",
 	}
+
+	observability.LogInfo(r.Context(), "comment hard deleted",
+		"comment_id", commentID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -532,6 +558,11 @@ func (h *AdminHandler) AdminRestorePost(w http.ResponseWriter, r *http.Request) 
 		Post: *post,
 	}
 
+	observability.LogInfo(r.Context(), "post restored",
+		"post_id", postID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -583,6 +614,11 @@ func (h *AdminHandler) AdminRestoreComment(w http.ResponseWriter, r *http.Reques
 	response := models.RestoreCommentResponse{
 		Comment: *comment,
 	}
+
+	observability.LogInfo(r.Context(), "comment restored",
+		"comment_id", commentID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -674,6 +710,16 @@ func (h *AdminHandler) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 			"new_value": config.MFARequired,
 		})
 	}
+
+	adminUserID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		adminUserID = uuid.Nil
+	}
+	observability.LogInfo(r.Context(), "config updated",
+		"admin_user_id", adminUserID.String(),
+		"link_metadata_enabled", strconv.FormatBool(config.LinkMetadataEnabled),
+		"mfa_required", strconv.FormatBool(config.MFARequired),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/handlers/comment.go
+++ b/backend/internal/handlers/comment.go
@@ -110,6 +110,17 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	_ = publishMentions(publishCtx, h.redis, mentionedUserIDs, userID, &comment.PostID, &comment.ID)
 	cancel()
 
+	sectionID := ""
+	if comment.SectionID != nil {
+		sectionID = comment.SectionID.String()
+	}
+	observability.LogInfo(r.Context(), "comment created",
+		"comment_id", comment.ID.String(),
+		"user_id", userID.String(),
+		"post_id", comment.PostID.String(),
+		"section_id", sectionID,
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -192,6 +203,17 @@ func (h *CommentHandler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = publishMentions(publishCtx, h.redis, mentionedUserIDs, userID, &comment.PostID, &comment.ID)
 	cancel()
+
+	sectionID := ""
+	if comment.SectionID != nil {
+		sectionID = comment.SectionID.String()
+	}
+	observability.LogInfo(r.Context(), "comment updated",
+		"comment_id", comment.ID.String(),
+		"user_id", userID.String(),
+		"post_id", comment.PostID.String(),
+		"section_id", sectionID,
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -381,6 +403,18 @@ func (h *CommentHandler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 		Message: "Comment deleted successfully",
 	}
 
+	sectionID := ""
+	if comment.SectionID != nil {
+		sectionID = comment.SectionID.String()
+	}
+	observability.LogInfo(r.Context(), "comment deleted",
+		"comment_id", comment.ID.String(),
+		"user_id", userID.String(),
+		"post_id", comment.PostID.String(),
+		"section_id", sectionID,
+		"is_admin", strconv.FormatBool(isAdmin),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -443,6 +477,18 @@ func (h *CommentHandler) RestoreComment(w http.ResponseWriter, r *http.Request) 
 	response := models.RestoreCommentResponse{
 		Comment: *comment,
 	}
+
+	sectionID := ""
+	if comment.SectionID != nil {
+		sectionID = comment.SectionID.String()
+	}
+	observability.LogInfo(r.Context(), "comment restored",
+		"comment_id", comment.ID.String(),
+		"user_id", userID.String(),
+		"post_id", comment.PostID.String(),
+		"section_id", sectionID,
+		"is_admin", strconv.FormatBool(session.IsAdmin),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/handlers/post.go
+++ b/backend/internal/handlers/post.go
@@ -105,6 +105,12 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	_ = publishMentions(publishCtx, h.redis, mentionedUserIDs, userID, &post.ID, nil)
 	cancel()
 
+	observability.LogInfo(r.Context(), "post created",
+		"post_id", post.ID.String(),
+		"user_id", userID.String(),
+		"section_id", post.SectionID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -183,6 +189,12 @@ func (h *PostHandler) UpdatePost(w http.ResponseWriter, r *http.Request) {
 	_ = h.notify.CreateMentionNotifications(publishCtx, mentionedUserIDs, userID, post.SectionID, post.ID, nil)
 	_ = publishMentions(publishCtx, h.redis, mentionedUserIDs, userID, &post.ID, nil)
 	cancel()
+
+	observability.LogInfo(r.Context(), "post updated",
+		"post_id", post.ID.String(),
+		"user_id", userID.String(),
+		"section_id", post.SectionID.String(),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -363,6 +375,13 @@ func (h *PostHandler) DeletePost(w http.ResponseWriter, r *http.Request) {
 		Message: "Post deleted successfully",
 	}
 
+	observability.LogInfo(r.Context(), "post deleted",
+		"post_id", post.ID.String(),
+		"user_id", userID.String(),
+		"section_id", post.SectionID.String(),
+		"is_admin", strconv.FormatBool(isAdmin),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -435,6 +454,13 @@ func (h *PostHandler) RestorePost(w http.ResponseWriter, r *http.Request) {
 	response := models.RestorePostResponse{
 		Post: *post,
 	}
+
+	observability.LogInfo(r.Context(), "post restored",
+		"post_id", post.ID.String(),
+		"user_id", userID.String(),
+		"section_id", post.SectionID.String(),
+		"is_admin", strconv.FormatBool(session.IsAdmin),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/handlers/reaction.go
+++ b/backend/internal/handlers/reaction.go
@@ -101,6 +101,13 @@ func (h *ReactionHandler) AddReactionToPost(w http.ResponseWriter, r *http.Reque
 	observability.RecordReactionAdded(publishCtx, "post")
 	cancel()
 
+	observability.LogInfo(r.Context(), "reaction added",
+		"reaction_id", reaction.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"emoji", reaction.Emoji,
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -216,6 +223,12 @@ func (h *ReactionHandler) RemoveReactionFromPost(w http.ResponseWriter, r *http.
 	observability.RecordReactionRemoved(publishCtx, "post")
 	cancel()
 
+	observability.LogInfo(r.Context(), "reaction removed",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"emoji", emoji,
+	)
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -284,6 +297,13 @@ func (h *ReactionHandler) AddReactionToComment(w http.ResponseWriter, r *http.Re
 	}
 	observability.RecordReactionAdded(publishCtx, "comment")
 	cancel()
+
+	observability.LogInfo(r.Context(), "reaction added",
+		"reaction_id", reaction.ID.String(),
+		"user_id", userID.String(),
+		"comment_id", commentID.String(),
+		"emoji", reaction.Emoji,
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -400,6 +420,12 @@ func (h *ReactionHandler) RemoveReactionFromComment(w http.ResponseWriter, r *ht
 	}
 	observability.RecordReactionRemoved(publishCtx, "comment")
 	cancel()
+
+	observability.LogInfo(r.Context(), "reaction removed",
+		"user_id", userID.String(),
+		"comment_id", commentID.String(),
+		"emoji", emoji,
+	)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/handlers/user.go
+++ b/backend/internal/handlers/user.go
@@ -246,6 +246,10 @@ func (h *UserHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	observability.LogInfo(r.Context(), "user profile updated",
+		"user_id", userID.String(),
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -299,6 +303,11 @@ func (h *UserHandler) EnrollMFA(w http.ResponseWriter, r *http.Request) {
 	h.logUserAudit(r.Context(), "enroll_mfa", session.UserID, map[string]interface{}{
 		"method": "totp",
 	})
+
+	observability.LogInfo(r.Context(), "mfa enrollment created",
+		"user_id", session.UserID.String(),
+		"method", "totp",
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -374,6 +383,11 @@ func (h *UserHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
 		"method": "totp",
 	})
 
+	observability.LogInfo(r.Context(), "mfa enabled",
+		"user_id", session.UserID.String(),
+		"method", "totp",
+	)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -440,6 +454,11 @@ func (h *UserHandler) DisableMFA(w http.ResponseWriter, r *http.Request) {
 	h.logUserAudit(r.Context(), "disable_mfa", session.UserID, map[string]interface{}{
 		"method": "totp",
 	})
+
+	observability.LogInfo(r.Context(), "mfa disabled",
+		"user_id", session.UserID.String(),
+		"method", "totp",
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -559,6 +578,12 @@ func (h *UserHandler) UpdateMySectionSubscription(w http.ResponseWriter, r *http
 		}
 		return
 	}
+
+	observability.LogInfo(r.Context(), "section subscription updated",
+		"user_id", userID.String(),
+		"section_id", sectionID.String(),
+		"opted_out", strconv.FormatBool(*req.OptedOut),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- add LogInfo for post/comment CRUD success paths and reaction add/remove
- log admin approvals/rejections, delete/restore actions, and config updates
- log user profile updates, section subscription updates, and MFA state changes

Closes #425