### PR TITLE
Tempo: Configure service map and trace exploration

### DIFF
--- a/grafana/dashboards/traces.json
+++ b/grafana/dashboards/traces.json
@@ -490,7 +490,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=\"$service\", span.name=\"$operation\", status.code=\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] = \"$tag_value\"",
+          "query": "{resource.service.name=~\"$service\", span.name=~\"$operation\", status.code=~\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] =~ \"$tag_value\"",
           "limit": 200,
           "refId": "A"
         }
@@ -589,6 +589,7 @@
         "definition": "label_values(tempo_spanmetrics_calls_total, service)",
         "hide": 0,
         "includeAll": true,
+        "allValue": ".*",
         "multi": false,
         "name": "service",
         "options": [],
@@ -614,6 +615,7 @@
         "definition": "label_values(tempo_spanmetrics_calls_total{service=\"$service\"}, span_name)",
         "hide": 0,
         "includeAll": true,
+        "allValue": ".*",
         "multi": false,
         "name": "operation",
         "options": [],
@@ -671,15 +673,15 @@
       {
         "current": {
           "selected": false,
-          "text": "",
-          "value": ""
+          "text": ".*",
+          "value": ".*"
         },
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "tag_value",
         "options": [],
-        "query": "",
+        "query": ".*",
         "skipUrlSync": false,
         "type": "textbox"
       },
@@ -691,6 +693,7 @@
         },
         "hide": 0,
         "includeAll": true,
