### PR TITLE
Fix Grafana xychart plugin registration error on startup

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -190,6 +190,7 @@ The backup/restore scripts source `.env.production` automatically when present.
 
 Grafana dashboards are provisioned from `grafana/dashboards`.
 The Grafana entrypoint ensures `/usr/share/grafana/plugins-bundled` exists to avoid startup warnings.
+Grafana startup removes any legacy external xychart plugin from the data volume to avoid duplicate registration with the built-in panel.
 
 Pinned observability image versions (see `docker-compose.yml` and `docker-compose.prod.yml`):
 

--- a/grafana/entrypoint.sh
+++ b/grafana/entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 set -e
 
-# Grafana expects the bundled plugins directory to exist; create it to avoid startup warnings.
-mkdir -p /usr/share/grafana/plugins-bundled
-
-# Grafana 11+ bundles xychart; remove stale external plugin to avoid double registration.
-if [ -d /var/lib/grafana/plugins/xychart ]; then
-  rm -rf /var/lib/grafana/plugins/xychart
+# Grafana 11+ bundles xychart; remove any stale external plugin to avoid double registration.
+if [ -d /var/lib/grafana/plugins ]; then
+  for plugin_dir in /var/lib/grafana/plugins/*; do
+    if [ -f "$plugin_dir/plugin.json" ] && grep -q '"id"[[:space:]]*:[[:space:]]*"xychart"' "$plugin_dir/plugin.json"; then
+      rm -rf "$plugin_dir"
+    fi
+  done
 fi
 
 exec /run.sh "$@"


### PR DESCRIPTION
## Summary
- remove any legacy xychart plugin directories from the Grafana data volume before startup
- document the Grafana xychart cleanup behavior in production deployment notes

Closes #526