### PR TITLE
Frontend: Add timestamp hover tooltip with exact time

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -6,6 +6,7 @@
   import CommentThread from './comments/CommentThread.svelte';
   import EditedBadge from './EditedBadge.svelte';
   import ReactionBar from './reactions/ReactionBar.svelte';
+  import RelativeTime from './RelativeTime.svelte';
   import { buildProfileHref, handleProfileNavigation } from '../services/profileNavigation';
   import { buildThreadHref } from '../services/routeNavigation';
   import LinkifiedText from './LinkifiedText.svelte';
@@ -131,26 +132,6 @@
     }
   }
 
-  function formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-    });
-  }
-
   function getProviderIcon(provider: string | undefined): string {
     switch (provider) {
       case 'spotify':
@@ -250,9 +231,7 @@
           </span>
         {/if}
         <span class="text-gray-400 text-sm">·</span>
-        <time class="text-gray-500 text-sm" datetime={post.createdAt}>
-          {formatDate(post.createdAt)}
-        </time>
+        <RelativeTime dateString={post.createdAt} className="text-gray-500 text-sm" />
         <EditedBadge createdAt={post.createdAt} updatedAt={post.updatedAt} />
         {#if canEdit}
           <div class="ml-auto relative">

--- a/frontend/src/components/RelativeTime.svelte
+++ b/frontend/src/components/RelativeTime.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  export let dateString: string | null | undefined;
+  export let className = '';
+
+  let showTooltip = false;
+  let tooltipId = '';
+
+  $: relativeLabel = formatRelative(dateString);
+  $: exactLabel = formatExact(dateString);
+
+  onMount(() => {
+    tooltipId = `timestamp-tooltip-${Math.random().toString(36).slice(2, 10)}`;
+  });
+
+  function formatRelative(value?: string | null): string {
+    if (!value) return 'Unknown date';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'Unknown date';
+
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+    });
+  }
+
+  function formatExact(value?: string | null): string {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+
+    const datePart = date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    const timePart = date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+
+    return `${datePart} ${timePart}`;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      showTooltip = false;
+    }
+  }
+</script>
+
+<span class="relative inline-flex items-center">
+  <button
+    type="button"
+    class={`inline-flex items-center bg-transparent border-0 p-0 ${className}`}
+    aria-describedby={tooltipId}
+    aria-label={exactLabel ? `Exact time ${exactLabel}` : 'Exact time unavailable'}
+    on:mouseenter={() => (showTooltip = true)}
+    on:mouseleave={() => (showTooltip = false)}
+    on:focus={() => (showTooltip = true)}
+    on:blur={() => (showTooltip = false)}
+    on:click={() => (showTooltip = !showTooltip)}
+    on:keydown={handleKeydown}
+  >
+    <time datetime={dateString ?? ''}>{relativeLabel}</time>
+  </button>
+  {#if showTooltip && exactLabel}
+    <span
+      id={tooltipId}
+      role="tooltip"
+      class="absolute left-1/2 top-full mt-1 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-lg z-20"
+    >
+      {exactLabel}
+    </span>
+  {/if}
+</span>

--- a/frontend/src/components/RelativeTime.svelte
+++ b/frontend/src/components/RelativeTime.svelte
@@ -6,6 +6,7 @@
 
   let showTooltip = false;
   let tooltipId = '';
+  let lastPointerType: string | null = null;
 
   $: relativeLabel = formatRelative(dateString);
   $: exactLabel = formatExact(dateString);
@@ -62,6 +63,18 @@
       showTooltip = false;
     }
   }
+
+  function handlePointerDown(event: PointerEvent) {
+    lastPointerType = event.pointerType;
+  }
+
+  function handleClick() {
+    if (lastPointerType === 'touch') {
+      showTooltip = true;
+      return;
+    }
+    showTooltip = !showTooltip;
+  }
 </script>
 
 <span class="relative inline-flex items-center">
@@ -69,12 +82,17 @@
     type="button"
     class={`inline-flex items-center bg-transparent border-0 p-0 ${className}`}
     aria-describedby={tooltipId}
