### PR TITLE
Make frontend Vite proxy log level configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Optional frontend environment variables:
 - `VITE_APP_VERSION`: Release identifier for error tracking.
 - `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP/HTTP traces endpoint for browser telemetry (in dev defaults to `http://localhost:4318/v1/traces`; leave unset in prod to disable).
 - `VITE_OTEL_SERVICE_NAME`: Service name used in frontend traces (defaults to `clubhouse-frontend`).
+- `VITE_PROXY_LOG_LEVEL`: Vite proxy logging level (`none`/`silent`, `error`, `warn`, `info`, `debug`; defaults to `warn`).
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,7 @@ services:
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
     environment:
       VITE_API_PROXY_TARGET: http://backend:8080
+      VITE_PROXY_LOG_LEVEL: ${VITE_PROXY_LOG_LEVEL:-warn}
     ports:
       - "5173:5173"
     volumes:


### PR DESCRIPTION
## Summary
- add configurable Vite proxy log level parsing with sensible defaults
- wire VITE_PROXY_LOG_LEVEL into dev docker compose env
- document the new frontend env option

## Testing
- prek (frontend-checks)

Closes #529