### PR TITLE
Highlight search query in unified thread results (post body + comments)

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -23,6 +23,7 @@
   export let highlightCommentIds: string[] = [];
   export let showSectionPill: boolean = false;
   export let profileUserId: string | null = null;
+  export let highlightQuery: string = '';
 
   type ImageItem = {
     id?: string;
@@ -982,6 +983,7 @@
       {:else}
         <LinkifiedText
           text={displayContent}
+          highlightQuery={highlightQuery}
           className="text-gray-800 whitespace-pre-wrap break-words mb-3"
         />
       {/if}
@@ -1256,6 +1258,7 @@
           {highlightCommentId}
           {highlightCommentIds}
           {profileUserId}
+          {highlightQuery}
           {imageItems}
           imageReplyTarget={imageReplyTarget}
           onClearImageReply={clearImageReplyTarget}

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -19,6 +19,7 @@
   export let highlightCommentId: string | null = null;
   export let highlightCommentIds: string[] = [];
   export let profileUserId: string | null = null;
+  export let highlightQuery: string = '';
   export let imageItems: {
     id?: string;
     url: string;
@@ -489,6 +490,7 @@
               {:else}
                 <LinkifiedText
                   text={comment.content}
+                  highlightQuery={highlightQuery}
                   className="text-gray-800 text-sm whitespace-pre-wrap break-words"
                   linkClassName="text-blue-600 hover:text-blue-800 underline"
                 />
@@ -706,6 +708,7 @@
                         {:else}
                           <LinkifiedText
                             text={reply.content}
+                            highlightQuery={highlightQuery}
                             className="text-gray-800 text-sm whitespace-pre-wrap break-words"
                             linkClassName="text-blue-600 hover:text-blue-800 underline"
                           />

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -409,11 +409,11 @@
             {#each group.groupedResults as item, index (itemKey(item, index))}
               {#if isThreadGroup(item)}
                 {@const thread = item}
-                <PostCard post={thread.post} highlightCommentIds={thread.matchingCommentIds} />
+                <PostCard post={thread.post} highlightCommentIds={thread.matchingCommentIds} highlightQuery={normalizedQuery} />
               {:else}
                 {@const result = item}
                 {#if result.type === 'post' && result.post}
-                  <PostCard post={result.post} />
+                  <PostCard post={result.post} highlightQuery={normalizedQuery} />
                 {:else if result.type === 'comment' && result.comment}
                 {@const comment = result.comment}
                 {@const parentPost = result.post}
@@ -595,7 +595,7 @@
               </span>
             </div>
           {/if}
-          <PostCard post={thread.post} highlightCommentIds={thread.matchingCommentIds} />
+          <PostCard post={thread.post} highlightCommentIds={thread.matchingCommentIds} highlightQuery={normalizedQuery} />
         {:else}
           {@const result = item}
           {@const sectionName = resolveSectionName(result, $activeSection?.id ?? null, $activeSection?.name ?? null)}
@@ -611,7 +611,7 @@
                 </span>
               </div>
             {/if}
-            <PostCard post={result.post} />
+            <PostCard post={result.post} highlightQuery={normalizedQuery} />
       {:else if result.type === 'comment' && result.comment}
         {@const comment = result.comment}
         {@const parentPost = result.post}


### PR DESCRIPTION
## Summary

Adds search query highlighting to unified thread results in search. When users search for text and results are displayed as threads, the matching query is now highlighted in both post bodies and comments.

## Changes

- Added `highlightQuery` prop to `PostCard` component
- `PostCard` now passes `highlightQuery` to `LinkifiedText` when rendering post content
- `PostCard` passes `highlightQuery` to `CommentThread` component
- `CommentThread` passes `highlightQuery` to `LinkifiedText` for both top-level comments and nested replies
- `SearchResults` now passes `normalizedQuery` to `PostCard` for:
  - Unified threads (post + matching comments)
  - Standalone posts
- Standalone comments already had highlighting via `LinkifiedText`

## Test plan

- [x] All 281 frontend tests pass
- [x] Frontend typecheck passes (`npm run check`)
- [x] Pre-commit hooks pass

### Manual testing scenarios:
1. Search for text that appears in a post body → post content should be highlighted
2. Search for text that appears in comments → comment content should be highlighted
3. Search for text that appears in both post and comments → both should be highlighted in unified thread
4. Multiple occurrences of the search term in the same text should all be highlighted
5. Highlight styling matches existing search highlight styles (yellow background from `LinkifiedText`)

## Closes

Closes #565