### PR TITLE
Frontend: Apply configured timezone to all timestamp displays

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
     activeProfileUserId,
     uiStore,
     threadRouteStore,
+    configStore,
   } from './stores';
   import { parseProfileUserId } from './services/profileNavigation';
   import {
@@ -46,6 +47,7 @@
     authStore.checkSession();
     websocketStore.init();
     pwaStore.init();
+    configStore.load();
     syncRouteFromLocation();
 
     if (typeof window !== 'undefined') {

--- a/frontend/src/components/EditedBadge.svelte
+++ b/frontend/src/components/EditedBadge.svelte
@@ -10,7 +10,7 @@
   let tooltipId = '';
 
   $: isEdited = isEditedAt(createdAt, updatedAt);
-  $: tooltipLabel = updatedAt ? `Edited ${formatEditedAt(updatedAt)}` : '';
+  $: tooltipLabel = updatedAt ? `Edited ${formatEditedAt(updatedAt, $displayTimezone)}` : '';
 
   onMount(() => {
     tooltipId = `edited-tooltip-${Math.random().toString(36).slice(2, 10)}`;
@@ -24,7 +24,7 @@
     return updatedTime > createdTime;
   }
 
-  function formatEditedAt(dateString: string): string {
+  function formatEditedAt(dateString: string, timezone: string | null | undefined): string {
     const date = new Date(dateString);
     if (Number.isNaN(date.getTime())) return '';
     const datePart = formatInTimezone(
@@ -34,7 +34,7 @@
         day: 'numeric',
         year: 'numeric',
       },
-      $displayTimezone
+      timezone
     );
     const timePart = formatInTimezone(
       date,
@@ -44,7 +44,7 @@
         second: '2-digit',
         hour12: false,
       },
-      $displayTimezone
+      timezone
     );
     return `${datePart} ${timePart}`;
   }

--- a/frontend/src/components/EditedBadge.svelte
+++ b/frontend/src/components/EditedBadge.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { displayTimezone } from '../stores';
+  import { formatInTimezone } from '../lib/time';
 
   export let createdAt: string | null | undefined;
   export let updatedAt: string | null | undefined;
@@ -25,17 +27,25 @@
   function formatEditedAt(dateString: string): string {
     const date = new Date(dateString);
     if (Number.isNaN(date.getTime())) return '';
-    const datePart = date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-    const timePart = date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-    });
+    const datePart = formatInTimezone(
+      date,
+      {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      },
+      $displayTimezone
+    );
+    const timePart = formatInTimezone(
+      date,
+      {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      },
+      $displayTimezone
+    );
     return `${datePart} ${timePart}`;
   }
 

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -12,8 +12,10 @@
   import RelativeTime from './RelativeTime.svelte';
   import { buildProfileHref, handleProfileNavigation, returnToFeed } from '../services/profileNavigation';
   import { buildThreadHref } from '../services/routeNavigation';
+  import { displayTimezone } from '../stores';
   import { sections } from '../stores/sectionStore';
   import { getSectionSlugById } from '../services/sectionSlug';
+  import { formatInTimezone } from '../lib/time';
 
   export let userId: string | null;
 
@@ -434,11 +436,15 @@
   function formatDate(dateString?: string | null): string {
     if (!dateString) return 'Unknown date';
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return formatInTimezone(
+      date,
+      {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      },
+      $displayTimezone
+    );
   }
 
   function getPreviewWindow(items: { comment: Comment; depth: number }[], targetId: string) {

--- a/frontend/src/components/__tests__/RelativeTime.test.ts
+++ b/frontend/src/components/__tests__/RelativeTime.test.ts
@@ -1,28 +1,41 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { configStore } from '../../stores';
+import { formatInTimezone } from '../../lib/time';
 
 const { default: RelativeTime } = await import('../RelativeTime.svelte');
 
 const baseDate = new Date('2026-01-29T08:47:31Z');
-const expectedTooltip = `${baseDate.toLocaleDateString('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-})} ${baseDate.toLocaleTimeString('en-US', {
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: false,
-})}`;
+const testTimezone = 'UTC';
+const expectedTooltip = `${formatInTimezone(
+  baseDate,
+  {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  },
+  testTimezone
+)} ${formatInTimezone(
+  baseDate,
+  {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  },
+  testTimezone
+)}`;
 
 describe('RelativeTime', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-29T09:00:00Z'));
+    configStore.setDisplayTimezone(testTimezone);
   });
 
   afterEach(() => {
     cleanup();
+    configStore.setDisplayTimezone(null);
     vi.useRealTimers();
   });
 

