### PR TITLE
Link metadata fetcher should skip internal upload URLs

### DIFF
--- a/backend/internal/services/link_metadata.go
+++ b/backend/internal/services/link_metadata.go
@@ -21,6 +21,9 @@ func fetchLinkMetadata(ctx context.Context, links []models.LinkRequest) []models
 
 	metadata := make([]models.JSONMap, len(links))
 	for i, link := range links {
+		if linkmeta.IsInternalUploadURL(link.URL) {
+			continue
+		}
 		observability.RecordLinkMetadataFetchAttempt(ctx, 1)
 		start := time.Now()
 		meta, err := linkmeta.FetchMetadata(ctx, link.URL)

--- a/backend/internal/services/links/metadata.go
+++ b/backend/internal/services/links/metadata.go
@@ -269,6 +269,29 @@ func ExtractDomain(rawURL string) string {
 	return host
 }
 
+// IsInternalUploadURL reports whether rawURL points to the internal uploads endpoint.
+func IsInternalUploadURL(rawURL string) bool {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "/api/v1/uploads/") || trimmed == "/api/v1/uploads" {
+		return true
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return false
+	}
+	path := strings.TrimSpace(parsed.Path)
+	if path == "" {
+		return false
+	}
+	if strings.HasPrefix(path, "/api/v1/uploads/") || path == "/api/v1/uploads" {
+		return true
+	}
+	return false
+}
+
 func isBlockedHostname(host string) bool {
 	switch host {
 	case "localhost", "metadata.google.internal":

--- a/backend/internal/services/links/metadata_test.go
+++ b/backend/internal/services/links/metadata_test.go
@@ -254,6 +254,28 @@ func TestFetchMetadataImageFallbackSkipsHTML(t *testing.T) {
 	}
 }
 
+func TestIsInternalUploadURL(t *testing.T) {
+	tests := []struct {
+		rawURL string
+		want   bool
+	}{
+		{rawURL: "/api/v1/uploads/128620aa-7f7e-47d6-9400-91699dc61e1a/photo.png", want: true},
+		{rawURL: "/api/v1/uploads", want: true},
+		{rawURL: "https://clubhouse.example/api/v1/uploads/128620aa-7f7e-47d6-9400-91699dc61e1a/photo.png", want: true},
+		{rawURL: "https://clubhouse.example/api/v1/uploads", want: true},
+		{rawURL: "https://example.com/api/v1/uploading/photo.png", want: false},
+		{rawURL: "/api/v1/upload/photo.png", want: false},
+		{rawURL: "https://example.com/photo.png", want: false},
+		{rawURL: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := IsInternalUploadURL(tt.rawURL); got != tt.want {
+			t.Errorf("IsInternalUploadURL(%q) = %v, want %v", tt.rawURL, got, tt.want)
+		}
+	}
+}
+
 func TestValidateURLBlocksHosts(t *testing.T) {
 	fetcher := NewFetcher(&http.Client{})
 	fetcher.resolver = fakeResolver{


### PR DESCRIPTION
## Summary
- skip internal upload URLs before fetching metadata to avoid warnings
- add helper for detecting upload URLs and tests

Closes #491