### PR TITLE
Navigation from standalone post back to section does not load feed

### DIFF
--- a/frontend/src/components/ThreadView.svelte
+++ b/frontend/src/components/ThreadView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { activeSection, sections, sectionStore, threadRouteStore, posts } from '../stores';
+  import { activeSection, sections, sectionStore, threadRouteStore, posts, uiStore } from '../stores';
   import { loadThreadTargetPost } from '../stores/threadRouteStore';
   import { buildFeedHref, getHistoryState, pushPath } from '../services/routeNavigation';
   import PostCard from './PostCard.svelte';
@@ -30,6 +30,8 @@
   function handleSectionClick() {
     if (!sectionContext) return;
     sectionStore.setActiveSection(sectionContext);
+    uiStore.setActiveView('feed');
+    threadRouteStore.clearTarget();
     pushPath(buildFeedHref(sectionContext.slug));
   }
 

--- a/frontend/src/components/__tests__/ThreadView.test.ts
+++ b/frontend/src/components/__tests__/ThreadView.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { sectionStore, threadRouteStore, uiStore, activeView } from '../../stores';
+
+const { default: ThreadView } = await import('../ThreadView.svelte');
+
+beforeEach(() => {
+  sectionStore.setSections([
+    { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+  ]);
+  sectionStore.setActiveSection(null);
+  threadRouteStore.setTarget('post-1', 'section-1');
+  threadRouteStore.setReady();
+  uiStore.setActiveView('thread');
+});
+
+afterEach(() => {
+  cleanup();
+  threadRouteStore.clearTarget();
+  uiStore.setActiveView('feed');
+});
+
+describe('ThreadView', () => {
+  it('navigates back to section and resets view state', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    render(ThreadView);
+
+    const button = screen.getByText('Back to Music');
+    await fireEvent.click(button);
+
+    expect(get(activeView)).toBe('feed');
+    expect(get(threadRouteStore).postId).toBeNull();
+    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/sections/music');
+  });
+});


### PR DESCRIPTION
## Summary
- set feed view + clear thread state when returning to section from thread view
- add ThreadView test covering back-to-section behavior

## Tests
- `npm run check` (fails: `svelte-check` not installed in env)
- `npm run test -- ThreadView` (fails: `vitest` not installed in env)

Closes #495