### PR TITLE
Section-scoped search pill missing container styling

### DIFF
--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -275,13 +275,14 @@
         Showing {$searchResults.length} result{$searchResults.length === 1 ? '' : 's'} for
         "{$lastSearchQuery}"
       </span>
-      <span>
+      <span class={sectionPillClass}>
         {#if displayScope === 'global'}
-          All sections
-        {:else if $activeSection}
-          {$activeSection.name}
+          <span class={sectionPillTextClass}>Everywhere</span>
         {:else}
-          Section
+          {#if $activeSection?.icon}
+            <span class={sectionPillIconClass} aria-hidden="true">{$activeSection.icon}</span>
+          {/if}
+          <span class={sectionPillTextClass}>{$activeSection?.name ?? 'Section'}</span>
         {/if}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- wrap the search scope summary in the same pill container styling used elsewhere
- render section scope with icon + label inside the pill for consistent alignment
- keep global scope labeled as Everywhere in the pill

## Testing
- `npm run test -- src/components/search/__tests__/SearchResults.test.ts` (fails: `vitest` not found in environment)

Closes #566