### PR TITLE
Frontend: Admin MFA requirement toggle and user status display

### DIFF
--- a/frontend/src/components/admin/AdminMfaRequirement.svelte
+++ b/frontend/src/components/admin/AdminMfaRequirement.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { api } from '../../services/api';
+
+  interface ConfigResponse {
+    config?: {
+      linkMetadataEnabled?: boolean;
+      mfaRequired?: boolean;
+      mfa_required?: boolean;
+    };
+  }
+
+  interface ApprovedUser {
+    id: string;
+    username: string;
+    email: string;
+    is_admin: boolean;
+    approved_at: string;
+    created_at: string;
+    totp_enabled?: boolean;
+  }
+
+  let isLoading = true;
+  let isSaving = false;
+  let errorMessage = '';
+  let successMessage = '';
+  let mfaRequired = false;
+  let totalUsers = 0;
+  let usersWithoutMfa = 0;
+  let configAbortController: AbortController | null = null;
+  let usersAbortController: AbortController | null = null;
+  let configTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let usersTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const normalizeMfaRequired = (response: ConfigResponse | null): boolean => {
+    const config = response?.config;
+    if (!config) return false;
+    if (typeof config.mfaRequired === 'boolean') return config.mfaRequired;
+    if (typeof config.mfa_required === 'boolean') return config.mfa_required;
+    return false;
+  };
+
+  const clearTimeouts = () => {
+    if (configTimeoutId) {
+      clearTimeout(configTimeoutId);
+      configTimeoutId = null;
+    }
+    if (usersTimeoutId) {
+      clearTimeout(usersTimeoutId);
+      usersTimeoutId = null;
+    }
+  };
+
+  const loadConfig = async () => {
+    configAbortController?.abort();
+    if (configTimeoutId) {
+      clearTimeout(configTimeoutId);
+      configTimeoutId = null;
+    }
+
+    const controller = typeof AbortController === 'undefined' ? null : new AbortController();
+    configAbortController = controller;
+
+    if (controller) {
+      configTimeoutId = setTimeout(() => controller.abort(), 10000);
+    }
+
+    const response = await api.get<ConfigResponse>(
+      '/admin/config',
+      controller ? { signal: controller.signal } : undefined
+    );
+    if (configAbortController === controller) {
+      configAbortController = null;
+      if (configTimeoutId) {
+        clearTimeout(configTimeoutId);
+        configTimeoutId = null;
+      }
+    }
+
+    mfaRequired = normalizeMfaRequired(response);
+  };
+
+  const loadUsers = async () => {
+    usersAbortController?.abort();
+    if (usersTimeoutId) {
+      clearTimeout(usersTimeoutId);
+      usersTimeoutId = null;
+    }
+
+    const controller = typeof AbortController === 'undefined' ? null : new AbortController();
+    usersAbortController = controller;
+
+    if (controller) {
+      usersTimeoutId = setTimeout(() => controller.abort(), 10000);
+    }
+
+    const response = await api.get<ApprovedUser[] | null>(
+      '/admin/users/approved',
+      controller ? { signal: controller.signal } : undefined
+    );
+
+    if (usersAbortController === controller) {
+      usersAbortController = null;
+      if (usersTimeoutId) {
+        clearTimeout(usersTimeoutId);
+        usersTimeoutId = null;
+      }
+    }
+
+    const approvedUsers = Array.isArray(response) ? response : [];
+    totalUsers = approvedUsers.length;
+    usersWithoutMfa = approvedUsers.filter((user) => !user.totp_enabled).length;
+  };
+
+  const refresh = async () => {
+    isLoading = true;
+    errorMessage = '';
+    successMessage = '';
+    try {
+      await Promise.all([loadConfig(), loadUsers()]);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        errorMessage = 'Request timed out. Please try again.';
+      } else {
+        errorMessage = error instanceof Error ? error.message : 'Failed to load MFA settings.';
+      }
+    } finally {
+      isLoading = false;
+    }
+  };
+
+  const confirmEnable = () => {
+    if (typeof window === 'undefined') return true;
+    return window.confirm(
+      'Requiring MFA will block members without MFA until they enroll. Continue?'
+    );
+  };
+
+  const updateRequirement = async (nextValue: boolean) => {
+    if (nextValue && !confirmEnable()) {
+      return;
+    }
+
+    isSaving = true;
+    errorMessage = '';
+    successMessage = '';
+
+    try {
+      const response = await api.patch<ConfigResponse>('/admin/config', {
+        mfa_required: nextValue,
+      });
+      mfaRequired = normalizeMfaRequired(response);
+      successMessage = mfaRequired
+        ? 'MFA requirement enabled for all members.'
+        : 'MFA requirement disabled.';
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Failed to update MFA requirement.';
+    } finally {
+      isSaving = false;
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    void refresh();
+  }
+
+  onDestroy(() => {
+    configAbortController?.abort();
+    usersAbortController?.abort();
+    clearTimeouts();
+  });
+</script>
+
+<section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+  <div class="flex flex-wrap items-start justify-between gap-4">
+    <div>
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-400 font-mono">Policy</p>
+      <h2 class="text-2xl font-serif font-semibold text-slate-900">MFA requirement</h2>
+      <p class="mt-2 text-sm text-slate-600">
+        Require every member to enroll in multi-factor authentication before they can sign in.
+      </p>
+    </div>
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        class={`relative inline-flex h-6 w-11 items-center rounded-full transition disabled:opacity-60 ${
+          mfaRequired ? 'bg-emerald-500' : 'bg-slate-300'
+        }`}
+        role="switch"
+        aria-checked={mfaRequired}
+        aria-label="Require MFA for all users"
+        on:click={() => updateRequirement(!mfaRequired)}
+        disabled={isLoading || isSaving}
+      >
+        <span
+          class={`inline-block h-4 w-4 rounded-full bg-white shadow transition ${
+            mfaRequired ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        ></span>
+      </button>
+      <button
+        type="button"
+        class="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 disabled:opacity-60"
+        on:click={refresh}
+        disabled={isLoading || isSaving}
+      >
+        Refresh
+      </button>
+    </div>
+  </div>
+
+  {#if errorMessage}
+    <div class="mt-6 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+      {errorMessage}
+    </div>
+  {/if}
+
+  {#if successMessage}
+    <div class="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+      {successMessage}
+    </div>
+  {/if}
+
+  <div class="mt-6 grid gap-4 md:grid-cols-[1.2fr,1fr]">
+    <div class="rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
+      <p class="text-xs font-mono uppercase tracking-widest text-slate-500">Status</p>
+      <div class="mt-3 flex flex-wrap items-center gap-3">
+        <span
+          class={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+            mfaRequired ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600'
+          }`}
+        >
+          <span class={`h-2 w-2 rounded-full ${mfaRequired ? 'bg-emerald-500' : 'bg-slate-400'}`}></span>
+          {mfaRequired ? 'MFA required' : 'MFA optional'}
+        </span>
+        {#if isLoading}
+          <span class="text-xs text-slate-400">Loading roster…</span>
+        {:else}
+          <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            {usersWithoutMfa} without MFA · {totalUsers} total
+          </span>
+        {/if}
+      </div>
+      <p class="mt-3 text-sm text-slate-600">
+        Members without MFA will be redirected to enrollment during sign-in when this is enabled.
+      </p>
+    </div>
+
+    <div class="rounded-2xl border border-slate-100 bg-white p-4">
+      <p class="text-xs font-mono uppercase tracking-widest text-slate-400">Before enabling</p>
+      <p class="mt-3 text-sm text-slate-600">
+        Turning on this policy blocks members without MFA until they enroll. Let your community
+        know ahead of time and verify that backup codes are stored.
+      </p>
+    </div>
+  </div>
+</section>

--- a/frontend/src/components/admin/UserResetLinks.svelte
+++ b/frontend/src/components/admin/UserResetLinks.svelte
@@ -8,6 +8,7 @@
     username: string;
     email: string;
     is_admin: boolean;
+    totp_enabled?: boolean;
     approved_at: string;
     created_at: string;
   }
@@ -255,6 +256,19 @@
                 {#if user.is_admin}
                   <span class="rounded-full bg-indigo-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-indigo-600">
                     Admin
+                  </span>
+                {/if}
+                {#if user.totp_enabled === true}
+                  <span class="rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-700">
+                    MFA Enabled
+                  </span>
+                {:else if user.totp_enabled === false}
+                  <span class="rounded-full bg-rose-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-rose-700">
+                    MFA Missing
+                  </span>
+                {:else}
+                  <span class="rounded-full bg-slate-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    MFA Unknown
                   </span>
                 {/if}
               </div>

--- a/frontend/src/components/admin/__tests__/AdminMfaRequirement.test.ts
+++ b/frontend/src/components/admin/__tests__/AdminMfaRequirement.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+const apiGet = vi.hoisted(() => vi.fn());
+const apiPatch = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../services/api', () => ({
+  api: {
+    get: apiGet,
+    patch: apiPatch,
+  },
+}));
+
+const { default: AdminMfaRequirement } = await import('../AdminMfaRequirement.svelte');
+
+const flush = async () => {
+  await tick();
+  await Promise.resolve();
+  await tick();
+};
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPatch.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AdminMfaRequirement', () => {
+  it('shows the current MFA requirement and roster counts', async () => {
+    apiGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/admin/config') {
+        return Promise.resolve({ config: { mfaRequired: false } });
+      }
+      if (endpoint === '/admin/users/approved') {
+        return Promise.resolve([
+          {
+            id: 'user-1',
+            username: 'lena',
+            email: 'lena@example.com',
+            is_admin: false,
+            approved_at: '2024-01-02T00:00:00Z',
+            created_at: '2024-01-01T00:00:00Z',
+            totp_enabled: false,
+          },
+          {
+            id: 'user-2',
+            username: 'marco',
+            email: 'marco@example.com',
+            is_admin: false,
+            approved_at: '2024-01-02T00:00:00Z',
+            created_at: '2024-01-01T00:00:00Z',
+            totp_enabled: true,
+          },
+          {
+            id: 'user-3',
+            username: 'sasha',
+            email: 'sasha@example.com',
+            is_admin: true,
+            approved_at: '2024-01-02T00:00:00Z',
+            created_at: '2024-01-01T00:00:00Z',
+            totp_enabled: false,
+          },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+
+    render(AdminMfaRequirement);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading roster…')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('MFA optional')).toBeInTheDocument();
+    expect(screen.getByText('2 without MFA · 3 total')).toBeInTheDocument();
+  });
+
+  it('updates MFA requirement after confirmation', async () => {
+    apiGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/admin/config') {
+        return Promise.resolve({ config: { mfaRequired: false } });
+      }
+      if (endpoint === '/admin/users/approved') {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(null);
+    });
+    apiPatch.mockResolvedValue({ config: { mfaRequired: true } });
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(AdminMfaRequirement);
+    await flush();
+
+    const toggle = screen.getByRole('switch', { name: /require mfa for all users/i });
+    await fireEvent.click(toggle);
+
+    expect(apiPatch).toHaveBeenCalledWith('/admin/config', { mfa_required: true });
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
+++ b/frontend/src/components/admin/__tests__/UserResetLinks.test.ts
@@ -37,6 +37,7 @@ describe('UserResetLinks', () => {
         username: 'lena',
         email: 'lena@example.com',
         is_admin: false,
+        totp_enabled: false,
         approved_at: '2024-01-02T00:00:00Z',
         created_at: '2024-01-01T00:00:00Z',
       },
@@ -49,6 +50,7 @@ describe('UserResetLinks', () => {
     const profileLink = await screen.findByRole('link', { name: "View lena's profile" });
     expect(profileLink).toHaveAttribute('href', '/users/user-1');
     expect(screen.getByText('lena@example.com')).toBeInTheDocument();
+    expect(screen.getByText('MFA Missing')).toBeInTheDocument();
     if (typeof AbortController === 'undefined') {
       expect(apiGet).toHaveBeenCalledWith('/admin/users/approved');
     } else {

--- a/frontend/src/routes/AdminPanel.svelte
+++ b/frontend/src/routes/AdminPanel.svelte
@@ -4,6 +4,7 @@
   import AuditLogs from '../components/admin/AuditLogs.svelte';
   import UserResetLinks from '../components/admin/UserResetLinks.svelte';
   import AdminTotpSetup from '../components/admin/AdminTotpSetup.svelte';
+  import AdminMfaRequirement from '../components/admin/AdminMfaRequirement.svelte';
 
   type AdminTab = 'pending' | 'users' | 'audit' | 'security';
 
@@ -104,7 +105,10 @@
       {:else if activeTab === 'audit'}
         <AuditLogs />
       {:else}
-        <AdminTotpSetup />
+        <div class="space-y-6">
+          <AdminMfaRequirement />
+          <AdminTotpSetup />
+        </div>
       {/if}
     </div>
   </section>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -19,6 +19,8 @@ const CSRF_ERROR_CODES = new Set(['CSRF_TOKEN_REQUIRED', 'INVALID_CSRF_TOKEN']);
 interface ApiError {
   error: string;
   code: string;
+  mfa_required?: boolean;
+  mfaRequired?: boolean;
 }
 
 interface ApiResponse<T> {
@@ -194,8 +196,11 @@ class ApiClient {
 
         const error = new Error(errorData?.error ?? 'An unexpected error occurred') as Error & {
           code?: string;
+          mfaRequired?: boolean;
         };
         error.code = errorData?.code ?? 'UNKNOWN_ERROR';
+        error.mfaRequired =
+          errorData?.mfa_required ?? errorData?.mfaRequired ?? false;
         const logContext = {
           endpoint,
           method,


### PR DESCRIPTION
## Summary
- add admin MFA requirement panel with roster counts and confirmation warning
- show MFA status badges on approved members list
- handle MFA setup required login messaging and propagate mfa_required API errors

## Testing
- frontend-checks (svelte-check + vitest)

Closes #392