### PR TITLE
Frontend: Add back navigation from standalone thread view

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
     activeSection,
     sections,
     searchQuery,
+    searchStore,
     websocketStore,
     sectionStore,
     activeView,
@@ -26,6 +27,7 @@
   import {
     buildFeedHref,
     buildThreadHref,
+    getHistoryState,
     isAdminPath,
     isSettingsPath,
     parseStandaloneThreadPostId,
@@ -69,6 +71,14 @@
   function syncRouteFromLocation() {
     if (typeof window === 'undefined') return;
     const path = window.location.pathname;
+    const historyState = getHistoryState();
+    const searchState = historyState?.search;
+    if (searchState?.query) {
+      searchStore.setScope(searchState.scope);
+      searchStore.setQuery(searchState.query);
+    } else {
+      searchStore.setQuery('');
+    }
     highlightCommentId = parseThreadCommentId(window.location.search);
     sectionNotFound = null;
     const { isReset, token } = parseResetRoute(window.location);

--- a/frontend/src/components/ThreadView.svelte
+++ b/frontend/src/components/ThreadView.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { activeSection, sections, sectionStore, threadRouteStore, posts } from '../stores';
   import { loadThreadTargetPost } from '../stores/threadRouteStore';
-  import { buildFeedHref, pushPath } from '../services/routeNavigation';
+  import { buildFeedHref, getHistoryState, pushPath } from '../services/routeNavigation';
   import PostCard from './PostCard.svelte';
 
   export let highlightCommentId: string | null = null;
@@ -21,26 +22,51 @@
     sectionStore.setActiveSection(sectionContext);
   }
 
+  let fromSearch = false;
+  onMount(() => {
+    fromSearch = getHistoryState()?.fromSearch === true;
+  });
+
   function handleSectionClick() {
     if (!sectionContext) return;
     sectionStore.setActiveSection(sectionContext);
     pushPath(buildFeedHref(sectionContext.slug));
   }
+
+  function handleSearchBack() {
+    if (typeof window === 'undefined') return;
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+    handleSectionClick();
+  }
 </script>
 
 <div class="space-y-4">
-  {#if sectionContext}
-    <button
-      class="inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-900"
-      on:click={handleSectionClick}
-    >
-      <span class="text-lg" aria-hidden="true">{sectionContext.icon}</span>
-      <span class="truncate">{sectionContext.name}</span>
-      <span class="text-gray-400">/ Thread</span>
-    </button>
-  {:else}
-    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400">Thread</div>
-  {/if}
+  <div class="flex flex-wrap items-center gap-3">
+    {#if fromSearch}
+      <button
+        class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 hover:text-gray-900 hover:border-gray-300"
+        on:click={handleSearchBack}
+      >
+        <span aria-hidden="true">←</span>
+        <span>Back to search results</span>
+      </button>
+    {/if}
+
+    {#if sectionContext}
+      <button
+        class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 hover:text-gray-900 hover:border-gray-300"
+        on:click={handleSectionClick}
+      >
+        <span class="text-base" aria-hidden="true">{sectionContext.icon}</span>
+        <span>Back to {sectionContext.name}</span>
+      </button>
+    {:else}
+      <div class="text-xs font-semibold uppercase tracking-wide text-gray-400">Thread</div>
+    {/if}
+  </div>
 
   {#if $threadRouteStore.status === 'loading' && !threadPost}
     <div class="flex items-center gap-2 text-gray-500 text-sm">

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -90,7 +90,7 @@
     const switchingSection = targetSection && $activeSection?.id !== targetSection.id;
     uiStore.setActiveView('thread');
     threadRouteStore.setTarget(post.id, targetSectionId);
-    pushPath(buildThreadHref(targetSectionSlug, post.id));
+    pushPath(buildThreadHref(targetSectionSlug, post.id), { fromSearch: true });
     if (switchingSection) {
       sectionStore.setActiveSection(targetSection);
     }

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -4,6 +4,16 @@ const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
 
+export type SearchHistoryState = {
+  query: string;
+  scope: 'section' | 'global';
+};
+
+export type AppHistoryState = {
+  search?: SearchHistoryState;
+  fromSearch?: boolean;
+};
+
 export function buildSectionHref(sectionSlug: string): string {
   return `${SECTION_PATH_PREFIX}${encodeURIComponent(sectionSlug)}`;
 }
@@ -80,12 +90,34 @@ export function buildFeedHref(sectionSlug?: string | null): string {
   return sectionSlug ? buildSectionHref(sectionSlug) : '/';
 }
 
-export function pushPath(path: string): void {
+export function pushPath(path: string, state?: AppHistoryState | null): void {
   if (typeof window === 'undefined') return;
-  window.history.pushState(null, '', path);
+  window.history.pushState(state ?? null, '', path);
 }
 
-export function replacePath(path: string): void {
+export function replacePath(path: string, state?: AppHistoryState | null): void {
   if (typeof window === 'undefined') return;
-  window.history.replaceState(null, '', path);
+  window.history.replaceState(state ?? null, '', path);
+}
+
+export function getHistoryState(): AppHistoryState | null {
+  if (typeof window === 'undefined') return null;
+  return (window.history.state as AppHistoryState | null) ?? null;
+}
+
+export function updateHistoryState(nextState: Partial<AppHistoryState>): void {
+  if (typeof window === 'undefined') return;
+  const current = (window.history.state ?? {}) as AppHistoryState;
+  const merged: AppHistoryState = { ...current, ...nextState };
+  if ('search' in nextState && nextState.search === undefined) {
+    delete merged.search;
+  }
+  if ('fromSearch' in nextState && nextState.fromSearch === undefined) {
+    delete merged.fromSearch;
+  }
+  window.history.replaceState(
+    merged,
+    '',
+    window.location.pathname + window.location.search
+  );
 }

--- a/frontend/src/stores/searchStore.ts
+++ b/frontend/src/stores/searchStore.ts
@@ -1,5 +1,6 @@
 import { writable, derived, get } from 'svelte/store';
 import { api } from '../services/api';
+import { updateHistoryState } from '../services/routeNavigation';
 import { activeSection } from './sectionStore';
 import { normalizeLinkMetadata } from './postMapper';
 import type { Post, Link } from './postStore';
@@ -209,6 +210,7 @@ function createSearchStore() {
         lastSearched: '',
         lastSearchedScope: null,
       });
+      updateHistoryState({ search: undefined });
     },
     updateUserProfilePicture: (userId: string, profilePictureUrl?: string) => {
       update((state) => ({
@@ -278,6 +280,7 @@ function createSearchStore() {
           lastSearched: '',
           lastSearchedScope: null,
         }));
+        updateHistoryState({ search: undefined });
         return;
       }
 
@@ -339,6 +342,7 @@ function createSearchStore() {
           lastSearched: query,
           lastSearchedScope: scope,
         }));
+        updateHistoryState({ search: { query, scope } });
       } catch (err) {
         if (currentToken !== requestToken) {
           return;


### PR DESCRIPTION
## Summary
- add history state helpers for search-aware navigation
- restore search context on popstate to support back-to-search behavior
- update thread view to show back-to-search and back-to-section actions

## Testing
- `npm run check` (fails: `svelte-check` not found in environment)

Closes #396