### PR TITLE
Frontend OTEL traces endpoint returns 405 due to CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ npm run dev
 Optional frontend environment variables:
 - `VITE_SENTRY_DSN`: Sentry DSN for client error tracking (leave unset to disable).
 - `VITE_APP_VERSION`: Release identifier for error tracking.
-- `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP/HTTP traces endpoint for browser telemetry (in dev defaults to `http://localhost:4318/v1/traces`; leave unset in prod to disable).
+- `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP/HTTP traces endpoint for browser telemetry (in dev defaults to `/otlp/v1/traces` via the Vite proxy; leave unset in prod to disable).
+- `VITE_OTEL_PROXY_TARGET`: Dev-only target for the Vite OTLP proxy (defaults to `http://localhost:4318`).
 - `VITE_OTEL_SERVICE_NAME`: Service name used in frontend traces (defaults to `clubhouse-frontend`).
 - `VITE_PROXY_LOG_LEVEL`: Vite proxy logging level (`none`/`silent`, `error`, `warn`, `info`, `debug`; defaults to `warn`).
 

--- a/frontend/src/lib/observability/tracing.ts
+++ b/frontend/src/lib/observability/tracing.ts
@@ -8,7 +8,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 let initialized = false;
 
-const DEFAULT_DEV_ENDPOINT = 'http://localhost:4318/v1/traces';
+const DEFAULT_DEV_ENDPOINT = '/otlp/v1/traces';
 
 const buildPropagationUrls = (): RegExp[] => {
   if (typeof window === 'undefined') {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -102,6 +102,12 @@ export default defineConfig({
           });
         },
       },
+      '/otlp': {
+        target: process.env.VITE_OTEL_PROXY_TARGET ?? 'http://localhost:4318',
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/otlp/, ''),
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- route dev OTLP traces through a same-origin Vite proxy to avoid CORS preflights
- update the default dev exporter URL to `/otlp/v1/traces`
- document the proxy target env var for local setup

Closes #574