### PR TITLE
Edit keyboard shortcut does not save posts or comments

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -296,6 +296,17 @@
     }
   }
 
+  function handleEditKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      const trimmed = editContent.trim();
+      if (!trimmed || isSaving || editImageUploading) {
+        return;
+      }
+      event.preventDefault();
+      saveEdit();
+    }
+  }
+
   async function toggleReaction(emoji: string) {
     const hasReacted = userReactions.has(emoji);
     // Optimistic update
@@ -874,6 +885,7 @@
             class="w-full rounded-lg border border-gray-300 p-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             rows="4"
             bind:value={editContent}
+            on:keydown={handleEditKeyDown}
           />
           {#if editError}
             <div class="text-sm text-red-600">{editError}</div>

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -284,4 +284,58 @@ describe('PostCard', () => {
       ],
     });
   });
+
+  it('saves edits with cmd+enter', async () => {
+    authStore.setUser({
+      id: 'user-1',
+      username: 'Sander',
+      email: 'sander@example.com',
+      isAdmin: false,
+      totpEnabled: false,
+    });
+
+    apiUpdatePost.mockResolvedValue({ post: { ...basePost } });
+
+    render(PostCard, { post: basePost });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const textareas = screen.getAllByRole('textbox');
+    const textarea = textareas.find((area) => area.getAttribute('rows') === '4');
+    if (!textarea) {
+      throw new Error('Edit textarea not found');
+    }
+    await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+    expect(apiUpdatePost).toHaveBeenCalledWith('post-1', {
+      content: 'Hello world',
+      links: undefined,
+    });
+  });
+
+  it('ignores cmd+enter when edit content is empty', async () => {
+    authStore.setUser({
+      id: 'user-1',
+      username: 'Sander',
+      email: 'sander@example.com',
+      isAdmin: false,
+      totpEnabled: false,
+    });
+
+    apiUpdatePost.mockResolvedValue({ post: { ...basePost } });
+
+    render(PostCard, { post: basePost });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const textareas = screen.getAllByRole('textbox');
+    const textarea = textareas.find((area) => area.getAttribute('rows') === '4');
+    if (!textarea) {
+      throw new Error('Edit textarea not found');
+    }
+    await fireEvent.input(textarea, { target: { value: '   ' } });
+    await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+    expect(apiUpdatePost).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -170,6 +170,17 @@
     }
   }
 
+  function handleEditKeyDown(event: KeyboardEvent, commentId: string) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      const trimmed = editCommentContent.trim();
+      if (!trimmed || isSavingComment) {
+        return;
+      }
+      event.preventDefault();
+      saveEdit(commentId);
+    }
+  }
+
   async function deleteComment(commentId: string) {
     if (typeof window !== 'undefined') {
       const confirmed = window.confirm('Delete this comment?');
@@ -447,6 +458,7 @@
                     class="w-full rounded-lg border border-gray-300 p-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
                     rows="3"
                     bind:value={editCommentContent}
+                    on:keydown={(event) => handleEditKeyDown(event, comment.id)}
                   />
                   {#if editCommentError}
                     <div class="text-sm text-red-600">{editCommentError}</div>
@@ -667,6 +679,7 @@
                               class="w-full rounded-lg border border-gray-300 p-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
                               rows="3"
                               bind:value={editCommentContent}
+                              on:keydown={(event) => handleEditKeyDown(event, reply.id)}
                             />
                             {#if editCommentError}
                               <div class="text-sm text-red-600">{editCommentError}</div>


### PR DESCRIPTION
## Summary
- handle Cmd/Ctrl+Enter for post and comment edit forms, with empty/invalid guards
- add component tests covering edit shortcut behavior

Closes #558