--- a/frontend/src/components/admin/AdminTimezoneSetting.svelte
+++ b/frontend/src/components/admin/AdminTimezoneSetting.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { api } from '../../services/api';
+  import { configStore } from '../../stores';
+  import { formatInTimezone } from '../../lib/time';
+
+  interface ConfigResponse {
+    config?: {
+      displayTimezone?: string;
+      display_timezone?: string;
+    };
+  }
+
+  const baseTimezones = [
+    { value: 'UTC', label: 'UTC' },
+    { value: 'America/New_York', label: 'America/New_York (ET)' },
+    { value: 'America/Chicago', label: 'America/Chicago (CT)' },
+    { value: 'America/Denver', label: 'America/Denver (MT)' },
+    { value: 'America/Los_Angeles', label: 'America/Los_Angeles (PT)' },
+    { value: 'Europe/London', label: 'Europe/London' },
+    { value: 'Europe/Berlin', label: 'Europe/Berlin' },
+    { value: 'Europe/Paris', label: 'Europe/Paris' },
+    { value: 'Asia/Dubai', label: 'Asia/Dubai' },
+    { value: 'Asia/Singapore', label: 'Asia/Singapore' },
+    { value: 'Asia/Tokyo', label: 'Asia/Tokyo' },
+    { value: 'Australia/Sydney', label: 'Australia/Sydney' },
+  ];
+
+  let isLoading = true;
+  let isSaving = false;
+  let errorMessage = '';
+  let successMessage = '';
+  let selectedTimezone = '';
+  let configAbortController: AbortController | null = null;
+  let configTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const normalizeTimezone = (response: ConfigResponse | null): string => {
+    const config = response?.config;
+    if (!config) return '';
+    if (typeof config.displayTimezone === 'string' && config.displayTimezone.trim() !== '') {
+      return config.displayTimezone.trim();
+    }
+    if (typeof config.display_timezone === 'string' && config.display_timezone.trim() !== '') {
+      return config.display_timezone.trim();
+    }
+    return '';
+  };
+
+  const clearTimeouts = () => {
+    if (configTimeoutId) {
+      clearTimeout(configTimeoutId);
+      configTimeoutId = null;
+    }
+  };
+
+  const loadConfig = async () => {
+    configAbortController?.abort();
+    clearTimeouts();
+
+    const controller = typeof AbortController === 'undefined' ? null : new AbortController();
+    configAbortController = controller;
+
+    if (controller) {
+      configTimeoutId = setTimeout(() => controller.abort(), 10000);
+    }
+
+    isLoading = true;
+    errorMessage = '';
+    successMessage = '';
+
+    try {
+      const response = await api.get<ConfigResponse>(
+        '/admin/config',
+        controller ? { signal: controller.signal } : undefined
+      );
+      const timezone = normalizeTimezone(response);
+      selectedTimezone = timezone || baseTimezones[0].value;
+      configStore.setDisplayTimezone(selectedTimezone || null);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        errorMessage = 'Request timed out. Please try again.';
+      } else {
+        errorMessage = error instanceof Error ? error.message : 'Failed to load timezone settings.';
+      }
+    } finally {
+      if (configAbortController === controller) {
+        configAbortController = null;
+        clearTimeouts();
+        isLoading = false;
+      }
+    }
+  };
+
+  const updateTimezone = async () => {
+    if (!selectedTimezone) return;
+    isSaving = true;
+    errorMessage = '';
+    successMessage = '';
+
+    try {
+      const response = await api.patch<ConfigResponse>('/admin/config', {
+        display_timezone: selectedTimezone,
+      });
+      const timezone = normalizeTimezone(response) || selectedTimezone;
+      selectedTimezone = timezone;
+      configStore.setDisplayTimezone(timezone || null);
+      successMessage = 'Display timezone updated.';
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Failed to update timezone.';
+    } finally {
+      isSaving = false;
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    void loadConfig();
+  }
+
+  onDestroy(() => {
+    configAbortController?.abort();
+    clearTimeouts();
+  });
+
+  $: timezoneOptions =
+    selectedTimezone && !baseTimezones.some((timezone) => timezone.value === selectedTimezone)
+      ? [{ value: selectedTimezone, label: `${selectedTimezone} (custom)` }, ...baseTimezones]
+      : baseTimezones;
+
+  $: previewLabel = selectedTimezone
+    ? formatInTimezone(new Date(), { dateStyle: 'full', timeStyle: 'long' }, selectedTimezone)
+    : 'Select a timezone to preview the current time.';
+</script>
+
+<section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+  <div class="flex flex-wrap items-start justify-between gap-4">
+    <div>
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-400 font-mono">Display</p>
+      <h2 class="text-2xl font-serif font-semibold text-slate-900">Timezone</h2>
+      <p class="mt-2 text-sm text-slate-600">
+        Choose the timezone used for all timestamps across the community.
+      </p>
+    </div>
+    <button
+      type="button"
+      class="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 disabled:opacity-60"
+      on:click={loadConfig}
+      disabled={isLoading || isSaving}
+    >
+      Refresh
+    </button>
+  </div>
+
+  {#if errorMessage}
+    <div class="mt-6 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+      {errorMessage}
+    </div>
+  {/if}
+
+  {#if successMessage}
+    <div class="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+      {successMessage}
+    </div>
+  {/if}
+
+  <div class="mt-6 grid gap-4">
+    <label class="block text-sm font-semibold text-slate-700" for="timezone-select">
+      Display timezone
+    </label>
+    <select
+      id="timezone-select"
+      class="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-sm focus:border-amber-400 focus:outline-none"
+      bind:value={selectedTimezone}
+      disabled={isLoading || isSaving}
+    >
+      {#each timezoneOptions as timezone}
+        <option value={timezone.value}>{timezone.label}</option>
+      {/each}
+    </select>
+    <div class="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600">
+      <p class="text-xs uppercase tracking-[0.2em] text-slate-400 font-mono">Preview</p>
+      <p class="mt-2 font-semibold text-slate-700">{previewLabel}</p>
+    </div>
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        class="rounded-full bg-slate-900 px-5 py-2 text-xs font-semibold text-white shadow transition hover:bg-slate-800 disabled:opacity-60"
+        on:click={updateTimezone}
+        disabled={isLoading || isSaving}
+      >
+        Save timezone
+      </button>
+      <p class="text-xs text-slate-500">Changes apply immediately after saving.</p>
+    </div>
+  </div>
+</section>

--- a/frontend/src/components/admin/AuditLogs.svelte
+++ b/frontend/src/components/admin/AuditLogs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { api } from '../../services/api';
+  import { displayTimezone } from '../../stores';
+  import { formatInTimezone } from '../../lib/time';
   import { replacePath } from '../../services/routeNavigation';
 
   interface AuditLog {
@@ -65,6 +67,8 @@
     delete_post: 'Deleted post',
     delete_comment: 'Deleted comment',
     toggle_link_metadata: 'Toggled link metadata',
+    toggle_mfa_requirement: 'Toggled MFA requirement',
+    update_display_timezone: 'Updated display timezone',
     register_user: 'Registered user',
     update_profile: 'Updated profile',
     suspend_user: 'Suspended user',
@@ -89,8 +93,15 @@
   ]);
 
   const formatAction = (action: string) => actionLabels[action] ?? action.replace(/_/g, ' ');
-  const formatDate = (value: string) =>
-    new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+  const formatDate = (value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'Unknown date';
+    return formatInTimezone(
+      date,
+      { dateStyle: 'medium', timeStyle: 'short' },
+      $displayTimezone
+    );
+  };
 
   const getMetadataValue = (metadata: Record<string, unknown> | null | undefined, key: string) => {
     if (!metadata) return null;

--- a/frontend/src/components/admin/PendingUsers.svelte
+++ b/frontend/src/components/admin/PendingUsers.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { api } from '../../services/api';
+  import { displayTimezone } from '../../stores';
+  import { formatInTimezone } from '../../lib/time';
 
   interface PendingUser {
     id: string;
@@ -16,7 +18,15 @@
   let pendingUsersAbortController: AbortController | null = null;
   let pendingUsersTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  const formatDate = (value: string) => new Date(value).toLocaleString();
+  const formatDate = (value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'Unknown date';
+    return formatInTimezone(
+      date,
+      { dateStyle: 'medium', timeStyle: 'short' },
+      $displayTimezone
+    );
+  };
 
   const clearPendingUsersTimeout = () => {
     if (pendingUsersTimeoutId) {

--- a/frontend/src/components/admin/UserResetLinks.svelte
+++ b/frontend/src/components/admin/UserResetLinks.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { api } from '../../services/api';
+  import { displayTimezone } from '../../stores';
+  import { formatInTimezone } from '../../lib/time';
   import { buildProfileHref, handleProfileNavigation } from '../../services/profileNavigation';
 
   interface AdminUser {
@@ -42,7 +44,15 @@
   let usersAbortController: AbortController | null = null;
   let usersTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  const formatDate = (value: string) => new Date(value).toLocaleString();
+  const formatDate = (value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'Unknown date';
+    return formatInTimezone(
+      date,
+      { dateStyle: 'medium', timeStyle: 'short' },
+      $displayTimezone
+    );
+  };
 
   const clearUsersTimeout = () => {
     if (usersTimeoutId) {

--- a/frontend/src/components/admin/__tests__/AdminTimezoneSetting.test.ts
+++ b/frontend/src/components/admin/__tests__/AdminTimezoneSetting.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { get } from 'svelte/store';
+import { configStore, displayTimezone } from '../../../stores';
+
+const apiGet = vi.hoisted(() => vi.fn());
+const apiPatch = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../services/api', () => ({
+  api: {
+    get: apiGet,
+    patch: apiPatch,
+  },
+}));
+
+const { default: AdminTimezoneSetting } = await import('../AdminTimezoneSetting.svelte');
+
+const flush = async () => {
+  await tick();
+  await Promise.resolve();
+  await tick();
+};
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPatch.mockReset();
+  configStore.setDisplayTimezone(null);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AdminTimezoneSetting', () => {
+  it('loads the configured timezone into the dropdown', async () => {
+    apiGet.mockResolvedValue({ config: { displayTimezone: 'America/New_York' } });
+
+    render(AdminTimezoneSetting);
+    await flush();
+
+    const select = screen.getByLabelText(/display timezone/i) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(select.value).toBe('America/New_York');
+    });
+
+    expect(get(displayTimezone)).toBe('America/New_York');
+  });
+
+  it('saves timezone changes', async () => {
+    apiGet.mockResolvedValue({ config: { displayTimezone: 'America/Los_Angeles' } });
+    apiPatch.mockResolvedValue({ config: { displayTimezone: 'UTC' } });
+
+    render(AdminTimezoneSetting);
+    await flush();
+
+    const select = screen.getByLabelText(/display timezone/i) as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: 'UTC' } });
+
+    const saveButton = screen.getByRole('button', { name: /save timezone/i });
+    await fireEvent.click(saveButton);
+
+    expect(apiPatch).toHaveBeenCalledWith('/admin/config', { display_timezone: 'UTC' });
+    expect(get(displayTimezone)).toBe('UTC');
+  });
+});

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -15,6 +15,7 @@ const storeRefs: {
   searchScope: ReturnType<typeof writable>;
   activeSection: ReturnType<typeof writable>;
   sections: ReturnType<typeof writable>;
+  displayTimezone: ReturnType<typeof writable>;
   sectionStore: { setActiveSection: ReturnType<typeof vi.fn> };
   searchStore: { setQuery: ReturnType<typeof vi.fn> };
   postStore: { upsertPost: ReturnType<typeof vi.fn> };
@@ -32,6 +33,7 @@ vi.mock('../../../stores', () => {
   storeRefs.searchScope = writable<'section' | 'global'>('section');
   storeRefs.activeSection = writable<{ id: string; name: string } | null>(null);
   storeRefs.sections = writable([]);
+  storeRefs.displayTimezone = writable<string | null>(null);
   storeRefs.sectionStore = { setActiveSection: vi.fn() };
   storeRefs.searchStore = { setQuery: vi.fn() };
   storeRefs.postStore = { upsertPost: vi.fn() };
@@ -57,6 +59,7 @@ beforeEach(() => {
   storeRefs.searchScope.set('section');
   storeRefs.activeSection.set(null);
   storeRefs.sections.set([]);
+  storeRefs.displayTimezone.set(null);
 });
 
 afterEach(() => {

--- a/frontend/src/lib/time.ts
+++ b/frontend/src/lib/time.ts
@@ -1,0 +1,30 @@
+export const normalizeTimezone = (timezone?: string | null): string | undefined => {
+  if (!timezone) return undefined;
+  const trimmed = timezone.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const formatInTimezone = (
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  timezone?: string | null
+): string => {
+  const normalized = normalizeTimezone(timezone);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    ...options,
+    ...(normalized ? { timeZone: normalized } : {}),
+  });
+  return formatter.format(date);
+};
+
+export const getYearInTimezone = (date: Date, timezone?: string | null): number => {
+  const normalized = normalizeTimezone(timezone);
+  if (!normalized) return date.getFullYear();
+  const parts = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    timeZone: normalized,
+  }).formatToParts(date);
+  const yearPart = parts.find((part) => part.type === 'year');
+  const year = yearPart ? Number(yearPart.value) : NaN;
+  return Number.isNaN(year) ? date.getFullYear() : year;
+};

--- a/frontend/src/routes/AdminPanel.svelte
+++ b/frontend/src/routes/AdminPanel.svelte
@@ -5,6 +5,7 @@
   import UserResetLinks from '../components/admin/UserResetLinks.svelte';
   import AdminTotpSetup from '../components/admin/AdminTotpSetup.svelte';
   import AdminMfaRequirement from '../components/admin/AdminMfaRequirement.svelte';
+  import AdminTimezoneSetting from '../components/admin/AdminTimezoneSetting.svelte';
 
   type AdminTab = 'pending' | 'users' | 'audit' | 'security';
 
@@ -106,6 +107,7 @@
         <AuditLogs />
       {:else}
         <div class="space-y-6">
+          <AdminTimezoneSetting />
           <AdminMfaRequirement />
           <AdminTotpSetup />
         </div>

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -1,0 +1,81 @@
+import { writable, derived } from 'svelte/store';
+import { api } from '../services/api';
+import { logWarn } from '../lib/observability/logger';
+
+interface ConfigResponse {
+  config?: {
+    displayTimezone?: string;
+    display_timezone?: string;
+  };
+}
+
+interface ConfigState {
+  displayTimezone: string | null;
+  loaded: boolean;
+}
+
+const normalizeTimezone = (response: ConfigResponse | null): string | null => {
+  const config = response?.config;
+  if (!config) return null;
+  if (typeof config.displayTimezone === 'string' && config.displayTimezone.trim() !== '') {
+    return config.displayTimezone.trim();
+  }
+  if (typeof config.display_timezone === 'string' && config.display_timezone.trim() !== '') {
+    return config.display_timezone.trim();
+  }
+  return null;
+};
+
+function createConfigStore() {
+  const { subscribe, update } = writable<ConfigState>({
+    displayTimezone: null,
+    loaded: false,
+  });
+
+  let loadPromise: Promise<void> | null = null;
+
+  const load = async (): Promise<void> => {
+    if (loadPromise) return loadPromise;
+
+    loadPromise = (async () => {
+      try {
+        const response = await api.get<ConfigResponse | null>('/config');
+        const displayTimezone = normalizeTimezone(response);
+        update((state) => ({
+          ...state,
+          displayTimezone,
+          loaded: true,
+        }));
+      } catch (error) {
+        logWarn('Failed to load public config', { error });
+        update((state) => ({
+          ...state,
+          loaded: true,
+        }));
+      }
+    })().finally(() => {
+      loadPromise = null;
+    });
+
+    return loadPromise;
+  };
+
+  const setDisplayTimezone = (displayTimezone: string | null) => {
+    update((state) => ({
+      ...state,
+      displayTimezone,
+      loaded: true,
+    }));
+  };
+
+  return {
+    subscribe,
+    load,
+    setDisplayTimezone,
+  };
+}
+
+export const configStore = createConfigStore();
+
+export const displayTimezone = derived(configStore, ($config) => $config.displayTimezone);
+export const configLoaded = derived(configStore, ($config) => $config.loaded);

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -9,3 +9,4 @@ export * from './websocketStore';
 export * from './searchStore';
 export * from './pwaStore';
 export * from './threadRouteStore';
+export * from './configStore';


### PR DESCRIPTION
## Summary
- load public display timezone config and use it in all timestamp formatters
- add admin timezone selector with preview and save flow
- update timestamp-related tests and admin search mocks for new store export

Closes #399