-    aria-label={exactLabel ? `Exact time ${exactLabel}` : 'Exact time unavailable'}
+    aria-label={
+      exactLabel
+        ? `${relativeLabel}. Exact time ${exactLabel}`
+        : `${relativeLabel}. Exact time unavailable`
+    }
     on:mouseenter={() => (showTooltip = true)}
     on:mouseleave={() => (showTooltip = false)}
     on:focus={() => (showTooltip = true)}
     on:blur={() => (showTooltip = false)}
-    on:click={() => (showTooltip = !showTooltip)}
+    on:pointerdown={handlePointerDown}
+    on:click={handleClick}
     on:keydown={handleKeydown}
   >
     <time datetime={dateString ?? ''}>{relativeLabel}</time>

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -9,6 +9,7 @@
   import ReactionBar from './reactions/ReactionBar.svelte';
   import LinkifiedText from './LinkifiedText.svelte';
   import EditedBadge from './EditedBadge.svelte';
+  import RelativeTime from './RelativeTime.svelte';
   import { buildProfileHref, handleProfileNavigation, returnToFeed } from '../services/profileNavigation';
   import { buildThreadHref } from '../services/routeNavigation';
   import { sections } from '../stores/sectionStore';
@@ -448,26 +449,6 @@
     return items.slice(start, end);
   }
 
