### PR TITLE
Unify thread UI in user profile comments section

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -19,6 +19,7 @@
 
   export let post: Post;
   export let highlightCommentId: string | null = null;
+  export let highlightCommentIds: string[] = [];
 
   $: userReactions = new Set(post.viewerReactions ?? []);
   $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
@@ -726,6 +727,7 @@
           postId={post.id}
           commentCount={post.commentCount ?? 0}
           {highlightCommentId}
+          {highlightCommentIds}
         />
       </div>
     </div>

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -17,6 +17,7 @@
   export let postId: string;
   export let commentCount = 0;
   export let highlightCommentId: string | null = null;
+  export let highlightCommentIds: string[] = [];
 
   const emptyThread: CommentThreadState = {
     comments: [],
@@ -237,6 +238,10 @@
       }
     });
   }
+
+  $: highlightIdSet = new Set(
+    [highlightCommentId, ...highlightCommentIds].filter((value): value is string => !!value)
+  );
 </script>
 
 <div class="space-y-4" bind:this={rootEl}>
@@ -279,7 +284,7 @@
         <article
           id={`comment-${comment.id}`}
           class={`border border-gray-200 rounded-lg p-3 ${
-            highlightCommentId === comment.id ? 'bg-amber-50 ring-2 ring-amber-300' : 'bg-white'
+            highlightIdSet.has(comment.id) ? 'bg-amber-50 ring-2 ring-amber-300' : 'bg-white'
           }`}
         >
           <div class="flex items-start gap-3">
@@ -502,7 +507,9 @@
                     <div
                       id={`comment-${reply.id}`}
                       class={`flex items-start gap-2 ${
-                        highlightCommentId === reply.id ? 'bg-amber-50 ring-2 ring-amber-300 rounded-lg p-2' : ''
+                        highlightIdSet.has(reply.id)
+                          ? 'bg-amber-50 ring-2 ring-amber-300 rounded-lg p-2'
+                          : ''
                       }`}
                     >
                       {#if reply.user?.id}


### PR DESCRIPTION
## Summary
- Group profile comments by thread and render the standard PostCard/CommentThread UI.
- Highlight all of a user’s comments per thread and add direct thread links.
- Extend comment highlighting support and update UserProfile tests.

Closes #522