### PR TITLE
Fix Tempo config: deprecated `enabled` fields in metrics_generator

### DIFF
--- a/tempo.yml
+++ b/tempo.yml
@@ -40,7 +40,5 @@ metrics_generator:
       source: tempo
       cluster: clubhouse
   processor:
-    service_graphs:
-      enabled: true
-    span_metrics:
-      enabled: true
+    service_graphs: {}
+    span_metrics: {}


### PR DESCRIPTION
## Summary
- remove deprecated `enabled` flags for Tempo metrics generator processors
- enable processors by config presence per current Tempo schema
- keep metrics generator paths/labels unchanged

## Testing
- not run (config-only change)

Closes #490