### PR TITLE
Add "Posted in:" label to section pills in user profile

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -22,6 +22,7 @@
   export let highlightCommentId: string | null = null;
   export let highlightCommentIds: string[] = [];
   export let showSectionPill: boolean = false;
+  export let showSectionLabel: boolean = false;
   export let profileUserId: string | null = null;
   export let highlightQuery: string = '';
 
@@ -725,7 +726,10 @@
 
 <article class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow">
   {#if showSectionPill && sectionInfo}
-    <div class="mb-3">
+    <div class="mb-3 flex flex-wrap items-center gap-2">
+      {#if showSectionLabel}
+        <span class="text-sm font-medium text-gray-500">Posted in:</span>
+      {/if}
       <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-600">
         {#if sectionInfo.icon}
           <span class="text-base leading-none" aria-hidden="true">{sectionInfo.icon}</span>

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -506,7 +506,7 @@
             <p class="text-gray-500 text-sm">No posts yet.</p>
           {:else}
             {#each posts as post (post.id)}
-              <PostCard {post} showSectionPill={true} />
+              <PostCard {post} showSectionPill={true} showSectionLabel={true} />
             {/each}
           {/if}
 
@@ -560,7 +560,13 @@
                   </div>
                 {:else if threadPost}
                   <a href={buildThreadLink(threadPost)} class="block hover:opacity-90 transition-opacity">
-                    <PostCard post={threadPost} highlightCommentIds={thread.commentIds} showSectionPill={true} profileUserId={resolvedUserId} />
+                    <PostCard
+                      post={threadPost}
+                      highlightCommentIds={thread.commentIds}
+                      showSectionPill={true}
+                      showSectionLabel={true}
+                      profileUserId={resolvedUserId}
+                    />
                   </a>
                 {:else}
                   <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import type { Post } from '../../stores/postStore';
 import { authStore } from '../../stores';
+import { sectionStore } from '../../stores/sectionStore';
 import { tick } from 'svelte';
 
 const loadThreadComments = vi.hoisted(() => vi.fn());
@@ -41,6 +42,7 @@ const basePost: Post = {
 beforeEach(() => {
   vi.clearAllMocks();
   authStore.setUser(null);
+  sectionStore.setSections([]);
 });
 
 afterEach(() => {
@@ -75,6 +77,23 @@ describe('PostCard', () => {
 
     render(PostCard, { post: postWithLink });
     expect(screen.getByText('Example')).toBeInTheDocument();
+  });
+
+  it('shows a posted in label when section pill label is enabled', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'General',
+        type: 'general',
+        icon: '💬',
+        slug: 'general',
+      },
+    ]);
+
+    render(PostCard, { post: basePost, showSectionPill: true, showSectionLabel: true });
+
+    expect(screen.getByText('Posted in:')).toBeInTheDocument();
+    expect(screen.getByText('General')).toBeInTheDocument();
   });
 
   it('renders plain link when metadata missing', () => {


### PR DESCRIPTION
## Summary
- add an optional "Posted in:" label before section pills in PostCard
- enable the label for user profile posts and comments views
- cover the label with a PostCard test

## Testing
- npm run check
- npm run test -- -t "posted in label"

Closes #601