### PR TITLE
[High] Add distributed tracing spans to service layer

### DIFF
--- a/backend/internal/services/auth_event.go
+++ b/backend/internal/services/auth_event.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/sanderginn/clubhouse/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // AuthEventService handles auth event logging.
@@ -20,12 +22,24 @@ func NewAuthEventService(db *sql.DB) *AuthEventService {
 
 // LogEvent records an authentication-related event for auditing.
 func (s *AuthEventService) LogEvent(ctx context.Context, event *models.AuthEventCreate) error {
+	ctx, span := otel.Tracer("clubhouse.auth_events").Start(ctx, "AuthEventService.LogEvent")
+	defer span.End()
+
 	if event == nil {
-		return fmt.Errorf("auth event is required")
+		err := fmt.Errorf("auth event is required")
+		recordSpanError(span, err)
+		return err
 	}
 	if event.EventType == "" {
-		return fmt.Errorf("auth event type is required")
+		err := fmt.Errorf("auth event type is required")
+		recordSpanError(span, err)
+		return err
 	}
+
+	span.SetAttributes(
+		attribute.String("user_id", event.UserID.String()),
+		attribute.String("event_type", event.EventType),
+	)
 
 	query := `
 		INSERT INTO auth_events (user_id, identifier, event_type, ip_address, user_agent, created_at)
@@ -33,6 +47,7 @@ func (s *AuthEventService) LogEvent(ctx context.Context, event *models.AuthEvent
 	`
 	_, err := s.db.ExecContext(ctx, query, event.UserID, event.Identifier, event.EventType, event.IPAddress, event.UserAgent)
 	if err != nil {
+		recordSpanError(span, err)
 		return fmt.Errorf("failed to insert auth event: %w", err)
 	}
 

--- a/backend/internal/services/comment.go
+++ b/backend/internal/services/comment.go
@@ -184,18 +184,19 @@ func (s *CommentService) CreateComment(ctx context.Context, req *models.CreateCo
 
 func (s *CommentService) UpdateComment(ctx context.Context, commentID uuid.UUID, userID uuid.UUID, req *models.UpdateCommentRequest) (*models.Comment, error) {
 	ctx, span := otel.Tracer("clubhouse.comments").Start(ctx, "CommentService.UpdateComment")
-	span.SetAttributes(
-		attribute.String("user_id", userID.String()),
-		attribute.String("comment_id", commentID.String()),
-		attribute.Int("content_length", len(strings.TrimSpace(req.Content))),
-		attribute.Bool("has_links", req.Links != nil && len(*req.Links) > 0),
-	)
 	defer span.End()
 
 	if err := validateUpdateCommentInput(req); err != nil {
 		recordSpanError(span, err)
 		return nil, err
 	}
+
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("comment_id", commentID.String()),
+		attribute.Int("content_length", len(strings.TrimSpace(req.Content))),
+		attribute.Bool("has_links", req.Links != nil && len(*req.Links) > 0),
+	)
 
 	trimmedContent := strings.TrimSpace(req.Content)
 	var linkMetadata []models.JSONMap

--- a/backend/internal/services/csrf.go
+++ b/backend/internal/services/csrf.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/sanderginn/clubhouse/internal/observability"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -37,9 +39,17 @@ func NewCSRFService(redis *redis.Client) *CSRFService {
 
 // GenerateToken generates a new CSRF token for a user session
 func (s *CSRFService) GenerateToken(ctx context.Context, sessionID string, userID uuid.UUID) (string, error) {
+	ctx, span := otel.Tracer("clubhouse.csrf").Start(ctx, "CSRFService.GenerateToken")
+	span.SetAttributes(
+		attribute.String("session_id", sessionID),
+		attribute.String("user_id", userID.String()),
+	)
+	defer span.End()
+
 	// Generate cryptographically secure random token
 	tokenBytes := make([]byte, CSRFTokenLength)
 	if _, err := rand.Read(tokenBytes); err != nil {
+		recordSpanError(span, err)
 		return "", fmt.Errorf("failed to generate random token: %w", err)
 	}
 
@@ -51,6 +61,7 @@ func (s *CSRFService) GenerateToken(ctx context.Context, sessionID string, userI
 	value := fmt.Sprintf("%s:%s", sessionID, userID.String())
 
 	if err := s.redis.Set(ctx, key, value, CSRFTokenDuration).Err(); err != nil {
+		recordSpanError(span, err)
 		return "", fmt.Errorf("failed to store CSRF token in Redis: %w", err)
 	}
 
@@ -59,8 +70,19 @@ func (s *CSRFService) GenerateToken(ctx context.Context, sessionID string, userI
 
 // ValidateToken validates a CSRF token and returns the associated session ID and user ID
 func (s *CSRFService) ValidateToken(ctx context.Context, token string, sessionID string, userID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.csrf").Start(ctx, "CSRFService.ValidateToken")
+	span.SetAttributes(
+		attribute.Bool("has_token", token != ""),
+		attribute.Int("token_length", len(token)),
+		attribute.String("session_id", sessionID),
+		attribute.String("user_id", userID.String()),
+	)
+	defer span.End()
+
 	if token == "" {
-		return errors.New("csrf token is required")
+		missingErr := errors.New("csrf token is required")
+		recordSpanError(span, missingErr)
+		return missingErr
 	}
 
 	key := CSRFKeyPrefix + token
@@ -68,8 +90,10 @@ func (s *CSRFService) ValidateToken(ctx context.Context, token string, sessionID
 	if err != nil {
 		if err == redis.Nil {
 			observability.RecordCacheMiss(ctx, "csrf")
+			recordSpanError(span, ErrCSRFTokenNotFound)
 			return ErrCSRFTokenNotFound
 		}
+		recordSpanError(span, err)
 		return fmt.Errorf("failed to get CSRF token from Redis: %w", err)
 	}
 	observability.RecordCacheHit(ctx, "csrf")
@@ -77,7 +101,9 @@ func (s *CSRFService) ValidateToken(ctx context.Context, token string, sessionID
 	// Verify the token is for this session and user
 	expectedValue := fmt.Sprintf("%s:%s", sessionID, userID.String())
 	if value != expectedValue {
-		return errors.New("csrf token does not match session")
+		mismatchErr := errors.New("csrf token does not match session")
+		recordSpanError(span, mismatchErr)
+		return mismatchErr
 	}
 
 	return nil
@@ -85,8 +111,16 @@ func (s *CSRFService) ValidateToken(ctx context.Context, token string, sessionID
 
 // DeleteToken removes a CSRF token from Redis
 func (s *CSRFService) DeleteToken(ctx context.Context, token string) error {
+	ctx, span := otel.Tracer("clubhouse.csrf").Start(ctx, "CSRFService.DeleteToken")
+	span.SetAttributes(
+		attribute.Bool("has_token", token != ""),
+		attribute.Int("token_length", len(token)),
+	)
+	defer span.End()
+
 	key := CSRFKeyPrefix + token
 	if err := s.redis.Del(ctx, key).Err(); err != nil {
+		recordSpanError(span, err)
 		return fmt.Errorf("failed to delete CSRF token from Redis: %w", err)
 	}
 	return nil

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -165,18 +165,19 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 
 func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID uuid.UUID, req *models.UpdatePostRequest) (*models.Post, error) {
 	ctx, span := otel.Tracer("clubhouse.posts").Start(ctx, "PostService.UpdatePost")
-	span.SetAttributes(
-		attribute.String("user_id", userID.String()),
-		attribute.String("post_id", postID.String()),
-		attribute.Int("content_length", len(strings.TrimSpace(req.Content))),
-		attribute.Bool("has_links", req.Links != nil && len(*req.Links) > 0),
-	)
 	defer span.End()
 
 	if err := validateUpdatePostInput(req); err != nil {
 		recordSpanError(span, err)
 		return nil, err
 	}
+
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+		attribute.Int("content_length", len(strings.TrimSpace(req.Content))),
+		attribute.Bool("has_links", req.Links != nil && len(*req.Links) > 0),
+	)
 
 	trimmedContent := strings.TrimSpace(req.Content)
 	var linkMetadata []models.JSONMap

--- a/backend/internal/services/tracing.go
+++ b/backend/internal/services/tracing.go
@@ -1,0 +1,11 @@
+package services
+
+import "go.opentelemetry.io/otel/trace"
+
+func recordSpanError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+
+	span.RecordError(err)
+}


### PR DESCRIPTION
## Summary
- add service-layer spans across auth events, sessions, users, reactions, notifications, sections, push, audit, password reset, TOTP, CSRF, search, and comment/post operations
- capture key attributes (user IDs, entity IDs, counts) and record errors on spans for failure paths
- introduce a small helper for consistent span error recording

Closes #418