### PR TITLE
Make Alertmanager log level configurable

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -145,6 +145,7 @@ services:
     restart: unless-stopped
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--log.level=${LOG_LEVEL:-info}'
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
     container_name: clubhouse-alertmanager
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--log.level=${LOG_LEVEL:-info}'
     ports:
       - "9093:9093"
     volumes:

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -207,7 +207,7 @@ Pinned observability image versions (see `docker-compose.yml` and `docker-compos
 - Keep frontend and backend on the same origin to avoid permissive CORS. If you add cross-origin access, implement a strict allowlist.
 - Keep the deployment host firewall locked down (only 80/443 open).
 - Ensure `.env.production` is stored securely and never committed.
-- Review environment values for production: `ENVIRONMENT=production`, `LOG_LEVEL=info`.
+- Review environment values for production: `ENVIRONMENT=production`, `LOG_LEVEL=info` (also sets Alertmanager log level; supported: debug, info, warn, error).
 - Use a least-privilege database user for the app (separate admin/maintenance credentials).
 
 ## 14) Health checks and uptime monitoring


### PR DESCRIPTION
## Summary
- add Alertmanager log level flag wired to LOG_LEVEL in compose (default info)
- document Alertmanager log level env in production deployment notes

Closes #528