### PR TITLE
Hide image URL text on posts with images

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -10,7 +10,7 @@
   import { buildProfileHref, handleProfileNavigation } from '../services/profileNavigation';
   import { buildThreadHref } from '../services/routeNavigation';
   import LinkifiedText from './LinkifiedText.svelte';
-  import { getImageLinkUrl } from '../services/linkUtils';
+  import { getImageLinkUrl, isInternalUploadUrl, stripInternalUploadUrls } from '../services/linkUtils';
   import { sections } from '../stores/sectionStore';
   import { getSectionSlugById } from '../services/sectionSlug';
   import { logError } from '../lib/observability/logger';
@@ -157,6 +157,11 @@
   $: link = post.links?.[0];
   $: metadata = link?.metadata;
   $: imageUrl = getImageLinkUrl(link);
+  $: isInternalUploadLink = link ? isInternalUploadUrl(link.url) : false;
+  $: displayContent =
+    !isEditing && imageUrl && isInternalUploadLink
+      ? stripInternalUploadUrls(post.content)
+      : post.content;
   $: canEdit = $currentUser?.id === post.userId;
 
   let imageLoadFailed = false;
@@ -298,7 +303,7 @@
         </div>
       {:else}
         <LinkifiedText
-          text={post.content}
+          text={displayContent}
           className="text-gray-800 whitespace-pre-wrap break-words mb-3"
         />
       {/if}
@@ -321,15 +326,17 @@
             />
           {/if}
         </div>
