### PR TITLE
Fix Grafana plugins-bundled directory warning on startup

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -189,6 +189,7 @@ The backup/restore scripts source `.env.production` automatically when present.
 - Retention: 7 days of traces (`tempo.yml`), 14 days of logs (`loki.yml`), and 30 days of metrics (`--storage.tsdb.retention.time=30d`)
 
 Grafana dashboards are provisioned from `grafana/dashboards`.
+The Grafana entrypoint ensures `/usr/share/grafana/plugins-bundled` exists to avoid startup warnings.
 
 Pinned observability image versions (see `docker-compose.yml` and `docker-compose.prod.yml`):
 

--- a/grafana/entrypoint.sh
+++ b/grafana/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Grafana expects the bundled plugins directory to exist; create it to avoid startup warnings.
+mkdir -p /usr/share/grafana/plugins-bundled
+
 # Grafana 11+ bundles xychart; remove stale external plugin to avoid double registration.
 if [ -d /var/lib/grafana/plugins/xychart ]; then
   rm -rf /var/lib/grafana/plugins/xychart


### PR DESCRIPTION
## Summary
- ensure Grafana entrypoint creates `/usr/share/grafana/plugins-bundled` to silence startup warning
- document the Grafana entrypoint behavior in production deployment notes

Closes #527