### PR TITLE
Thread comment box should appear below existing comments

### DIFF
--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -297,14 +297,6 @@
 </script>
 
 <div class="space-y-4" bind:this={rootEl}>
-  <div id={`comment-form-${postId}`} class="border border-gray-200 rounded-lg p-3 bg-gray-50">
-    <CommentForm
-      {postId}
-      imageContext={imageReplyTarget}
-      onClearImageContext={onClearImageReply}
-    />
-  </div>
-
   {#if thread.isLoading && thread.comments.length === 0}
     <div class="flex items-center gap-2 text-gray-500 text-sm">
       <svg
@@ -744,4 +736,12 @@
       {/if}
     </div>
   {/if}
+
+  <div id={`comment-form-${postId}`} class="border border-gray-200 rounded-lg p-3 bg-gray-50">
+    <CommentForm
+      {postId}
+      imageContext={imageReplyTarget}
+      onClearImageContext={onClearImageReply}
+    />
+  </div>
 </div>


### PR DESCRIPTION
## Summary

- Moved the comment input box from above the comment list to below it
- The comment form now renders after all existing comments, following typical thread flow

Closes #569