-        <a
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm break-all"
-        >
-          <span>🔗</span>
-          <span class="underline">{link.url}</span>
-        </a>
+        {#if !isInternalUploadLink}
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm break-all"
+          >
+            <span>🔗</span>
+            <span class="underline">{link.url}</span>
+          </a>
+        {/if}
       {:else if !isEditing && link && metadata}
         <a
           href={link.url}

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -326,7 +326,7 @@
             />
           {/if}
         </div>
-        {#if !isInternalUploadLink}
+        {#if !isInternalUploadLink || imageLoadFailed}
           <a
             href={link.url}
             target="_blank"

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/svelte';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import type { Post } from '../../stores/postStore';
 import { authStore } from '../../stores';
 
@@ -106,6 +106,27 @@ describe('PostCard', () => {
     expect(screen.getByRole('img', { name: 'Uploaded image' })).toBeInTheDocument();
     expect(screen.getByText('Look')).toBeInTheDocument();
     expect(screen.queryByText('/api/v1/uploads/user-1/photo.png')).not.toBeInTheDocument();
+  });
+
+  it('shows internal upload link when image fails to load', async () => {
+    const postWithInternalImage: Post = {
+      ...basePost,
+      links: [
+        {
+          url: '/api/v1/uploads/user-1/photo.png',
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithInternalImage });
+
+    const image = screen.getByRole('img', { name: 'Uploaded image' });
+    await fireEvent.error(image);
+
+    const link = screen.getByRole('link', {
+      name: /\/api\/v1\/uploads\/user-1\/photo\.png/,
+    });
+    expect(link).toHaveAttribute('href', '/api/v1/uploads/user-1/photo.png');
   });
 
   it('shows avatar fallback when no profile image', () => {

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -90,6 +90,24 @@ describe('PostCard', () => {
     expect(screen.getByRole('img', { name: 'Uploaded image' })).toBeInTheDocument();
   });
 
+  it('hides internal upload URLs from post content when an image is rendered', () => {
+    const postWithInternalImage: Post = {
+      ...basePost,
+      content: 'Look /api/v1/uploads/user-1/photo.png',
+      links: [
+        {
+          url: '/api/v1/uploads/user-1/photo.png',
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithInternalImage });
+
+    expect(screen.getByRole('img', { name: 'Uploaded image' })).toBeInTheDocument();
+    expect(screen.getByText('Look')).toBeInTheDocument();
+    expect(screen.queryByText('/api/v1/uploads/user-1/photo.png')).not.toBeInTheDocument();
+  });
+
   it('shows avatar fallback when no profile image', () => {
     render(PostCard, { post: basePost });
     expect(screen.getByText('S')).toBeInTheDocument();

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -24,6 +24,7 @@
   import { buildProfileHref, handleProfileNavigation } from '../../services/profileNavigation';
   import { buildThreadHref, pushPath } from '../../services/routeNavigation';
   import { getSectionSlug } from '../../services/sectionSlug';
+  import { getImageLinkUrl, isInternalUploadUrl, stripInternalUploadUrls } from '../../services/linkUtils';
   import type { Post } from '../../stores/postStore';
   import type { CommentResult, SearchResult } from '../../stores/searchStore';
   import { logError } from '../../lib/observability/logger';
@@ -307,6 +308,14 @@
                 {@const parentPost = result.post}
                 <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 space-y-4">
                   {#if parentPost}
+                    {@const parentPostHasInternalImage =
+                      parentPost.links?.some((link) => isInternalUploadUrl(link.url) && getImageLinkUrl(link)) ??
+                      false}
+                    {@const parentPostContent = parentPostHasInternalImage
+                      ? stripInternalUploadUrls(parentPost.content)
+                      : parentPost.content}
+                    {@const parentPostLink =
+                      parentPost.links?.find((link) => !isInternalUploadUrl(link.url)) ?? null}
                     <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
                       <div class="flex items-center justify-between text-xs text-gray-500 mb-2">
                         <div class="flex items-center gap-2">
@@ -345,17 +354,17 @@
                             <EditedBadge createdAt={parentPost.createdAt} updatedAt={parentPost.updatedAt} />
                           </div>
                           <p class="text-gray-800 text-sm whitespace-pre-wrap break-words line-clamp-3">
-                            {parentPost.content}
+                            {parentPostContent}
                           </p>
-                          {#if parentPost.links && parentPost.links.length > 0}
+                          {#if parentPostLink}
                             <div class="mt-2 text-xs text-blue-600 break-all">
                               <a
-                                href={parentPost.links[0].url}
+                                href={parentPostLink.url}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 class="underline"
                               >
-                                {parentPost.links[0].url}
+                                {parentPostLink.url}
                               </a>
                             </div>
                           {/if}

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -488,6 +488,13 @@
         {@const parentPost = result.post}
         <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 space-y-4">
           {#if parentPost}
+            {@const parentPostHasInternalImage =
+              parentPost.links?.some((link) => isInternalUploadUrl(link.url) && getImageLinkUrl(link)) ?? false}
+            {@const parentPostContent = parentPostHasInternalImage
+              ? stripInternalUploadUrls(parentPost.content)
+              : parentPost.content}
+            {@const parentPostLink =
+              parentPost.links?.find((link) => !isInternalUploadUrl(link.url)) ?? null}
             <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
               <div class="flex items-center justify-between text-xs text-gray-500 mb-2">
                 <div class="flex items-center gap-2">
@@ -534,17 +541,17 @@
                     <EditedBadge createdAt={parentPost.createdAt} updatedAt={parentPost.updatedAt} />
                   </div>
                   <p class="text-gray-800 text-sm whitespace-pre-wrap break-words line-clamp-3">
-                    {parentPost.content}
+                    {parentPostContent}
                   </p>
-                  {#if parentPost.links && parentPost.links.length > 0}
+                  {#if parentPostLink}
                     <div class="mt-2 text-xs text-blue-600 break-all">
                       <a
-                        href={parentPost.links[0].url}
+                        href={parentPostLink.url}
                         target="_blank"
                         rel="noopener noreferrer"
                         class="underline"
                       >
-                        {parentPost.links[0].url}
+                        {parentPostLink.url}
                       </a>
                     </div>
                   {/if}

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -139,6 +139,47 @@ describe('SearchResults', () => {
     expect(sectionLabels.length).toBeGreaterThan(0);
   });
 
+  it('strips internal upload URLs from parent post content in search results', () => {
+    storeRefs.searchQuery.set('photo');
+    storeRefs.lastSearchQuery.set('photo');
+    storeRefs.lastSearchScope.set('section');
+    storeRefs.sections.set([
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+    ]);
+    storeRefs.activeSection.set({ id: 'section-1', name: 'Music', slug: 'music' });
+    storeRefs.searchResults.set([
+      {
+        type: 'comment',
+        score: 1,
+        comment: {
+          id: 'comment-1',
+          postId: 'post-1',
+          sectionId: 'section-1',
+          content: 'Nice photo',
+          createdAt: '2025-01-01T00:00:00Z',
+          user: { id: 'user-1', username: 'Sander' },
+        },
+        post: {
+          id: 'post-1',
+          sectionId: 'section-1',
+          content: 'Look /api/v1/uploads/user-1/photo.png today',
+          createdAt: '2025-01-01T00:00:00Z',
+          userId: 'user-1',
+          links: [{ url: '/api/v1/uploads/user-1/photo.png' }],
+        },
+      },
+    ]);
+
+    render(SearchResults);
+
+    expect(screen.getByText(/Look/)).toBeInTheDocument();
+    expect(screen.getByText(/today/)).toBeInTheDocument();
+    expect(screen.queryByText('/api/v1/uploads/user-1/photo.png')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: '/api/v1/uploads/user-1/photo.png' })
+    ).not.toBeInTheDocument();
+  });
+
   it('renders section label for post results', () => {
     storeRefs.searchQuery.set('hello');
     storeRefs.lastSearchQuery.set('hello');

--- a/frontend/src/services/linkUtils.ts
+++ b/frontend/src/services/linkUtils.ts
@@ -15,6 +15,10 @@ const IMAGE_FORMATS = new Set([
   'tiff',
   'image',
 ]);
+const INTERNAL_UPLOAD_URL_PATTERN =
+  /(?:https?:\/\/[^\s<>"{}|\\^`[\]]*\/api\/v1\/uploads[^\s<>"{}|\\^`[\]]*|\/api\/v1\/uploads[^\s<>"{}|\\^`[\]]*)/gi;
+const INTERNAL_UPLOAD_MATCH = /^(?:https?:\/\/[^/]+)?\/api\/v1\/uploads(?:\/|$)/i;
+const TRAILING_PUNCTUATION = /[).,;:!?]+$/;
 
 export function looksLikeImageUrl(value: string): boolean {
   if (!value) {
@@ -31,6 +35,23 @@ export function looksLikeImageUrl(value: string): boolean {
   }
 
   return IMAGE_FORMATS.has(match[1]);
+}
+
+export function isInternalUploadUrl(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  return INTERNAL_UPLOAD_MATCH.test(value.trim());
+}
+
+export function stripInternalUploadUrls(value: string): string {
+  if (!value) {
+    return value;
+  }
+  return value.replace(INTERNAL_UPLOAD_URL_PATTERN, (match) => {
+    const trailing = match.match(TRAILING_PUNCTUATION)?.[0] ?? '';
+    return trailing;
+  });
 }
 
 export function getImageLinkUrl(link?: Link): string | undefined {


### PR DESCRIPTION
## Summary
- suppress internal upload URLs in post content when an image renders
- hide internal upload URLs beneath image previews while keeping external links visible
- add coverage for internal upload URL suppression in PostCard

Closes #493