### PR TITLE
Notification click updates URL but does not navigate

### DIFF
--- a/frontend/src/components/notifications/NotificationMenu.svelte
+++ b/frontend/src/components/notifications/NotificationMenu.svelte
@@ -88,6 +88,9 @@
     const href = buildNotificationHref(notification);
     if (href) {
       pushPath(href);
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }));
+      }
     }
     closeMenu();
   }


### PR DESCRIPTION
## Summary
- dispatch a popstate event after notification pushState so App route sync runs
- ensure notification clicks navigate to thread/comment without manual refresh

## Testing
- `cd frontend && npm run test -- --grep "NotificationMenu"` (failed: `vitest` not found in environment)

Closes #556
