### PR TITLE
Profile Comments tab highlight rules for nested replies

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -22,6 +22,7 @@
   export let highlightCommentId: string | null = null;
   export let highlightCommentIds: string[] = [];
   export let showSectionPill: boolean = false;
+  export let profileUserId: string | null = null;
 
   type ImageItem = {
     id?: string;
@@ -1254,6 +1255,7 @@
           commentCount={post.commentCount ?? 0}
           {highlightCommentId}
           {highlightCommentIds}
+          {profileUserId}
           {imageItems}
           imageReplyTarget={imageReplyTarget}
           onClearImageReply={clearImageReplyTarget}

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -576,7 +576,7 @@
                     {postContextErrors[thread.postId]}
                   </div>
                 {:else if threadPost}
-                  <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} />
+                  <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} profileUserId={resolvedUserId} />
                 {:else}
                   <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
                     Thread unavailable.

--- a/frontend/src/components/__tests__/UserProfile.test.ts
+++ b/frontend/src/components/__tests__/UserProfile.test.ts
@@ -186,7 +186,13 @@ describe('UserProfile', () => {
     highlighted.forEach((node) => {
       expect(node).toBeTruthy();
       expect(node?.className).toContain('ring-2');
+      expect(node?.className).toContain('bg-amber-100');
+      expect(node?.className).toContain('ring-amber-400');
     });
+
+    const parentComment = document.getElementById('comment-comment-parent');
+    expect(parentComment).toBeTruthy();
+    expect(parentComment?.className).not.toContain('bg-amber');
 
     expect(screen.getAllByRole('button', { name: 'Share' })).toHaveLength(1);
   });

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -18,6 +18,7 @@
   export let commentCount = 0;
   export let highlightCommentId: string | null = null;
   export let highlightCommentIds: string[] = [];
+  export let profileUserId: string | null = null;
   export let imageItems: {
     id?: string;
     url: string;
@@ -294,6 +295,19 @@
   $: highlightIdSet = new Set(
     [highlightCommentId, ...highlightCommentIds].filter((value): value is string => !!value)
   );
+
+  function getHighlightClass(commentId: string, commentUserId: string, isNested: boolean): string {
+    if (!highlightIdSet.has(commentId)) {
+      return isNested ? '' : 'bg-white';
+    }
+    if (profileUserId && commentUserId !== profileUserId) {
+      return isNested ? '' : 'bg-white';
+    }
+    if (isNested) {
+      return 'bg-amber-100 ring-2 ring-amber-400 rounded-lg p-2';
+    }
+    return 'bg-amber-50 ring-2 ring-amber-300';
+  }
 </script>
 
 <div class="space-y-4" bind:this={rootEl}>
@@ -331,9 +345,7 @@
       {#each thread.comments as comment (comment.id)}
         <article
           id={`comment-${comment.id}`}
-          class={`border border-gray-200 rounded-lg p-3 ${
-            highlightIdSet.has(comment.id) ? 'bg-amber-50 ring-2 ring-amber-300' : 'bg-white'
-          }`}
+          class={`border border-gray-200 rounded-lg p-3 ${getHighlightClass(comment.id, comment.userId, false)}`}
         >
           <div class="flex items-start gap-3">
             {#if comment.user?.id}
@@ -577,11 +589,7 @@
                   {#each comment.replies as reply (reply.id)}
                     <div
                       id={`comment-${reply.id}`}
-                      class={`flex items-start gap-2 ${
-                        highlightIdSet.has(reply.id)
-                          ? 'bg-amber-50 ring-2 ring-amber-300 rounded-lg p-2'
-                          : ''
-                      }`}
+                      class={`flex items-start gap-2 ${getHighlightClass(reply.id, reply.userId, true)}`}
                     >
                       {#if reply.user?.id}
                         <a

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -292,4 +292,150 @@ describe('CommentThread', () => {
 
     expect(apiUpdateComment).not.toHaveBeenCalled();
   });
+
+  describe('profile highlighting', () => {
+    it('highlights top-level comment by profile user with amber-50', () => {
+      commentStore.setThread('post-1', [
+        {
+          id: 'comment-1',
+          postId: 'post-1',
+          userId: 'profile-user',
+          content: 'Profile user comment',
+          createdAt: 'now',
+          user: { id: 'profile-user', username: 'ProfileUser' },
+          replies: [],
+        },
+      ], null, false);
+
+      render(CommentThread, {
+        postId: 'post-1',
+        commentCount: 1,
+        highlightCommentIds: ['comment-1'],
+        profileUserId: 'profile-user',
+      });
+
+      const article = document.getElementById('comment-comment-1');
+      expect(article?.className).toContain('bg-amber-50');
+      expect(article?.className).toContain('ring-amber-300');
+    });
+
+    it('does not highlight comment by other user even if in highlightCommentIds', () => {
+      commentStore.setThread('post-1', [
+        {
+          id: 'comment-1',
+          postId: 'post-1',
+          userId: 'other-user',
+          content: 'Other user comment',
+          createdAt: 'now',
+          user: { id: 'other-user', username: 'OtherUser' },
+          replies: [],
+        },
+      ], null, false);
+
+      render(CommentThread, {
+        postId: 'post-1',
+        commentCount: 1,
+        highlightCommentIds: ['comment-1'],
+        profileUserId: 'profile-user',
+      });
+
+      const article = document.getElementById('comment-comment-1');
+      expect(article?.className).toContain('bg-white');
+      expect(article?.className).not.toContain('ring-amber');
+    });
+
+    it('highlights nested reply by profile user with darker amber-100', () => {
+      commentStore.setThread('post-1', [
+        {
+          id: 'comment-1',
+          postId: 'post-1',
+          userId: 'other-user',
+          content: 'Parent comment',
+          createdAt: 'now',
+          user: { id: 'other-user', username: 'OtherUser' },
+          replies: [
+            {
+              id: 'reply-1',
+              postId: 'post-1',
+              userId: 'profile-user',
+              parentCommentId: 'comment-1',
+              content: 'Profile user reply',
+              createdAt: 'now',
+              user: { id: 'profile-user', username: 'ProfileUser' },
+            },
+          ],
+        },
+      ], null, false);
+
+      render(CommentThread, {
+        postId: 'post-1',
+        commentCount: 2,
+        highlightCommentIds: ['reply-1'],
+        profileUserId: 'profile-user',
+      });
+
+      const replyEl = document.getElementById('comment-reply-1');
+      expect(replyEl?.className).toContain('bg-amber-100');
+      expect(replyEl?.className).toContain('ring-amber-400');
+    });
+
+    it('does not highlight nested reply by other user', () => {
+      commentStore.setThread('post-1', [
+        {
+          id: 'comment-1',
+          postId: 'post-1',
+          userId: 'profile-user',
+          content: 'Profile user comment',
+          createdAt: 'now',
+          user: { id: 'profile-user', username: 'ProfileUser' },
+          replies: [
+            {
+              id: 'reply-1',
+              postId: 'post-1',
+              userId: 'other-user',
+              parentCommentId: 'comment-1',
+              content: 'Other user reply',
+              createdAt: 'now',
+              user: { id: 'other-user', username: 'OtherUser' },
+            },
+          ],
+        },
+      ], null, false);
+
+      render(CommentThread, {
+        postId: 'post-1',
+        commentCount: 2,
+        highlightCommentIds: ['comment-1', 'reply-1'],
+        profileUserId: 'profile-user',
+      });
+
+      const replyEl = document.getElementById('comment-reply-1');
+      expect(replyEl?.className).not.toContain('bg-amber');
+      expect(replyEl?.className).not.toContain('ring-amber');
+    });
+
+    it('highlights comments without profileUserId filter (backward compatibility)', () => {
+      commentStore.setThread('post-1', [
+        {
+          id: 'comment-1',
+          postId: 'post-1',
+          userId: 'any-user',
+          content: 'Any user comment',
+          createdAt: 'now',
+          user: { id: 'any-user', username: 'AnyUser' },
+          replies: [],
+        },
+      ], null, false);
+
+      render(CommentThread, {
+        postId: 'post-1',
+        commentCount: 1,
+        highlightCommentIds: ['comment-1'],
+      });
+
+      const article = document.getElementById('comment-comment-1');
+      expect(article?.className).toContain('bg-amber-50');
+      expect(article?.className).toContain('ring-amber-300');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes highlighting behavior in the Profile Comments tab to ensure only the profile user's comments are highlighted, with proper visual distinction between top-level and nested replies.

## Changes

- Added `profileUserId` prop to `PostCard`, `CommentThread` components
- Implemented `getHighlightClass` function in `CommentThread.svelte` to apply highlighting rules:
  - Top-level comments by profile user: `bg-amber-50` with `ring-amber-300`
  - Nested replies by profile user: `bg-amber-100` with `ring-amber-400` (darker shade)
  - Comments by other users: no highlight (normal styling)
- Added comprehensive test coverage in both `CommentThread.test.ts` and `UserProfile.test.ts`

## Test Plan

- All existing tests pass
- New tests verify:
  - Only profile user's comments are highlighted
  - Nested replies use darker shade
  - Other users' comments remain unhighlighted
  - Backward compatibility without `profileUserId`

Closes #572