### PR TITLE
Improve replies emoji and counter layout

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -708,14 +708,11 @@
         </a>
       {/if}
 
-      <div class="flex items-center gap-4 mt-3 text-gray-500 text-sm">
-        <div class="flex items-center gap-1">
+      <div class="mt-3 flex flex-wrap items-center gap-2">
+        <div class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600">
           <span>💬</span>
           <span>{post.commentCount || 0}</span>
         </div>
-      </div>
-
-      <div class="mt-3">
         <ReactionBar
           reactionCounts={post.reactionCounts ?? {}}
           userReactions={userReactions}

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -465,7 +465,14 @@
               {/if}
 
               {#if editingCommentId !== comment.id}
-                <div class="mt-2">
+                <div class="mt-2 flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    on:click={() => toggleReply(comment.id)}
+                    class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 transition hover:border-gray-300 hover:text-gray-700"
+                  >
+                    Reply
+                  </button>
                   <ReactionBar
                     reactionCounts={comment.reactionCounts ?? {}}
                     userReactions={getUserReactions(comment)}
@@ -474,16 +481,6 @@
                   />
                 </div>
               {/if}
-
-              <div class="mt-2">
-                <button
-                  type="button"
-                  on:click={() => toggleReply(comment.id)}
-                  class="text-xs text-gray-500 hover:text-gray-700"
-                >
-                  Reply
-                </button>
-              </div>
 
               {#if openReplies.has(comment.id)}
                 <div class="mt-3">


### PR DESCRIPTION
## Summary
- Align post comment count badge with the reaction controls in a single action row.
- Style the comment reply action as a pill and place it inline with reactions for consistent layout.

## Testing
- `npm run check` (fails: `svelte-check: command not found`)

Closes #524