-  function formatRelative(dateString: string): string {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-    });
-  }
-
   async function toggleCommentReaction(comment: Comment, emoji: string) {
     const key = `${comment.id}-${emoji}`;
     if (pendingCommentReactions.has(key)) return;
@@ -804,9 +785,7 @@
                         </span>
                       {/if}
                       <span class="text-gray-400 text-sm">commented</span>
-                      <time class="text-gray-500 text-sm" datetime={comment.createdAt}>
-                        {formatRelative(comment.createdAt)}
-                      </time>
+                      <RelativeTime dateString={comment.createdAt} className="text-gray-500 text-sm" />
                       <EditedBadge createdAt={comment.createdAt} updatedAt={comment.updatedAt} />
                     </div>
 
@@ -879,7 +858,7 @@
                         >
                           <div class="text-xs text-gray-500">
                             {item.comment.user?.username ?? 'Unknown'} ·{' '}
-                            {formatRelative(item.comment.createdAt)}
+                            <RelativeTime dateString={item.comment.createdAt} className="text-gray-500 text-xs" />
                           </div>
                           <div class="text-sm text-gray-800">
                             {truncateText(item.comment.content, 160)}

--- a/frontend/src/components/__tests__/RelativeTime.test.ts
+++ b/frontend/src/components/__tests__/RelativeTime.test.ts
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { default: RelativeTime } = await import('../RelativeTime.svelte');
+
+const baseDate = new Date('2026-01-29T08:47:31Z');
+const expectedTooltip = `${baseDate.toLocaleDateString('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})} ${baseDate.toLocaleTimeString('en-US', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})}`;
+
+describe('RelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-29T09:00:00Z'));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('shows exact timestamp tooltip on hover', async () => {
+    render(RelativeTime, { dateString: baseDate.toISOString() });
+
+    expect(screen.queryByText(expectedTooltip)).not.toBeInTheDocument();
+
+    const trigger = screen.getByRole('button');
+    await fireEvent.mouseEnter(trigger);
+
+    expect(screen.getByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('toggles tooltip on click for touch devices', async () => {
+    render(RelativeTime, { dateString: baseDate.toISOString() });
+
+    const trigger = screen.getByRole('button');
+    await fireEvent.click(trigger);
+
+    expect(screen.getByText(expectedTooltip)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -10,6 +10,7 @@
   import ReactionBar from '../reactions/ReactionBar.svelte';
   import LinkifiedText from '../LinkifiedText.svelte';
   import EditedBadge from '../EditedBadge.svelte';
+  import RelativeTime from '../RelativeTime.svelte';
   import { logError } from '../../lib/observability/logger';
   import { recordComponentRender } from '../../lib/observability/performance';
 
@@ -131,26 +132,6 @@
     } finally {
       isSavingComment = false;
     }
-  }
-
-  function formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-    });
   }
 
   function getProviderIcon(provider: string | undefined): string {
@@ -311,9 +292,7 @@
                   </span>
                 {/if}
                 <span class="text-gray-400 text-xs">·</span>
-                <time class="text-gray-500 text-xs" datetime={comment.createdAt}>
-                  {formatDate(comment.createdAt)}
-                </time>
+                <RelativeTime dateString={comment.createdAt} className="text-gray-500 text-xs" />
                 <EditedBadge createdAt={comment.createdAt} updatedAt={comment.updatedAt} />
                 {#if $currentUser?.id === comment.userId}
                   <div class="ml-auto relative">
@@ -531,9 +510,7 @@
                             </span>
                           {/if}
                           <span class="text-gray-400 text-xs">·</span>
-                          <time class="text-gray-500 text-xs" datetime={reply.createdAt}>
-                            {formatDate(reply.createdAt)}
-                          </time>
+                          <RelativeTime dateString={reply.createdAt} className="text-gray-500 text-xs" />
                           <EditedBadge createdAt={reply.createdAt} updatedAt={reply.updatedAt} />
                           {#if $currentUser?.id === reply.userId}
                             <div class="ml-auto relative">

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -19,6 +19,7 @@
   import ReactionBar from '../reactions/ReactionBar.svelte';
   import LinkifiedText from '../LinkifiedText.svelte';
   import EditedBadge from '../EditedBadge.svelte';
+  import RelativeTime from '../RelativeTime.svelte';
   import { api } from '../../services/api';
   import { buildProfileHref, handleProfileNavigation } from '../../services/profileNavigation';
   import { buildThreadHref, pushPath } from '../../services/routeNavigation';
@@ -79,26 +80,6 @@
     } finally {
       pendingReactions.delete(key);
     }
-  }
-
-  function formatDate(dateString: string): string {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-    });
   }
 
   function openPostThread(post: Post | undefined) {
@@ -360,9 +341,7 @@
                               {parentPost.user?.username || 'Unknown'}
                             </span>
                             <span class="text-gray-400 text-xs">·</span>
-                            <time class="text-gray-500 text-xs" datetime={parentPost.createdAt}>
-                              {formatDate(parentPost.createdAt)}
-                            </time>
+                            <RelativeTime dateString={parentPost.createdAt} className="text-gray-500 text-xs" />
                             <EditedBadge createdAt={parentPost.createdAt} updatedAt={parentPost.updatedAt} />
                           </div>
                           <p class="text-gray-800 text-sm whitespace-pre-wrap break-words line-clamp-3">
@@ -439,9 +418,7 @@
                           </span>
                         {/if}
                         <span class="text-gray-400 text-sm">commented</span>
-                        <time class="text-gray-500 text-sm" datetime={comment.createdAt}>
-                          {formatDate(comment.createdAt)}
-                        </time>
+                        <RelativeTime dateString={comment.createdAt} className="text-gray-500 text-sm" />
                         <EditedBadge createdAt={comment.createdAt} updatedAt={comment.updatedAt} />
                       </div>
 
@@ -544,9 +521,7 @@
                       {parentPost.user?.username || 'Unknown'}
                     </span>
                     <span class="text-gray-400 text-xs">·</span>
-                    <time class="text-gray-500 text-xs" datetime={parentPost.createdAt}>
-                      {formatDate(parentPost.createdAt)}
-                    </time>
+                    <RelativeTime dateString={parentPost.createdAt} className="text-gray-500 text-xs" />
                     <EditedBadge createdAt={parentPost.createdAt} updatedAt={parentPost.updatedAt} />
                   </div>
                   <p class="text-gray-800 text-sm whitespace-pre-wrap break-words line-clamp-3">
@@ -634,9 +609,7 @@
                   </span>
                 {/if}
                 <span class="text-gray-400 text-sm">commented</span>
-                <time class="text-gray-500 text-sm" datetime={comment.createdAt}>
-                  {formatDate(comment.createdAt)}
-                </time>
+                <RelativeTime dateString={comment.createdAt} className="text-gray-500 text-sm" />
                 <EditedBadge createdAt={comment.createdAt} updatedAt={comment.updatedAt} />
               </div>
 


### PR DESCRIPTION
## Summary
- add reusable RelativeTime component with hover/tap tooltip for exact timestamps
- swap post/comment/search/profile timestamps to use RelativeTime consistently
- add RelativeTime component tests for hover and tap behavior

## Testing
- `npm run check` (fails: `svelte-check` not found)
- `npm run test -- --grep "RelativeTime"` (fails: `vitest` not found)

Closes #397