### PR TITLE
[Medium] Add audit logging for reaction operations

### DIFF
--- a/backend/internal/services/reaction_test.go
+++ b/backend/internal/services/reaction_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -30,6 +31,51 @@ func TestAddReactionToPost(t *testing.T) {
 	}
 }
 
+func TestAddReactionToPostCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "auditpostreaction", "auditpostreaction@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Audit Post Reaction", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Audit reaction post")
+
+	service := NewReactionService(db)
+	_, err := service.AddReactionToPost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), "🔥")
+	if err != nil {
+		t.Fatalf("AddReactionToPost failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'add_reaction' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["target"] != "post" {
+		t.Errorf("expected target post, got %v", metadata["target"])
+	}
+	if metadata["target_id"] != postID {
+		t.Errorf("expected target_id %s, got %v", postID, metadata["target_id"])
+	}
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if metadata["emoji"] != "🔥" {
+		t.Errorf("expected emoji 🔥, got %v", metadata["emoji"])
+	}
+}
+
 func TestRemoveReaction(t *testing.T) {
 	db := testutil.RequireTestDB(t)
 	t.Cleanup(func() { testutil.CleanupTables(t, db) })
@@ -49,6 +95,157 @@ func TestRemoveReaction(t *testing.T) {
 	err = service.RemoveReactionFromPost(context.Background(), uuid.MustParse(postID), "👍", uuid.MustParse(userID))
 	if err != nil {
 		t.Fatalf("RemoveReactionFromPost failed: %v", err)
+	}
+}
+
+func TestRemoveReactionFromPostCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "auditremovereaction", "auditremovereaction@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Audit Remove Reaction", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post for remove reaction")
+
+	service := NewReactionService(db)
+	_, err := service.AddReactionToPost(context.Background(), uuid.MustParse(postID), uuid.MustParse(userID), "👍")
+	if err != nil {
+		t.Fatalf("AddReactionToPost failed: %v", err)
+	}
+
+	if err := service.RemoveReactionFromPost(context.Background(), uuid.MustParse(postID), "👍", uuid.MustParse(userID)); err != nil {
+		t.Fatalf("RemoveReactionFromPost failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'remove_reaction' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["target"] != "post" {
+		t.Errorf("expected target post, got %v", metadata["target"])
+	}
+	if metadata["target_id"] != postID {
+		t.Errorf("expected target_id %s, got %v", postID, metadata["target_id"])
+	}
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if metadata["emoji"] != "👍" {
+		t.Errorf("expected emoji 👍, got %v", metadata["emoji"])
+	}
+}
+
+func TestAddReactionToCommentCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "auditcommentreaction", "auditcommentreaction@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Audit Comment Reaction", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post for comment reaction")
+	commentID := testutil.CreateTestComment(t, db, userID, postID, "Comment for reaction")
+
+	service := NewReactionService(db)
+	_, err := service.AddReactionToComment(context.Background(), uuid.MustParse(commentID), uuid.MustParse(userID), "✅")
+	if err != nil {
+		t.Fatalf("AddReactionToComment failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'add_reaction' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["target"] != "comment" {
+		t.Errorf("expected target comment, got %v", metadata["target"])
+	}
+	if metadata["target_id"] != commentID {
+		t.Errorf("expected target_id %s, got %v", commentID, metadata["target_id"])
+	}
+	if metadata["comment_id"] != commentID {
+		t.Errorf("expected comment_id %s, got %v", commentID, metadata["comment_id"])
+	}
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if metadata["emoji"] != "✅" {
+		t.Errorf("expected emoji ✅, got %v", metadata["emoji"])
+	}
+}
+
+func TestRemoveReactionFromCommentCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "auditremovecommentreaction", "auditremovecommentreaction@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Audit Remove Comment Reaction", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post for remove comment reaction")
+	commentID := testutil.CreateTestComment(t, db, userID, postID, "Comment for remove reaction")
+
+	service := NewReactionService(db)
+	_, err := service.AddReactionToComment(context.Background(), uuid.MustParse(commentID), uuid.MustParse(userID), "❌")
+	if err != nil {
+		t.Fatalf("AddReactionToComment failed: %v", err)
+	}
+
+	if err := service.RemoveReactionFromComment(context.Background(), uuid.MustParse(commentID), "❌", uuid.MustParse(userID)); err != nil {
+		t.Fatalf("RemoveReactionFromComment failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'remove_reaction' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["target"] != "comment" {
+		t.Errorf("expected target comment, got %v", metadata["target"])
+	}
+	if metadata["target_id"] != commentID {
+		t.Errorf("expected target_id %s, got %v", commentID, metadata["target_id"])
+	}
+	if metadata["comment_id"] != commentID {
+		t.Errorf("expected comment_id %s, got %v", commentID, metadata["comment_id"])
+	}
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if metadata["emoji"] != "❌" {
+		t.Errorf("expected emoji ❌, got %v", metadata["emoji"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add audit logging for add/remove reactions on posts and comments with target metadata
- include comment post_id lookup for comment reaction audits
- add service tests for reaction audit logs

## Testing
- cd backend && go build ./...
- cd backend && go test ./internal/services -run Reaction -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #421