### PR TITLE
Profile Posts and Comments tabs should display section on thread components

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -21,6 +21,7 @@
   export let post: Post;
   export let highlightCommentId: string | null = null;
   export let highlightCommentIds: string[] = [];
+  export let showSectionPill: boolean = false;
 
   type ImageItem = {
     id?: string;
@@ -32,6 +33,7 @@
 
   $: userReactions = new Set(post.viewerReactions ?? []);
   $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
+  $: sectionInfo = $sections.find((s) => s.id === post.sectionId) ?? null;
   let copiedLink = false;
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
   let isEditing = false;
@@ -720,6 +722,16 @@
 <svelte:window on:keydown={handleLightboxKeydown} />
 
 <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow">
+  {#if showSectionPill && sectionInfo}
+    <div class="mb-3">
+      <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-600">
+        {#if sectionInfo.icon}
+          <span class="text-base leading-none" aria-hidden="true">{sectionInfo.icon}</span>
+        {/if}
+        <span class="truncate">{sectionInfo.name}</span>
+      </span>
+    </div>
+  {/if}
   <div class="flex items-start gap-3">
     {#if post.user?.id}
       <a

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -511,7 +511,7 @@
             <p class="text-gray-500 text-sm">No posts yet.</p>
           {:else}
             {#each posts as post (post.id)}
-              <PostCard {post} />
+              <PostCard {post} showSectionPill={true} />
             {/each}
           {/if}
 
@@ -576,7 +576,7 @@
                     {postContextErrors[thread.postId]}
                   </div>
                 {:else if threadPost}
-                  <PostCard post={threadPost} highlightCommentIds={thread.commentIds} />
+                  <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} />
                 {:else}
                   <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
                     Thread unavailable.


### PR DESCRIPTION
## Summary

Adds section pill display to thread components in the user profile Posts and Comments tabs, matching the existing section display in the main feed.

## Changes

- Added `showSectionPill` prop to `PostCard` component (defaults to `false` for backward compatibility)
- When enabled, displays the section pill above the post content with icon and name
- Enabled section pill display in both Posts and Comments tabs in UserProfile component
- Styling matches existing thread section display using the same pill design

## Test plan

- View a user profile Posts tab and verify section pills appear on each post
- View a user profile Comments tab and verify section pills appear on thread previews
- Verify section pills show correct icon and name for each section
- Verify main feed posts do NOT show section pills (backward compatibility)
- Verify styling is consistent with existing section display patterns

## Screenshots

(Section pills now appear in profile tabs matching the main feed design)

Closes #571