### PR TITLE
Un-highlight nested comments by other users in profile and search

### DIFF
--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -299,10 +299,10 @@
 
   function getHighlightClass(commentId: string, commentUserId: string, isNested: boolean): string {
     if (!highlightIdSet.has(commentId)) {
-      return isNested ? '' : 'bg-white';
+      return 'bg-white';
     }
     if (profileUserId && commentUserId !== profileUserId) {
-      return isNested ? '' : 'bg-white';
+      return 'bg-white';
     }
     if (isNested) {
       return 'bg-amber-100 ring-2 ring-amber-400 rounded-lg p-2';

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -412,6 +412,7 @@ describe('CommentThread', () => {
       const replyEl = document.getElementById('comment-reply-1');
       expect(replyEl?.className).not.toContain('bg-amber');
       expect(replyEl?.className).not.toContain('ring-amber');
+      expect(replyEl?.className).toContain('bg-white');
     });
 
     it('highlights comments without profileUserId filter (backward compatibility)', () => {


### PR DESCRIPTION
## Summary
- prevent non-profile nested replies from inheriting highlight styling
- keep highlight behavior for matching/profile comments and top-level defaults
- add coverage for non-profile nested reply background state

Closes #599