### PR TITLE
Fix Loki config: compactor.delete-request-store not configured for retention

### DIFF
--- a/loki.yml
+++ b/loki.yml
@@ -29,6 +29,7 @@ schema_config:
 compactor:
   working_directory: /loki/compactor
   retention_enabled: true
+  delete_request_store: filesystem
 
 limits_config:
   retention_period: 336h


### PR DESCRIPTION
## Summary
- configure Loki compactor delete request store to match filesystem backend
- keep retention config intact while satisfying Loki startup requirement

Closes #489