### PR TITLE
Lightbox image transitions should not slide vertically

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -1301,15 +1301,17 @@
           </button>
         </div>
       {/if}
-      {#key lightboxImageUrl}
-        <img
-          src={lightboxImageUrl}
-          alt={lightboxAltText}
-          class="max-h-[85vh] w-auto max-w-[95vw] rounded-lg object-contain bg-white shadow-lg"
-          style="touch-action: pan-y pinch-zoom;"
-          transition:fade={{ duration: 180 }}
-        />
-      {/key}
+      <div class="relative flex items-center justify-center">
+        {#key lightboxImageUrl}
+          <img
+            src={lightboxImageUrl}
+            alt={lightboxAltText}
+            class="max-h-[85vh] w-auto max-w-[95vw] rounded-lg object-contain bg-white shadow-lg"
+            style="touch-action: pan-y pinch-zoom;"
+            in:fade={{ duration: 180 }}
+          />
+        {/key}
+      </div>
       {#if lightboxImageId}
         <div class="mt-3 flex justify-center">
           <button


### PR DESCRIPTION
## Summary

- Changed lightbox image transition from `transition:fade` to `in:fade` to eliminate vertical sliding during image changes
- Wrapped the image in a container with relative positioning and flex centering for stable layout
- The old `transition:fade` caused both outgoing and incoming images to exist simultaneously during the transition, causing vertical stacking/jumping
- With `in:fade`, only the new image fades in while the old one is removed immediately, providing smooth directional-consistent transitions

Closes #567