### PR TITLE
Remove redundant "Open full thread" link and THREAD label in profile comments

### DIFF
--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -7,7 +7,10 @@
   import type { Comment } from '../stores/commentStore';
   import PostCard from './PostCard.svelte';
   import { returnToFeed } from '../services/profileNavigation';
+  import { buildThreadHref } from '../services/routeNavigation';
   import { displayTimezone } from '../stores';
+  import { sections } from '../stores/sectionStore';
+  import { getSectionSlugById } from '../services/sectionSlug';
   import { formatInTimezone } from '../lib/time';
 
   export let userId: string | null;
@@ -345,6 +348,11 @@
     return groups;
   }
 
+  function buildThreadLink(post: Post): string {
+    const sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
+    return buildThreadHref(sectionSlug, post.id);
+  }
+
   function formatDate(dateString?: string | null): string {
     if (!dateString) return 'Unknown date';
     const date = new Date(dateString);
@@ -551,7 +559,9 @@
                     {postContextErrors[thread.postId]}
                   </div>
                 {:else if threadPost}
-                  <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} profileUserId={resolvedUserId} />
+                  <a href={buildThreadLink(threadPost)} class="block hover:opacity-90 transition-opacity">
+                    <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} profileUserId={resolvedUserId} />
+                  </a>
                 {:else}
                   <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
                     Thread unavailable.

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -7,10 +7,7 @@
   import type { Comment } from '../stores/commentStore';
   import PostCard from './PostCard.svelte';
   import { returnToFeed } from '../services/profileNavigation';
-  import { buildThreadHref } from '../services/routeNavigation';
   import { displayTimezone } from '../stores';
-  import { sections } from '../stores/sectionStore';
-  import { getSectionSlugById } from '../services/sectionSlug';
   import { formatInTimezone } from '../lib/time';
 
   export let userId: string | null;
@@ -348,16 +345,6 @@
     return groups;
   }
 
-  function buildThreadLink(post: Post): string {
-    const sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
-    return buildThreadHref(sectionSlug, post.id);
-  }
-
-  function buildThreadLinkForPost(post?: Post | null): string {
-    if (!post) return '#';
-    return buildThreadLink(post);
-  }
-
   function formatDate(dateString?: string | null): string {
     if (!dateString) return 'Unknown date';
     const date = new Date(dateString);
@@ -557,18 +544,6 @@
             {#each commentThreads as thread (thread.postId)}
               {@const threadPost = postContext[thread.postId]}
               <div class="space-y-3">
-                <div class="flex items-center justify-between text-xs text-gray-500">
-                  <span class="font-semibold uppercase tracking-wide text-gray-400">Thread</span>
-                  {#if threadPost}
-                    <a
-                      href={buildThreadLinkForPost(threadPost)}
-                      class="text-xs text-blue-600 hover:text-blue-800"
-                    >
-                      Open full thread ->
-                    </a>
-                  {/if}
-                </div>
-
                 {#if postContextLoading.has(thread.postId)}
                   <div class="text-sm text-gray-500">Loading thread...</div>
                 {:else if postContextErrors[thread.postId]}

--- a/frontend/src/components/__tests__/UserProfile.test.ts
+++ b/frontend/src/components/__tests__/UserProfile.test.ts
@@ -169,8 +169,7 @@ describe('UserProfile', () => {
     await commentsTab.click();
     await flushProfileLoad();
 
-    expect(await screen.findByText('Thread')).toBeInTheDocument();
-    expect(await screen.findByText('Open full thread ->')).toBeInTheDocument();
+    expect(await screen.findByText('Riley')).toBeInTheDocument();
 
     const observer = (globalThis as { __lastObserver?: { trigger: (value: boolean) => void } })
       .__lastObserver;


### PR DESCRIPTION
## Summary

Simplified the profile comments view by removing the redundant "Open full thread" link and making the entire PostCard clickable instead. Users can now click anywhere on the thread card to navigate to the full thread.

## Changes

- Wrapped PostCard in a clickable link (`<a>` tag) in the profile comments view
- Removed standalone "Open full thread" link that appeared above each thread
- Added hover effect (opacity transition) to indicate clickability

## Test Plan

- Verified clicking on any part of the thread card navigates to the full thread
- Checked that the hover effect provides visual feedback
- Confirmed all other PostCard functionality (reactions, comment display) still works
- All CI checks passed (backend format/lint, backend tests, frontend lint/check/test)

Closes #573