### PR TITLE
Exclude current user from @ mention suggestions

### DIFF
--- a/frontend/src/components/mentions/MentionTextarea.svelte
+++ b/frontend/src/components/mentions/MentionTextarea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, tick } from 'svelte';
   import { api, type ApiUserSummary } from '../../services/api';
+  import { currentUser } from '../../stores/authStore';
 
   export let value = '';
   export let id = '';
@@ -67,7 +68,8 @@
     try {
       const response = await api.searchUsers(query, 8);
       if (token !== requestToken) return;
-      suggestions = response.users ?? [];
+      const currentUserId = $currentUser?.id;
+      suggestions = (response.users ?? []).filter((user) => user.id !== currentUserId);
       highlightedIndex = 0;
     } catch {
       if (token !== requestToken) return;

--- a/frontend/src/components/mentions/__tests__/MentionTextarea.test.ts
+++ b/frontend/src/components/mentions/__tests__/MentionTextarea.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+const storeRefs = {
+  currentUser: writable<{ id: string; username: string } | null>(null),
+  api: {
+    searchUsers: vi.fn(),
+  },
+};
+
+vi.mock('../../../services/api', () => ({
+  api: storeRefs.api,
+}));
+
+vi.mock('../../../stores/authStore', () => ({
+  currentUser: storeRefs.currentUser,
+}));
+
+const { default: MentionTextarea } = await import('../MentionTextarea.svelte');
+
+describe('MentionTextarea', () => {
+  beforeEach(() => {
+    storeRefs.currentUser.set({ id: 'current-user-id', username: 'currentuser' });
+  });
+
+  afterEach(() => {
+    cleanup();
+    storeRefs.api.searchUsers.mockReset();
+    storeRefs.currentUser.set(null);
+  });
+
+  it('excludes current user from mention suggestions', async () => {
+    storeRefs.api.searchUsers.mockResolvedValue({
+      users: [
+        { id: 'current-user-id', username: 'currentuser', profile_picture_url: null },
+        { id: 'other-user-id', username: 'otheruser', profile_picture_url: null },
+        { id: 'third-user-id', username: 'thirduser', profile_picture_url: null },
+      ],
+    });
+
+    render(MentionTextarea, { value: '' });
+
+    const textarea = screen.getByRole('textbox');
+    await fireEvent.input(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(storeRefs.api.searchUsers).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('@currentuser')).not.toBeInTheDocument();
+      expect(screen.getByText('@otheruser')).toBeInTheDocument();
+      expect(screen.getByText('@thirduser')).toBeInTheDocument();
+    });
+  });
+
+  it('shows other users when searching for mentions', async () => {
+    storeRefs.api.searchUsers.mockResolvedValue({
+      users: [
+        { id: 'user-1', username: 'alice', profile_picture_url: null },
+        { id: 'user-2', username: 'bob', profile_picture_url: null },
+      ],
+    });
+
+    render(MentionTextarea, { value: '' });
+
+    const textarea = screen.getByRole('textbox');
+    await fireEvent.input(textarea, { target: { value: '@al' } });
+
+    await waitFor(() => {
+      expect(storeRefs.api.searchUsers).toHaveBeenCalledWith('al', 8);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('@alice')).toBeInTheDocument();
+      expect(screen.getByText('@bob')).toBeInTheDocument();
+    });
+  });
+
+  it('allows keyboard navigation of suggestions', async () => {
+    storeRefs.api.searchUsers.mockResolvedValue({
+      users: [
+        { id: 'user-1', username: 'alice', profile_picture_url: null },
+        { id: 'user-2', username: 'bob', profile_picture_url: null },
+      ],
+    });
+
+    render(MentionTextarea, { value: '' });
+
+    const textarea = screen.getByRole('textbox');
+    await fireEvent.input(textarea, { target: { value: '@' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('@alice')).toBeInTheDocument();
+    });
+
+    const aliceOption = screen.getByRole('option', { name: /@alice/i });
+    expect(aliceOption).toHaveAttribute('aria-selected', 'true');
+
+    await fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+
+    const bobOption = screen.getByRole('option', { name: /@bob/i });
+    expect(bobOption).toHaveAttribute('aria-selected', 'true');
+    expect(aliceOption).toHaveAttribute('aria-selected', 'false');
+  });
+});


### PR DESCRIPTION
## Summary
- Modified `MentionTextarea.svelte` to filter out the current user from mention suggestions
- Import `currentUser` store from authStore
- Filter the API response to exclude users matching the current user's ID
- Added tests for the filtering behavior and keyboard navigation

Closes #563