+        "allValue": ".*",
         "multi": false,
         "name": "status",
         "options": [

--- a/grafana/dashboards/traces.json
+++ b/grafana/dashboards/traces.json
@@ -1,0 +1,682 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_spanmetrics_calls_total[$__rate_interval]))",
+          "legendFormat": "Span Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_spanmetrics_latency_sum[$__rate_interval])) / sum(rate(tempo_spanmetrics_latency_count[$__rate_interval]))",
+          "legendFormat": "Avg Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Trace Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_spanmetrics_errors_total[$__rate_interval])) / sum(rate(tempo_spanmetrics_calls_total[$__rate_interval])) * 100",
+          "legendFormat": "Error %",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Trace Percentage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_spanmetrics_calls_total[$__rate_interval])) by (service)",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Traces by Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "nodes": {
+          "mainStat": "Total",
+          "secondaryStat": "Errors",
+          "arc": "errorRate"
+        },
+        "edges": {
+          "mainStat": "Requests",
+          "secondaryStat": "p95",
+          "arc": "errorRate"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_service_graph_request_total[$__rate_interval])) by (client, server)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_service_graph_request_failed_total[$__rate_interval])) by (client, server)",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(tempo_service_graph_request_duration_seconds_bucket[$__rate_interval])) by (le, client, server))",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Service Graph",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "client": "source",
+              "server": "target",
+              "Value": "requests",
+              "Value #A": "requests",
+              "Value #B": "errors",
+              "Value #C": "p95"
+            }
+          }
+        }
+      ],
+      "type": "nodeGraph"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "queryType": "traceql",
+          "query": "{resource.service.name=\"$service\", span.name=\"$operation\", status.code=\"$status\"} | duration > ${min_duration_ms}ms",
+          "limit": 200,
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Search",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 7,
+      "options": {
+        "calculate": false,
+        "cellGap": 2,
+        "color": {
+          "mode": "scheme"
+        },
+        "exemplars": {
+          "color": "rgba(255, 255, 255, 0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "reverseYBuckets": false,
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 2,
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tempo_spanmetrics_latency_bucket[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Trace Duration Histogram",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["clubhouse", "tempo", "tracing"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(tempo_spanmetrics_calls_total, service)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(tempo_spanmetrics_calls_total, service)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(tempo_spanmetrics_calls_total{service=\"$service\"}, span_name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "operation",
+        "options": [],
+        "query": {
+          "query": "label_values(tempo_spanmetrics_calls_total{service=\"$service\"}, span_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "500",
+          "value": "500"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "min_duration_ms",
+        "options": [
+          {"selected": false, "text": "50", "value": "50"},
+          {"selected": false, "text": "100", "value": "100"},
+          {"selected": false, "text": "250", "value": "250"},
+          {"selected": true, "text": "500", "value": "500"},
+          {"selected": false, "text": "1000", "value": "1000"},
+          {"selected": false, "text": "2000", "value": "2000"}
+        ],
+        "query": "50,100,250,500,1000,2000",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "status",
+        "options": [
+          {"selected": false, "text": "STATUS_CODE_UNSET", "value": "STATUS_CODE_UNSET"},
+          {"selected": false, "text": "STATUS_CODE_OK", "value": "STATUS_CODE_OK"},
+          {"selected": false, "text": "STATUS_CODE_ERROR", "value": "STATUS_CODE_ERROR"}
+        ],
+        "query": "STATUS_CODE_UNSET,STATUS_CODE_OK,STATUS_CODE_ERROR",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Clubhouse - Traces",
+  "uid": "clubhouse-traces",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/dashboards/traces.json
+++ b/grafana/dashboards/traces.json
@@ -490,7 +490,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=\"$service\", span.name=\"$operation\", status.code=\"$status\"} | duration > ${min_duration_ms}ms",
+          "query": "{resource.service.name=\"$service\", span.name=\"$operation\", status.code=\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] = \"$tag_value\"",
           "limit": 200,
           "refId": "A"
         }
@@ -647,6 +647,41 @@
         "query": "50,100,250,500,1000,2000",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "user_id",
+          "value": "user_id"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "tag_key",
+        "options": [
+          {"selected": true, "text": "user_id", "value": "user_id"},
+          {"selected": false, "text": "post_id", "value": "post_id"},
+          {"selected": false, "text": "comment_id", "value": "comment_id"},
+          {"selected": false, "text": "section_id", "value": "section_id"}
+        ],
+        "query": "user_id,post_id,comment_id,section_id",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "tag_value",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
       },
       {
         "current": {

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -29,8 +29,35 @@ datasources:
       streamingEnabled: false
       tracesToLogsV2:
         datasourceUid: loki
+        spanStartTimeShift: "1h"
+        spanEndTimeShift: "1h"
+        filterByTraceID: true
+        filterBySpanID: false
+        tags:
+          - key: service.name
+            value: service
+          - key: service.namespace
+            value: namespace
+          - key: deployment.environment
+            value: environment
       tracesToMetrics:
         datasourceUid: prometheus
+        spanStartTimeShift: "5m"
+        spanEndTimeShift: "5m"
+        tags:
+          - key: service.name
+            value: service
+          - key: span.name
+            value: span
+          - key: status.code
+            value: status
+        queries:
+          - name: "Span rate"
+            query: "sum(rate(tempo_spanmetrics_calls_total{service=\"$service\", span_name=\"$span\"}[$__rate_interval]))"
+          - name: "Span error rate"
+            query: "sum(rate(tempo_spanmetrics_errors_total{service=\"$service\", span_name=\"$span\"}[$__rate_interval])) / sum(rate(tempo_spanmetrics_calls_total{service=\"$service\", span_name=\"$span\"}[$__rate_interval])) * 100"
+          - name: "p95 latency"
+            query: "histogram_quantile(0.95, sum(rate(tempo_spanmetrics_latency_bucket{service=\"$service\", span_name=\"$span\"}[$__rate_interval])) by (le))"
       nodeGraph:
         enabled: true
       lokiSearch:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -20,3 +20,7 @@ scrape_configs:
       - targets: ['backend:8080']
     metrics_path: '/metrics'
     scrape_interval: 15s
+
+  - job_name: 'tempo'
+    static_configs:
+      - targets: ['tempo:3200']

--- a/tempo.yml
+++ b/tempo.yml
@@ -33,3 +33,14 @@ querier:
 metrics_generator:
   storage:
     path: /var/tempo/generator/metrics
+  traces_storage:
+    path: /var/tempo/generator/traces
+  registry:
+    external_labels:
+      source: tempo
+      cluster: clubhouse
+  processor:
+    service_graphs:
+      enabled: true
+    span_metrics:
+      enabled: true


### PR DESCRIPTION
## Summary
- enable Tempo metrics generator processors for service graphs and span metrics
- add Prometheus scrape target for Tempo metrics
- provision Tempo datasource correlations and a traces dashboard for search and service graphs

Closes #439