### PR TITLE
Fix search box: don't clear container until search is executed

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,7 +11,9 @@
     isAuthenticated,
     activeSection,
     sections,
-    searchQuery,
+    lastSearchQuery,
+    searchError,
+    isSearching,
     searchStore,
     websocketStore,
     sectionStore,
@@ -304,7 +306,7 @@
             <PostForm />
           </div>
 
-          {#if $searchQuery.trim().length > 0}
+          {#if $isSearching || $searchError || $lastSearchQuery.trim().length > 0}
             <SearchResults />
           {:else}
             <SectionFeed />

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -221,15 +221,17 @@
 
   $: normalizedQuery = $searchQuery.trim();
   $: hasQuery = normalizedQuery.length > 0;
-  $: showResults = $lastSearchQuery && $lastSearchQuery === normalizedQuery;
-  $: displayScope = showResults && $lastSearchScope ? $lastSearchScope : $searchScope;
+  $: hasSearched = $lastSearchQuery.length > 0;
+  $: queryMatchesLastSearch = hasSearched && $lastSearchQuery === normalizedQuery;
+  $: showResults = hasSearched;
+  $: displayScope = hasSearched && $lastSearchScope ? $lastSearchScope : $searchScope;
   $: isGlobalScope = displayScope === 'global';
   $: showParentSectionPill = displayScope === 'global';
   $: sectionGroups = isGlobalScope ? buildSectionGroups($searchResults, $sections) : [];
 </script>
 
 <section class="space-y-4">
-  {#if !hasQuery}
+  {#if !hasSearched && !hasQuery}
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
       <p class="text-gray-500">Start typing to search posts and comments.</p>
     </div>
@@ -254,6 +256,9 @@
   {:else if showResults && $searchResults.length === 0}
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
       <p class="text-gray-500">No results for "{$lastSearchQuery}".</p>
+      {#if hasQuery && !queryMatchesLastSearch}
+        <p class="text-sm text-gray-400 mt-2">Press Search to refresh results.</p>
+      {/if}
     </div>
   {:else if !showResults}
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
@@ -280,6 +285,12 @@
         {/if}
       </span>
     </div>
+
+    {#if hasQuery && !queryMatchesLastSearch}
+      <div class="rounded-lg border border-blue-100 bg-blue-50 px-4 py-2 text-sm text-blue-700">
+        Press Search to refresh results for "{normalizedQuery}".
+      </div>
+    {/if}
 
     {#if $lastSearchScope && $lastSearchScope !== $searchScope}
       <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-700">

--- a/frontend/src/components/search/__tests__/SearchResults.test.ts
+++ b/frontend/src/components/search/__tests__/SearchResults.test.ts
@@ -99,12 +99,36 @@ describe('SearchResults', () => {
     expect(screen.getByText('No results for "hello".')).toBeInTheDocument();
   });
 
-  it('hides results when query changes', () => {
+  it('keeps last empty results when query changes', () => {
     storeRefs.searchQuery.set('new');
     storeRefs.lastSearchQuery.set('old');
     storeRefs.lastSearchScope.set('section');
     render(SearchResults);
-    expect(screen.getByText('Press Search to see results.')).toBeInTheDocument();
+    expect(screen.getByText('No results for "old".')).toBeInTheDocument();
+    expect(screen.getByText('Press Search to refresh results.')).toBeInTheDocument();
+  });
+
+  it('keeps last results when query changes', () => {
+    storeRefs.searchQuery.set('updated');
+    storeRefs.lastSearchQuery.set('original');
+    storeRefs.lastSearchScope.set('section');
+    storeRefs.searchResults.set([
+      {
+        type: 'post',
+        score: 1,
+        post: {
+          id: 'post-1',
+          sectionId: 'section-1',
+          content: 'Original post',
+          createdAt: '2025-01-01T00:00:00Z',
+          user: { id: 'user-1', username: 'Sander' },
+        },
+      },
+    ]);
+
+    render(SearchResults);
+    expect(screen.getByText('post-1')).toBeInTheDocument();
+    expect(screen.getByText('Press Search to refresh results for "updated".')).toBeInTheDocument();
   });
 
   it('renders comment results', () => {


### PR DESCRIPTION
## Summary
- keep section feed visible until a search executes by keying the view off the last executed search
- retain last search results while editing a new query, with a refresh prompt
- update SearchResults tests for the new behavior

## Testing
- `npm run check` (fails: svelte-check not found)
- `npm run test -- --grep "SearchResults"` (fails: vitest not found)

Closes #512