### PR TITLE
Add reply-to-specific-image functionality

### DIFF
--- a/backend/internal/handlers/comment.go
+++ b/backend/internal/handlers/comment.go
@@ -81,6 +81,10 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_PARENT_COMMENT_ID", err.Error())
 		case "parent comment not found":
 			writeError(r.Context(), w, http.StatusNotFound, "PARENT_COMMENT_NOT_FOUND", err.Error())
+		case "invalid image id":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_IMAGE_ID", err.Error())
+		case "image not found":
+			writeError(r.Context(), w, http.StatusNotFound, "IMAGE_NOT_FOUND", err.Error())
 		case "content is required":
 			writeError(r.Context(), w, http.StatusBadRequest, "CONTENT_REQUIRED", err.Error())
 		case "content must be less than 5000 characters":

--- a/backend/internal/handlers/comment_test.go
+++ b/backend/internal/handlers/comment_test.go
@@ -238,6 +238,7 @@ func TestCreateCommentHandlerInvalidImageID(t *testing.T) {
 
 	userID := uuid.New()
 	postID := uuid.New()
+	sectionID := uuid.New()
 
 	body, err := json.Marshal(models.CreateCommentRequest{
 		PostID:  postID.String(),
@@ -248,9 +249,9 @@ func TestCreateCommentHandlerInvalidImageID(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM posts").
+	mock.ExpectQuery("SELECT section_id FROM posts").
 		WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		WillReturnRows(sqlmock.NewRows([]string{"section_id"}).AddRow(sectionID))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/v1/comments", bytes.NewReader(body))
 	if err != nil {
@@ -291,6 +292,7 @@ func TestCreateCommentHandlerImageNotFound(t *testing.T) {
 
 	userID := uuid.New()
 	postID := uuid.New()
+	sectionID := uuid.New()
 	imageID := uuid.New()
 
 	body, err := json.Marshal(models.CreateCommentRequest{
@@ -302,9 +304,9 @@ func TestCreateCommentHandlerImageNotFound(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM posts").
+	mock.ExpectQuery("SELECT section_id FROM posts").
 		WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		WillReturnRows(sqlmock.NewRows([]string{"section_id"}).AddRow(sectionID))
 	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM post_images").
 		WithArgs(imageID, postID).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))

--- a/backend/internal/handlers/comment_test.go
+++ b/backend/internal/handlers/comment_test.go
@@ -471,11 +471,11 @@ func TestUpdateCommentSuccess(t *testing.T) {
 	mock.ExpectCommit()
 
 	rows := mock.NewRows([]string{
-		"id", "user_id", "post_id", "section_id", "parent_comment_id", "content",
+		"id", "user_id", "post_id", "section_id", "parent_comment_id", "image_id", "content",
 		"created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
 	}).AddRow(
-		commentID, userID, postID, sectionID, nil, "Updated comment",
+		commentID, userID, postID, sectionID, nil, nil, "Updated comment",
 		now, updatedAt, nil, nil,
 		userID, "testuser", "test@example.com", nil, nil, false, now,
 	)

--- a/backend/internal/handlers/search_test.go
+++ b/backend/internal/handlers/search_test.go
@@ -223,10 +223,10 @@ func TestSearchSectionScopeUsesContextSectionID(t *testing.T) {
 
 	commentRows := sqlmock.NewRows([]string{
 
-		"id", "user_id", "post_id", "section_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "user_id", "post_id", "section_id", "parent_comment_id", "image_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
 	}).AddRow(
-		commentID, userID, postID, sectionID, nil, "comment content", commentCreated, nil, nil, nil,
+		commentID, userID, postID, sectionID, nil, nil, "comment content", commentCreated, nil, nil, nil,
 		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
 	)
 
@@ -372,10 +372,10 @@ func TestSearchSuccessGlobal(t *testing.T) {
 
 	commentRows := sqlmock.NewRows([]string{
 
-		"id", "user_id", "post_id", "section_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "user_id", "post_id", "section_id", "parent_comment_id", "image_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
 	}).AddRow(
-		commentID, userID, postID, sectionID, nil, "comment content", commentCreated, nil, nil, nil,
+		commentID, userID, postID, sectionID, nil, nil, "comment content", commentCreated, nil, nil, nil,
 		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
 	)
 

--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -13,6 +13,7 @@ type Comment struct {
 	PostID          uuid.UUID      `json:"post_id"`
 	SectionID       *uuid.UUID     `json:"section_id,omitempty"`
 	ParentCommentID *uuid.UUID     `json:"parent_comment_id,omitempty"`
+	ImageID         *uuid.UUID     `json:"image_id,omitempty"`
 	Content         string         `json:"content"`
 	Links           []Link         `json:"links,omitempty"`
 	CreatedAt       time.Time      `json:"created_at"`
@@ -29,6 +30,7 @@ type Comment struct {
 type CreateCommentRequest struct {
 	PostID          string        `json:"post_id"`
 	ParentCommentID *string       `json:"parent_comment_id,omitempty"`
+	ImageID         *string       `json:"image_id,omitempty"`
 	Content         string        `json:"content"`
 	Links           []LinkRequest `json:"links,omitempty"`
 }

--- a/backend/internal/services/comment_test.go
+++ b/backend/internal/services/comment_test.go
@@ -80,6 +80,66 @@ func TestCreateCommentWithImageID(t *testing.T) {
 	}
 }
 
+func TestCreateCommentCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "createcommentuser", "createcomment@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Create Comment Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post for create comment audit")
+
+	imageID := uuid.New()
+	_, err := db.Exec(`
+		INSERT INTO post_images (id, post_id, image_url, position, caption, alt_text, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, now())
+	`, imageID, uuid.MustParse(postID), "https://example.com/audit.jpg", 1, "Caption", "Alt text")
+	if err != nil {
+		t.Fatalf("failed to create post image: %v", err)
+	}
+
+	service := NewCommentService(db)
+	req := &models.CreateCommentRequest{
+		PostID:  postID,
+		Content: "Create comment audit log",
+		ImageID: stringPtr(imageID.String()),
+	}
+
+	comment, err := service.CreateComment(context.Background(), req, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("CreateComment failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	err = db.QueryRow(`
+		SELECT metadata
+		FROM audit_logs
+		WHERE admin_user_id = $1 AND action = 'create_comment'
+	`, userID).Scan(&metadataBytes)
+	if err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+	if metadata["comment_id"] != comment.ID.String() {
+		t.Errorf("expected comment_id %s, got %v", comment.ID.String(), metadata["comment_id"])
+	}
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if metadata["section_id"] != sectionID {
+		t.Errorf("expected section_id %s, got %v", sectionID, metadata["section_id"])
+	}
+	if metadata["image_id"] != imageID.String() {
+		t.Errorf("expected image_id %s, got %v", imageID.String(), metadata["image_id"])
+	}
+	if metadata["content_excerpt"] != "Create comment audit log" {
+		t.Errorf("expected content_excerpt %q, got %v", "Create comment audit log", metadata["content_excerpt"])
+	}
+}
+
 func TestCreateCommentInvalidImageID(t *testing.T) {
 	db := testutil.RequireTestDB(t)
 	t.Cleanup(func() { testutil.CleanupTables(t, db) })

--- a/backend/internal/services/search_test.go
+++ b/backend/internal/services/search_test.go
@@ -63,10 +63,10 @@ func TestSearchServiceGlobal(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"emoji", "count"}))
 
 	commentRows := sqlmock.NewRows([]string{
-		"id", "user_id", "post_id", "section_id", "parent_comment_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
+		"id", "user_id", "post_id", "section_id", "parent_comment_id", "image_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
 	}).AddRow(
-		commentID, userID, postID, sectionID, nil, "comment content", commentCreated, nil, nil, nil,
+		commentID, userID, postID, sectionID, nil, nil, "comment content", commentCreated, nil, nil, nil,
 		userID, "alice", "alice@example.com", nil, nil, false, userCreated,
 	)
 

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -1176,7 +1176,7 @@ func (s *UserService) GetUserComments(ctx context.Context, userID uuid.UUID, cur
 	// Build query for user's comments
 	query := `
 		SELECT
-			c.id, c.user_id, c.post_id, c.parent_comment_id, c.content,
+			c.id, c.user_id, c.post_id, c.parent_comment_id, c.image_id, c.content,
 			c.created_at, c.updated_at,
 			u.id, u.username, u.profile_picture_url
 		FROM comments c
@@ -1208,9 +1208,10 @@ func (s *UserService) GetUserComments(ctx context.Context, userID uuid.UUID, cur
 	for rows.Next() {
 		var comment models.Comment
 		var user models.User
+		var imageID sql.NullString
 
 		err := rows.Scan(
-			&comment.ID, &comment.UserID, &comment.PostID, &comment.ParentCommentID, &comment.Content,
+			&comment.ID, &comment.UserID, &comment.PostID, &comment.ParentCommentID, &imageID, &comment.Content,
 			&comment.CreatedAt, &comment.UpdatedAt,
 			&user.ID, &user.Username, &user.ProfilePictureURL,
 		)
@@ -1220,6 +1221,10 @@ func (s *UserService) GetUserComments(ctx context.Context, userID uuid.UUID, cur
 		}
 
 		comment.User = &user
+		if imageID.Valid {
+			parsedID, _ := uuid.Parse(imageID.String)
+			comment.ImageID = &parsedID
+		}
 
 		// Fetch reactions
 		// Note: We don't have the viewer ID here in the current signature.

--- a/backend/migrations/027_add_image_id_to_comments.down.sql
+++ b/backend/migrations/027_add_image_id_to_comments.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_comments_image_id;
+
+ALTER TABLE comments
+  DROP COLUMN IF EXISTS image_id;

--- a/backend/migrations/027_add_image_id_to_comments.up.sql
+++ b/backend/migrations/027_add_image_id_to_comments.up.sql
@@ -1,0 +1,5 @@
+-- Add optional image reference to comments
+ALTER TABLE comments
+  ADD COLUMN image_id UUID REFERENCES post_images(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_comments_image_id ON comments(image_id);

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -162,6 +162,7 @@ describe('api client', () => {
     await api.createComment({
       postId: 'post-1',
       parentCommentId: 'comment-1',
+      imageId: 'image-1',
       content: 'Reply',
       links: [{ url: 'https://example.com' }],
     });
@@ -170,6 +171,7 @@ describe('api client', () => {
     const body = JSON.parse(commentCall?.[1]?.body as string);
     expect(body.post_id).toBe('post-1');
     expect(body.parent_comment_id).toBe('comment-1');
+    expect(body.image_id).toBe('image-1');
   });
 
   it('getFeed builds query params', async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -442,6 +442,7 @@ class ApiClient {
     return this.post('/comments', {
       post_id: data.postId,
       parent_comment_id: data.parentCommentId,
+      image_id: data.imageId,
       content: data.content,
       links: data.links,
     });

--- a/frontend/src/stores/__tests__/commentMapper.test.ts
+++ b/frontend/src/stores/__tests__/commentMapper.test.ts
@@ -6,6 +6,7 @@ const apiComment = {
   user_id: 'user-1',
   post_id: 'post-1',
   parent_comment_id: null,
+  image_id: 'image-1',
   content: 'Hello',
   created_at: '2025-01-01T00:00:00Z',
   user: {
@@ -51,6 +52,7 @@ describe('mapApiComment', () => {
     expect(comment.links?.[0].metadata?.url).toBe('https://example.com');
     expect(comment.replies).toHaveLength(1);
     expect(comment.replies?.[0].parentCommentId).toBe('comment-1');
+    expect(comment.imageId).toBe('image-1');
   });
 
   it('maps API comment without metadata', () => {

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -55,6 +55,31 @@ describe('mapApiPost', () => {
     expect(post.links).toBeUndefined();
   });
 
+  it('maps post images', () => {
+    const post = mapApiPost({
+      id: 'post-6',
+      user_id: 'user-6',
+      section_id: 'section-6',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      images: [
+        {
+          id: 'image-1',
+          url: 'https://example.com/one.png',
+          position: 0,
+          caption: 'First',
+          alt_text: 'First image',
+          created_at: '2025-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    expect(post.images?.[0].id).toBe('image-1');
+    expect(post.images?.[0].url).toBe('https://example.com/one.png');
+    expect(post.images?.[0].caption).toBe('First');
+    expect(post.images?.[0].altText).toBe('First image');
+  });
+
   it('falls back to link url when metadata url is missing', () => {
     const post = mapApiPost({
       id: 'post-3',

--- a/frontend/src/stores/commentMapper.ts
+++ b/frontend/src/stores/commentMapper.ts
@@ -7,6 +7,7 @@ export interface ApiComment {
   user_id: string;
   post_id: string;
   parent_comment_id?: string | null;
+  image_id?: string | null;
   content: string;
   links?: ApiLink[];
   user?: ApiUser;
@@ -23,6 +24,7 @@ export function mapApiComment(apiComment: ApiComment): Comment {
     userId: apiComment.user_id,
     postId: apiComment.post_id,
     parentCommentId: apiComment.parent_comment_id ?? undefined,
+    imageId: apiComment.image_id ?? undefined,
     content: apiComment.content,
     links: apiComment.links?.map((link): Link => ({
       id: link.id,

--- a/frontend/src/stores/commentStore.ts
+++ b/frontend/src/stores/commentStore.ts
@@ -6,6 +6,7 @@ export interface Comment {
   userId: string;
   postId: string;
   parentCommentId?: string;
+  imageId?: string;
   content: string;
   links?: Link[];
   user?: {
@@ -23,6 +24,7 @@ export interface Comment {
 export interface CreateCommentRequest {
   postId: string;
   parentCommentId?: string;
+  imageId?: string;
   content: string;
   links?: { url: string }[];
 }

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -1,4 +1,4 @@
-import type { Post, Link, LinkMetadata } from './postStore';
+import type { Post, Link, LinkMetadata, PostImage } from './postStore';
 
 export interface ApiUser {
   id: string;
@@ -12,12 +12,22 @@ export interface ApiLink {
   metadata?: Record<string, unknown> | string | null;
 }
 
+export interface ApiPostImage {
+  id: string;
+  url: string;
+  position: number;
+  caption?: string | null;
+  alt_text?: string | null;
+  created_at?: string;
+}
+
 export interface ApiPost {
   id: string;
   user_id: string;
   section_id: string;
   content: string;
   links?: ApiLink[];
+  images?: ApiPostImage[];
   user?: ApiUser;
   comment_count?: number;
   reaction_counts?: Record<string, number>;
@@ -123,6 +133,15 @@ export function normalizeLinkMetadata(
 }
 
 export function mapApiPost(apiPost: ApiPost): Post {
+  const images: PostImage[] | undefined = apiPost.images?.map((image) => ({
+    id: image.id,
+    url: image.url,
+    position: image.position,
+    caption: image.caption ?? undefined,
+    altText: image.alt_text ?? undefined,
+    createdAt: image.created_at,
+  }));
+
   return {
     id: apiPost.id,
     userId: apiPost.user_id,
@@ -133,6 +152,7 @@ export function mapApiPost(apiPost: ApiPost): Post {
       url: link.url,
       metadata: normalizeLinkMetadata(link.metadata, link.url),
     })),
+    images,
     user: apiPost.user
       ? {
           id: apiPost.user.id,

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -18,12 +18,22 @@ export interface LinkMetadata {
   type?: string;
 }
 
+export interface PostImage {
+  id: string;
+  url: string;
+  position: number;
+  caption?: string;
+  altText?: string;
+  createdAt?: string;
+}
+
 export interface Post {
   id: string;
   userId: string;
   sectionId: string;
   content: string;
   links?: Link[];
+  images?: PostImage[];
   user?: {
     id: string;
     username: string;


### PR DESCRIPTION
## Summary
- wire comment creation + mapping for image-specific replies via `image_id`
- add reply-to-image UI in carousel/lightbox and show referenced thumbnails in threads
- enable navigating from image-referenced comments back to the correct image

## Testing
- frontend-checks (lint/check/test) via pre-commit
- backend-test (go test ./...; go build ./...) skipped (SKIP=backend-test)

Closes #519