### PR TITLE
Group section-scoped search results under single section header

### DIFF
--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -194,20 +194,6 @@
     return section?.icon ?? fallbackIcon;
   }
 
-  function resolveSectionName(result: SearchResult, fallbackSectionId: string | null, fallbackName: string | null): string | null {
-    const sectionId = resolveSectionId(result, fallbackSectionId);
-    return resolveSectionNameById(sectionId, fallbackName, $sections);
-  }
-
-  function resolveSectionIcon(
-    result: SearchResult,
-    fallbackSectionId: string | null,
-    fallbackIcon: string | null,
-  ): string | null {
-    const sectionId = resolveSectionId(result, fallbackSectionId);
-    return resolveSectionIconById(sectionId, fallbackIcon, $sections);
-  }
-
   function buildSectionGroups(results: SearchResult[], availableSections: typeof $sections): SectionGroup[] {
     const groups: SectionGroup[] = [];
     const seen = new Map<string, SectionGroup>();
@@ -228,6 +214,24 @@
       group.groupedResults = groupResultsByThread(group.results);
     }
     return groups;
+  }
+
+  function buildScopedGroup(
+    results: SearchResult[],
+    currentSection: typeof $activeSection,
+    availableSections: typeof $sections,
+  ): SectionGroup | null {
+    if (results.length === 0) return null;
+    const sectionId = currentSection?.id ?? resolveSectionId(results[0], null);
+    const name = currentSection?.name ?? resolveSectionNameById(sectionId, null, availableSections) ?? 'Section';
+    const icon = currentSection?.icon ?? resolveSectionIconById(sectionId, '📁', availableSections);
+    return {
+      id: sectionId,
+      name,
+      icon,
+      results,
+      groupedResults: groupResultsByThread(results),
+    };
   }
 
   function groupResultsByThread(results: SearchResult[]): (SearchResult | ThreadGroup)[] {
@@ -319,9 +323,9 @@
   $: showResults = hasSearched;
   $: displayScope = hasSearched && $lastSearchScope ? $lastSearchScope : $searchScope;
   $: isGlobalScope = displayScope === 'global';
-  $: showParentSectionPill = displayScope === 'global';
   $: sectionGroups = isGlobalScope ? buildSectionGroups($searchResults, $sections) : [];
-  $: groupedResults = groupResultsByThread($searchResults);
+  $: scopedGroup = isGlobalScope ? null : buildScopedGroup($searchResults, $activeSection, $sections);
+  $: displayGroups = isGlobalScope ? sectionGroups : scopedGroup ? [scopedGroup] : [];
 </script>
 
 <section class="space-y-4">
@@ -393,8 +397,8 @@
       </div>
     {/if}
 
-    {#if isGlobalScope}
-      {#each sectionGroups as group}
+    {#if displayGroups.length > 0}
+      {#each displayGroups as group}
         <div class="border border-gray-200 rounded-lg bg-white shadow-sm">
           <div class="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-gray-50 rounded-t-lg">
             <span class={sectionPillClass}>
@@ -578,219 +582,6 @@
             {/each}
           </div>
         </div>
-      {/each}
-    {:else}
-      {#each groupedResults as item, index (itemKey(item, index))}
-        {#if isThreadGroup(item)}
-          {@const thread = item}
-          {@const sectionName = resolveSectionName({ type: 'post', score: 0, post: thread.post }, $activeSection?.id ?? null, $activeSection?.name ?? null)}
-          {@const sectionIcon = resolveSectionIcon({ type: 'post', score: 0, post: thread.post }, $activeSection?.id ?? null, $activeSection?.icon ?? null)}
-          {#if sectionName}
-            <div class="inline-flex items-center gap-2 text-gray-500 min-w-0">
-              <span class={sectionPillClass}>
-                {#if sectionIcon}
-                  <span class={sectionPillIconClass} aria-hidden="true">{sectionIcon}</span>
-                {/if}
-                <span class={sectionPillTextClass}>{sectionName}</span>
-              </span>
-            </div>
-          {/if}
-          <PostCard post={thread.post} highlightCommentIds={thread.matchingCommentIds} highlightQuery={normalizedQuery} />
-        {:else}
-          {@const result = item}
-          {@const sectionName = resolveSectionName(result, $activeSection?.id ?? null, $activeSection?.name ?? null)}
-          {@const sectionIcon = resolveSectionIcon(result, $activeSection?.id ?? null, $activeSection?.icon ?? null)}
-          {#if result.type === 'post' && result.post}
-            {#if sectionName}
-              <div class="inline-flex items-center gap-2 text-gray-500 min-w-0">
-                <span class={sectionPillClass}>
-                  {#if sectionIcon}
-                    <span class={sectionPillIconClass} aria-hidden="true">{sectionIcon}</span>
-                  {/if}
-                  <span class={sectionPillTextClass}>{sectionName}</span>
-                </span>
-              </div>
-            {/if}
-            <PostCard post={result.post} highlightQuery={normalizedQuery} />
-      {:else if result.type === 'comment' && result.comment}
-        {@const comment = result.comment}
-        {@const parentPost = result.post}
-        <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 space-y-4">
-          {#if parentPost}
-            {@const parentPostHasInternalImage =
-              parentPost.links?.some((link) => isInternalUploadUrl(link.url) && getImageLinkUrl(link)) ?? false}
-            {@const parentPostContent = parentPostHasInternalImage
-              ? stripInternalUploadUrls(parentPost.content)
-              : parentPost.content}
-            {@const parentPostLink =
-              parentPost.links?.find((link) => !isInternalUploadUrl(link.url)) ?? null}
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-              <div class="flex items-center justify-between text-xs text-gray-500 mb-2">
-                <div class="flex items-center gap-2">
-                  <span>Parent post</span>
-                  {#if sectionName && showParentSectionPill}
-                    <span class={sectionPillClass}>
-                      {#if sectionIcon}
-                        <span class={sectionPillIconClass} aria-hidden="true">{sectionIcon}</span>
-                      {/if}
-                      <span class={sectionPillTextClass}>{sectionName}</span>
-                    </span>
-                  {/if}
-                </div>
-                <button
-                  type="button"
-                  class="text-blue-600 hover:text-blue-800 underline"
-                  on:click={() => openPostThread(parentPost)}
-                >
-                  View full thread
-                </button>
-              </div>
-              <div class="flex items-start gap-3">
-                {#if parentPost.user?.profilePictureUrl}
-                  <img
-                    src={parentPost.user.profilePictureUrl}
-                    alt={parentPost.user.username}
-                    class="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                  />
-                {:else}
-                  <div class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
-                    <span class="text-gray-500 text-xs font-medium">
-                      {parentPost.user?.username?.charAt(0).toUpperCase() || '?'}
-                    </span>
-                  </div>
-                {/if}
-
-                <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2 mb-1">
-                    <span class="text-sm font-medium text-gray-900 truncate">
-                      {parentPost.user?.username || 'Unknown'}
-                    </span>
-                    <span class="text-gray-400 text-xs">·</span>
-                    <RelativeTime dateString={parentPost.createdAt} className="text-gray-500 text-xs" />
-                    <EditedBadge createdAt={parentPost.createdAt} updatedAt={parentPost.updatedAt} />
-                  </div>
-                  <p class="text-gray-800 text-sm whitespace-pre-wrap break-words line-clamp-3">
-                    {parentPostContent}
-                  </p>
-                  {#if parentPostLink}
-                    <div class="mt-2 text-xs text-blue-600 break-all">
-                      <a
-                        href={parentPostLink.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="underline"
-                      >
-                        {parentPostLink.url}
-                      </a>
-                    </div>
-                  {/if}
-                </div>
-              </div>
-            </div>
-          {/if}
-
-          {#if !parentPost && sectionName}
-            <div class="inline-flex items-center gap-2 text-gray-500 min-w-0">
-              <span class={sectionPillClass}>
-                {#if sectionIcon}
-                  <span class={sectionPillIconClass} aria-hidden="true">{sectionIcon}</span>
-                {/if}
-                <span class={sectionPillTextClass}>{sectionName}</span>
-              </span>
-            </div>
-          {/if}
-
-          <div class="flex items-start gap-3">
-            {#if comment.user?.id}
-              <a
-                href={buildProfileHref(comment.user.id)}
-                class="flex-shrink-0"
-                on:click={(event) => handleProfileNavigation(event, comment.user?.id)}
-                aria-label={`View ${(comment.user?.username ?? 'user')}'s profile`}
-              >
-                {#if comment.user?.profilePictureUrl}
-                  <img
-                    src={comment.user.profilePictureUrl}
-                    alt={comment.user.username}
-                    class="w-9 h-9 rounded-full object-cover"
-                  />
-                {:else}
-                  <div class="w-9 h-9 rounded-full bg-gray-200 flex items-center justify-center">
-                    <span class="text-gray-500 text-sm font-medium">
-                      {comment.user?.username?.charAt(0).toUpperCase() || '?'}
-                    </span>
-                  </div>
-                {/if}
-              </a>
-            {:else}
-              {#if comment.user?.profilePictureUrl}
-                <img
-                  src={comment.user.profilePictureUrl}
-                  alt={comment.user.username}
-                  class="w-9 h-9 rounded-full object-cover flex-shrink-0"
-                />
-              {:else}
-                <div class="w-9 h-9 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
-                  <span class="text-gray-500 text-sm font-medium">
-                    {comment.user?.username?.charAt(0).toUpperCase() || '?'}
-                  </span>
-                </div>
-              {/if}
-            {/if}
-
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-1">
-                {#if comment.user?.id}
-                  <a
-                    href={buildProfileHref(comment.user.id)}
-                    class="font-medium text-gray-900 truncate hover:underline"
-                    on:click={(event) => handleProfileNavigation(event, comment.user?.id)}
-                  >
-                    {comment.user?.username || 'Unknown'}
-                  </a>
-                {:else}
-                  <span class="font-medium text-gray-900 truncate">
-                    {comment.user?.username || 'Unknown'}
-                  </span>
-                {/if}
-                <span class="text-gray-400 text-sm">commented</span>
-                <RelativeTime dateString={comment.createdAt} className="text-gray-500 text-sm" />
-                <EditedBadge createdAt={comment.createdAt} updatedAt={comment.updatedAt} />
-              </div>
-
-              <LinkifiedText
-                text={comment.content}
-                highlightQuery={normalizedQuery}
-                className="text-gray-800 whitespace-pre-wrap break-words"
-                linkClassName="text-blue-600 hover:text-blue-800 underline"
-              />
-
-              {#if comment.links && comment.links.length > 0}
-                <div class="mt-2 text-sm text-blue-600 break-all">
-                  <a
-                    href={comment.links[0].url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="underline"
-                  >
-                    {comment.links[0].url}
-                  </a>
-                </div>
-              {/if}
-
-              <div class="mt-3">
-                <ReactionBar
-                  reactionCounts={comment.reactionCounts ?? {}}
-                  userReactions={new Set(comment.viewerReactions ?? [])}
-                  onToggle={(emoji) => toggleCommentReaction(comment, emoji)}
-                  commentId={comment.id}
-                />
-              </div>
-            </div>
-          </div>
-        </article>
-          {/if}
-        {/if}
       {/each}
     {/if}
   {/if}

--- a/frontend/src/components/search/SearchResults.svelte
+++ b/frontend/src/components/search/SearchResults.svelte
@@ -222,9 +222,16 @@
     availableSections: typeof $sections,
   ): SectionGroup | null {
     if (results.length === 0) return null;
-    const sectionId = currentSection?.id ?? resolveSectionId(results[0], null);
-    const name = currentSection?.name ?? resolveSectionNameById(sectionId, null, availableSections) ?? 'Section';
-    const icon = currentSection?.icon ?? resolveSectionIconById(sectionId, '📁', availableSections);
+    const resultSectionId = resolveSectionId(results[0], null);
+    const currentSectionId = currentSection?.id ?? null;
+    const sectionId = resultSectionId ?? currentSectionId;
+    const useCurrentSection = Boolean(sectionId && currentSectionId && sectionId === currentSectionId);
+    const name = useCurrentSection
+      ? currentSection?.name ?? resolveSectionNameById(sectionId, null, availableSections) ?? 'Section'
+      : resolveSectionNameById(sectionId, null, availableSections) ?? 'Section';
+    const icon = useCurrentSection
+      ? currentSection?.icon ?? resolveSectionIconById(sectionId, '📁', availableSections)
+      : resolveSectionIconById(sectionId, '📁', availableSections);
     return {
       id: sectionId,
       name,


### PR DESCRIPTION
## Summary
- reuse section-grouped search layout for section-scoped searches with a single header
- remove per-result section pills in section-scoped search results
- keep section header styling consistent with the Everywhere view

Closes #600