### PR TITLE
Reduce padding on highlighted words (@mentions and search matches)

### DIFF
--- a/frontend/src/components/LinkifiedText.svelte
+++ b/frontend/src/components/LinkifiedText.svelte
@@ -12,7 +12,7 @@
   export let className = '';
   export let linkClassName = 'text-blue-600 hover:text-blue-800 underline';
   export let mentionClassName =
-    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-1';
+    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-[1px]';
   export let highlightQuery = '';
   export let validMentions: string[] | null = null;
   export let validateMentions = true;
@@ -277,7 +277,7 @@
     {:else}
       {#each buildHighlightParts(part.value, highlightQuery) as highlight, highlightIndex (highlightIndex)}
         {#if highlight.isMatch}
-          <mark class="rounded bg-amber-100 px-0.5 text-gray-900 ring-1 ring-amber-200">
+          <mark class="rounded bg-amber-100 px-[1px] text-gray-900 ring-1 ring-amber-200">
             {highlight.text}
           </mark>
         {:else}

--- a/frontend/src/components/LinkifiedText.svelte
+++ b/frontend/src/components/LinkifiedText.svelte
@@ -12,7 +12,7 @@
   export let className = '';
   export let linkClassName = 'text-blue-600 hover:text-blue-800 underline';
   export let mentionClassName =
-    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-[1px]';
+    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-0.5';
   export let highlightQuery = '';
   export let validMentions: string[] | null = null;
   export let validateMentions = true;
@@ -277,7 +277,7 @@
     {:else}
       {#each buildHighlightParts(part.value, highlightQuery) as highlight, highlightIndex (highlightIndex)}
         {#if highlight.isMatch}
-          <mark class="rounded bg-amber-100 px-[1px] text-gray-900 ring-1 ring-amber-200">
+          <mark class="rounded bg-amber-100 px-0.5 text-gray-900 ring-1 ring-amber-200">
             {highlight.text}
           </mark>
         {:else}

--- a/frontend/src/components/mentions/MentionTextarea.svelte
+++ b/frontend/src/components/mentions/MentionTextarea.svelte
@@ -10,7 +10,7 @@
   export let className = '';
   export let ariaLabel = '';
   export let mentionClassName =
-    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-1';
+    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-[1px]';
 
   const dispatch = createEventDispatcher<{
     input: Event;

--- a/frontend/src/components/mentions/MentionTextarea.svelte
+++ b/frontend/src/components/mentions/MentionTextarea.svelte
@@ -10,7 +10,7 @@
   export let className = '';
   export let ariaLabel = '';
   export let mentionClassName =
-    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-[1px]';
+    'text-indigo-600 hover:text-indigo-800 font-medium bg-indigo-50 rounded px-0.5';
 
   const dispatch = createEventDispatcher<{
     input: Event;


### PR DESCRIPTION
## Summary
- Reduce horizontal padding for mention highlights in rendered text and mention suggestions.
- Tighten search match highlight padding to keep inline flow compact.

## Testing
- Not run (style-only change)

Closes #525