### PR TITLE
Frontend: Create standalone thread view route

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -17,6 +17,7 @@
   import { recordComponentRender } from '../lib/observability/performance';
 
   export let post: Post;
+  export let highlightCommentId: string | null = null;
 
   $: userReactions = new Set(post.viewerReactions ?? []);
   $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
@@ -407,7 +408,11 @@
       </div>
 
       <div class="mt-4 border-t border-gray-200 pt-4">
-        <CommentThread postId={post.id} commentCount={post.commentCount ?? 0} />
+        <CommentThread
+          postId={post.id}
+          commentCount={post.commentCount ?? 0}
+          {highlightCommentId}
+        />
       </div>
     </div>
   </div>

--- a/frontend/src/components/ThreadView.svelte
+++ b/frontend/src/components/ThreadView.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { activeSection, sections, sectionStore, threadRouteStore, posts } from '../stores';
+  import { loadThreadTargetPost } from '../stores/threadRouteStore';
+  import { buildFeedHref, pushPath } from '../services/routeNavigation';
+  import PostCard from './PostCard.svelte';
+
+  export let highlightCommentId: string | null = null;
+
+  $: threadPost = $threadRouteStore.postId
+    ? $posts.find((post) => post.id === $threadRouteStore.postId) ?? null
+    : null;
+  $: sectionContext = $threadRouteStore.sectionId
+    ? $sections.find((section) => section.id === $threadRouteStore.sectionId) ?? null
+    : null;
+
+  $: if ($threadRouteStore.postId && $threadRouteStore.status === 'idle') {
+    loadThreadTargetPost($threadRouteStore.postId, $threadRouteStore.sectionId);
+  }
+
+  $: if (sectionContext && $activeSection?.id !== sectionContext.id) {
+    sectionStore.setActiveSection(sectionContext);
+  }
+
+  function handleSectionClick() {
+    if (!sectionContext) return;
+    sectionStore.setActiveSection(sectionContext);
+    pushPath(buildFeedHref(sectionContext.slug));
+  }
+</script>
+
+<div class="space-y-4">
+  {#if sectionContext}
+    <button
+      class="inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-900"
+      on:click={handleSectionClick}
+    >
+      <span class="text-lg" aria-hidden="true">{sectionContext.icon}</span>
+      <span class="truncate">{sectionContext.name}</span>
+      <span class="text-gray-400">/ Thread</span>
+    </button>
+  {:else}
+    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400">Thread</div>
+  {/if}
+
+  {#if $threadRouteStore.status === 'loading' && !threadPost}
+    <div class="flex items-center gap-2 text-gray-500 text-sm">
+      <svg
+        class="animate-spin h-4 w-4"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        />
+      </svg>
+      <span>Loading thread...</span>
+    </div>
+  {:else if $threadRouteStore.status === 'not_found'}
+    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
+      This thread is no longer available.
+    </div>
+  {:else if $threadRouteStore.status === 'error'}
+    <div class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
+      Unable to load this thread. {$threadRouteStore.error}
+    </div>
+  {:else if threadPost}
+    <PostCard post={threadPost} {highlightCommentId} />
+  {:else}
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h1 class="text-xl font-semibold text-gray-900 mb-2">Thread unavailable</h1>
+      <p class="text-gray-600">We couldn't load this thread. Try again in a moment.</p>
+    </div>
+  {/if}
+</div>

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -88,7 +88,7 @@
     const targetSectionId = targetSection?.id ?? post.sectionId;
     const targetSectionSlug = targetSection ? getSectionSlug(targetSection) : post.sectionId;
     const switchingSection = targetSection && $activeSection?.id !== targetSection.id;
-    uiStore.setActiveView('feed');
+    uiStore.setActiveView('thread');
     threadRouteStore.setTarget(post.id, targetSectionId);
     pushPath(buildThreadHref(targetSectionSlug, post.id));
     if (switchingSection) {

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -3,11 +3,14 @@ import {
   buildAdminHref,
   buildFeedHref,
   buildSectionHref,
+  buildStandaloneThreadHref,
   buildSettingsHref,
   buildThreadHref,
   isAdminPath,
   isSettingsPath,
+  parseStandaloneThreadPostId,
   parseSectionSlug,
+  parseThreadCommentId,
   parseThreadPostId,
 } from '../routeNavigation';
 
@@ -30,6 +33,20 @@ describe('routeNavigation', () => {
     expect(parseThreadPostId('/sections/section-1')).toBeNull();
     expect(parseThreadPostId('/sections/section-1/posts/')).toBeNull();
     expect(parseThreadPostId('/admin')).toBeNull();
+  });
+
+  it('builds and parses standalone thread hrefs', () => {
+    expect(buildStandaloneThreadHref('post-99')).toBe('/posts/post-99');
+    expect(parseStandaloneThreadPostId('/posts/post-99')).toBe('post-99');
+    expect(parseStandaloneThreadPostId('/posts/post-99/comments')).toBe('post-99');
+    expect(parseStandaloneThreadPostId('/sections/section-1/posts/post-1')).toBeNull();
+  });
+
+  it('parses comment highlight params', () => {
+    expect(parseThreadCommentId('?comment=comment-1')).toBe('comment-1');
+    expect(parseThreadCommentId('?commentId=comment-2')).toBe('comment-2');
+    expect(parseThreadCommentId('?foo=bar')).toBeNull();
+    expect(parseThreadCommentId('')).toBeNull();
   });
 
   it('builds admin hrefs and recognizes admin paths', () => {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -1,4 +1,5 @@
 const SECTION_PATH_PREFIX = '/sections/';
+const THREAD_ROOT_PATH = '/posts/';
 const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
@@ -9,6 +10,10 @@ export function buildSectionHref(sectionSlug: string): string {
 
 export function buildThreadHref(sectionSlug: string, postId: string): string {
   return `${buildSectionHref(sectionSlug)}${THREAD_PATH_SEGMENT}${postId}`;
+}
+
+export function buildStandaloneThreadHref(postId: string): string {
+  return `${THREAD_ROOT_PATH}${postId}`;
 }
 
 export function parseSectionSlug(pathname: string): string | null {
@@ -37,6 +42,22 @@ export function parseThreadPostId(pathname: string): string | null {
   }
   const trimmed = postId?.trim();
   return trimmed ? trimmed : null;
+}
+
+export function parseStandaloneThreadPostId(pathname: string): string | null {
+  if (!pathname.startsWith(THREAD_ROOT_PATH)) {
+    return null;
+  }
+  const remainder = pathname.slice(THREAD_ROOT_PATH.length);
+  const [postId] = remainder.split('/');
+  const trimmed = postId?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function parseThreadCommentId(search: string): string | null {
+  if (!search) return null;
+  const params = new URLSearchParams(search);
+  return params.get('comment') ?? params.get('commentId') ?? null;
 }
 
 export function buildAdminHref(): string {

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -3,7 +3,7 @@ import { writable, derived } from 'svelte/store';
 interface UIState {
   sidebarOpen: boolean;
   isMobile: boolean;
-  activeView: 'feed' | 'admin' | 'profile' | 'settings';
+  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread';
   activeProfileUserId: string | null;
 }
 
@@ -25,7 +25,7 @@ function createUIStore() {
         isMobile,
         sidebarOpen: isMobile ? false : state.sidebarOpen,
       })),
-    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings') =>
+    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread') =>
       update((state) => ({
         ...state,
         activeView,


### PR DESCRIPTION
## Summary
- route standalone thread views for /posts/{id} and /sections/{slug}/posts/{id}
- render dedicated thread view with section context and safe loading behavior
- support URL-driven comment highlighting in thread comments

## Testing
- npm run check

Closes #395