### PR TITLE
Unescaped @ mentions should render as literal text when user does not exist

### DIFF
--- a/frontend/src/components/LinkifiedText.svelte
+++ b/frontend/src/components/LinkifiedText.svelte
@@ -94,7 +94,7 @@
           return existing;
         }
         const task = api
-          .lookupUserByUsername(username)
+          .lookupUserByUsername(username, { suppressNotFound: true })
           .then(() => {
             mentionValidationCache.set(username, true);
           })


### PR DESCRIPTION
## Summary
- suppress API warn logging for expected 404s on mention validation lookups
- use quiet lookup when validating mentions in LinkifiedText
- add test to ensure unknown mentions remain visible when lookup fails

Closes #562