### PR TITLE
Backend: Add admin timezone configuration endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -138,6 +138,7 @@ func main() {
 
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(dbConn, redisConn)
+	configHandler := handlers.NewConfigHandler()
 	pushService := services.NewPushService(dbConn)
 	postHandler := handlers.NewPostHandler(dbConn, redisConn, pushService)
 	commentHandler := handlers.NewCommentHandler(dbConn, redisConn, pushService)
@@ -163,6 +164,7 @@ func main() {
 	}
 
 	// API routes
+	mux.Handle("/api/v1/config", http.HandlerFunc(configHandler.GetPublicConfig))
 	mux.HandleFunc("/api/v1/auth/register", authHandler.Register)
 	mux.HandleFunc("/api/v1/auth/login", authHandler.Login)
 	mux.Handle("/api/v1/auth/logout", requireAuthCSRF(http.HandlerFunc(authHandler.Logout)))

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/sanderginn/clubhouse/internal/cache"
 	"github.com/sanderginn/clubhouse/internal/db"

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -158,7 +158,7 @@ func TestLoginMFASetupRequired(t *testing.T) {
 	t.Cleanup(services.ResetConfigServiceForTests)
 
 	required := true
-	if _, err := services.GetConfigService().UpdateConfig(context.Background(), nil, &required); err != nil {
+	if _, err := services.GetConfigService().UpdateConfig(context.Background(), nil, &required, nil); err != nil {
 		t.Fatalf("failed to enable mfa_required: %v", err)
 	}
 

--- a/backend/internal/handlers/config.go
+++ b/backend/internal/handlers/config.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// PublicConfigResponse wraps public config for the frontend.
+type PublicConfigResponse struct {
+	Config PublicConfig `json:"config"`
+}
+
+// PublicConfig represents publicly available configuration values.
+type PublicConfig struct {
+	DisplayTimezone string `json:"displayTimezone"`
+}
+
+// ConfigHandler handles public configuration endpoints.
+type ConfigHandler struct{}
+
+// NewConfigHandler creates a new ConfigHandler.
+func NewConfigHandler() *ConfigHandler {
+	return &ConfigHandler{}
+}
+
+// GetPublicConfig returns the public configuration.
+func (h *ConfigHandler) GetPublicConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	config := services.GetConfigService().GetConfig()
+	response := PublicConfigResponse{
+		Config: PublicConfig{
+			DisplayTimezone: config.DisplayTimezone,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode public config response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}

--- a/backend/internal/handlers/config_test.go
+++ b/backend/internal/handlers/config_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+func TestGetPublicConfig(t *testing.T) {
+	services.ResetConfigServiceForTests()
+	configService := services.GetConfigService()
+	t.Cleanup(func() { services.ResetConfigServiceForTests() })
+
+	timezone := "America/Los_Angeles"
+	if _, err := configService.UpdateConfig(context.Background(), nil, nil, &timezone); err != nil {
+		t.Fatalf("failed to set display timezone: %v", err)
+	}
+
+	handler := NewConfigHandler()
+	req := httptest.NewRequest("GET", "/api/v1/config", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetPublicConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Config struct {
+			DisplayTimezone string `json:"displayTimezone"`
+		} `json:"config"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Config.DisplayTimezone != timezone {
+		t.Fatalf("expected displayTimezone %s, got %s", timezone, response.Config.DisplayTimezone)
+	}
+}

--- a/backend/internal/handlers/links_test.go
+++ b/backend/internal/handlers/links_test.go
@@ -83,12 +83,12 @@ func TestPreviewLinkSuccess(t *testing.T) {
 func TestPreviewLinkDisabled(t *testing.T) {
 	configService := services.GetConfigService()
 	disabled := false
-	if _, err := configService.UpdateConfig(context.Background(), &disabled, nil); err != nil {
+	if _, err := configService.UpdateConfig(context.Background(), &disabled, nil, nil); err != nil {
 		t.Fatalf("failed to disable link metadata: %v", err)
 	}
 	defer func() {
 		enabled := true
-		if _, err := configService.UpdateConfig(context.Background(), &enabled, nil); err != nil {
+		if _, err := configService.UpdateConfig(context.Background(), &enabled, nil, nil); err != nil {
 			t.Fatalf("failed to re-enable link metadata: %v", err)
 		}
 	}()
@@ -137,7 +137,7 @@ func TestPreviewLinkInvalidBody(t *testing.T) {
 
 func TestPreviewLinkRequestTooLarge(t *testing.T) {
 	enabled := true
-	if _, err := services.GetConfigService().UpdateConfig(context.Background(), &enabled, nil); err != nil {
+	if _, err := services.GetConfigService().UpdateConfig(context.Background(), &enabled, nil, nil); err != nil {
 		t.Fatalf("failed to enable link metadata: %v", err)
 	}
 

--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -453,11 +453,11 @@ func disableLinkMetadata(t *testing.T) {
 	config := GetConfigService()
 	current := config.GetConfig().LinkMetadataEnabled
 	disabled := false
-	if _, err := config.UpdateConfig(context.Background(), &disabled, nil); err != nil {
+	if _, err := config.UpdateConfig(context.Background(), &disabled, nil, nil); err != nil {
 		t.Fatalf("failed to disable link metadata: %v", err)
 	}
 	t.Cleanup(func() {
-		if _, err := config.UpdateConfig(context.Background(), &current, nil); err != nil {
+		if _, err := config.UpdateConfig(context.Background(), &current, nil, nil); err != nil {
 			t.Fatalf("failed to restore link metadata: %v", err)
 		}
 	})

--- a/backend/migrations/024_add_display_timezone_to_admin_config.down.sql
+++ b/backend/migrations/024_add_display_timezone_to_admin_config.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE admin_config
+DROP COLUMN IF EXISTS display_timezone;

--- a/backend/migrations/024_add_display_timezone_to_admin_config.up.sql
+++ b/backend/migrations/024_add_display_timezone_to_admin_config.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE admin_config
+ADD COLUMN IF NOT EXISTS display_timezone TEXT NOT NULL DEFAULT 'UTC';
+
+UPDATE admin_config
+SET display_timezone = 'UTC'
+WHERE display_timezone IS NULL OR display_timezone = '';


### PR DESCRIPTION
## Summary
- add display timezone to admin config with validation + persistence
- expose public config endpoint for frontend consumption
- add audit logging and tests for display timezone

Closes #398