### PR TITLE
Fix frontend OTLP traces proxy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Optional frontend environment variables:
 - `VITE_SENTRY_DSN`: Sentry DSN for client error tracking (leave unset to disable).
 - `VITE_APP_VERSION`: Release identifier for error tracking.
 - `VITE_OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP/HTTP traces endpoint for browser telemetry (in dev defaults to `/otlp/v1/traces` via the Vite proxy; leave unset in prod to disable).
-- `VITE_OTEL_PROXY_TARGET`: Dev-only target for the Vite OTLP proxy (defaults to `http://localhost:4318`).
+- `VITE_OTEL_PROXY_TARGET`: Dev-only target for the Vite OTLP proxy (defaults to `http://localhost:4318`; `docker compose` sets this to `http://tempo:4318`).
 - `VITE_OTEL_SERVICE_NAME`: Service name used in frontend traces (defaults to `clubhouse-frontend`).
 - `VITE_PROXY_LOG_LEVEL`: Vite proxy logging level (`none`/`silent`, `error`, `warn`, `info`, `debug`; defaults to `warn`).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,7 @@ services:
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
     environment:
       VITE_API_PROXY_TARGET: http://backend:8080
+      VITE_OTEL_PROXY_TARGET: http://tempo:4318
       VITE_PROXY_LOG_LEVEL: ${VITE_PROXY_LOG_LEVEL:-warn}
     ports:
       - "5173:5173"


### PR DESCRIPTION
## Summary
- route the Vite OTLP proxy to the Tempo container in docker compose
- document the docker compose OTLP proxy target in the README

## Testing
- not run (config/doc-only change)

Closes #597