### PR TITLE
Reply option missing on images (regression)

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -53,7 +53,6 @@
   let editImageInputs: Array<HTMLInputElement | null> = [];
   let isImageLightboxOpen = false;
   let lightboxImageIndex = 0;
-  let lightboxImageId: string | null = null;
   let isDeleting = false;
   let deleteError: string | null = null;
   let imageReplyTarget:
@@ -422,7 +421,6 @@
   $: lightboxImageUrl = lightboxImageItem?.url;
   $: lightboxAltText =
     lightboxImageItem?.altText ?? lightboxImageItem?.title ?? 'Full size image';
-  $: lightboxImageId = lightboxImageItem?.id ?? null;
   $: if (imageReplyTarget && !imageItems.find((item) => item.id === imageReplyTarget?.id)) {
     imageReplyTarget = null;
   }
@@ -1017,7 +1015,7 @@
                 />
               </button>
             {/if}
-            {#if activeImageItem?.id}
+            {#if activeImageItem}
               <button
                 type="button"
                 class="absolute bottom-3 right-3 inline-flex items-center gap-1 rounded-full border border-blue-200 bg-white/95 px-3 py-1 text-xs text-blue-700 shadow-sm hover:bg-white"
@@ -1074,7 +1072,7 @@
                           />
                         </button>
                       {/if}
-                      {#if item.id}
+                      {#if item}
                         <button
                           type="button"
                           class="absolute bottom-3 right-3 inline-flex items-center gap-1 rounded-full border border-blue-200 bg-white/95 px-3 py-1 text-xs text-blue-700 shadow-sm hover:bg-white"
@@ -1329,7 +1327,7 @@
           />
         {/key}
       </div>
-      {#if lightboxImageId}
+      {#if lightboxImageUrl}
         <div class="mt-3 flex justify-center">
           <button
             type="button"

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -237,7 +237,7 @@
       return;
     }
     imageReplyTarget = {
-      id: item.id,
+      id: item.id ?? undefined,
       url: item.url,
       index,
       altText: item.altText ?? item.title,

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -57,7 +57,7 @@
   let deleteError: string | null = null;
   let imageReplyTarget:
     | {
-        id: string;
+        id?: string;
         url: string;
         index: number;
         altText?: string;
@@ -233,7 +233,7 @@
 
   function startImageReply(index: number) {
     const item = imageItems[index];
-    if (!item?.id) {
+    if (!item) {
       return;
     }
     imageReplyTarget = {
@@ -421,8 +421,16 @@
   $: lightboxImageUrl = lightboxImageItem?.url;
   $: lightboxAltText =
     lightboxImageItem?.altText ?? lightboxImageItem?.title ?? 'Full size image';
-  $: if (imageReplyTarget && !imageItems.find((item) => item.id === imageReplyTarget?.id)) {
-    imageReplyTarget = null;
+  $: if (imageReplyTarget) {
+    const target = imageReplyTarget;
+    const stillExists = imageItems.find((item, index) =>
+      item.id && target.id
+        ? item.id === target.id
+        : item.url === target.url && index === target.index
+    );
+    if (!stillExists) {
+      imageReplyTarget = null;
+    }
   }
 
   let activeImageIndex = 0;

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -103,6 +103,7 @@ describe('PostCard', () => {
 
     render(PostCard, { post: postWithImage });
     expect(screen.getByRole('img', { name: 'Uploaded image' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reply to image' })).toBeInTheDocument();
   });
 
   it('hides internal upload URLs from post content when an image is rendered', () => {

--- a/frontend/src/components/comments/CommentForm.svelte
+++ b/frontend/src/components/comments/CommentForm.svelte
@@ -10,7 +10,7 @@
   export let postId: string;
   export let imageContext:
     | {
-        id: string;
+        id?: string;
         url: string;
         index: number;
         altText?: string;

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -28,7 +28,7 @@
   }[] = [];
   export let imageReplyTarget:
     | {
-        id: string;
+        id?: string;
         url: string;
         index: number;
         altText?: string;

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -198,6 +198,36 @@ describe('CommentThread', () => {
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
   });
 
+  it('shows reply action for comments with images', () => {
+    commentStore.setThread('post-1', [
+      {
+        id: 'comment-1',
+        postId: 'post-1',
+        userId: 'user-1',
+        content: 'Image comment',
+        imageId: 'image-1',
+        createdAt: 'now',
+        user: { id: 'user-1', username: 'Sander' },
+        replies: [],
+      },
+    ], null, false);
+
+    render(CommentThread, {
+      postId: 'post-1',
+      commentCount: 1,
+      imageItems: [
+        {
+          id: 'image-1',
+          url: 'https://cdn.example.com/uploads/photo.png',
+          title: 'Image 1',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument();
+    expect(screen.getByText('Image 1')).toBeInTheDocument();
+  });
+
   it('saves edits with ctrl+enter', async () => {
     authStore.setUser({
       id: 'user-1',

--- a/frontend/src/components/posts/PostForm.svelte
+++ b/frontend/src/components/posts/PostForm.svelte
@@ -307,16 +307,22 @@
         return;
       }
 
-      const links = [
-        ...uploadedUrls.map((url) => ({ url })),
-        ...(linkValue ? [{ url: linkValue }] : []),
-      ];
+      const images = uploadedUrls.map((url) => ({ url }));
+      const links = linkValue ? [{ url: linkValue }] : [];
 
-      const response = await api.createPost({
+      const payload = {
         sectionId: $activeSection.id,
         content: trimmedContent,
-        links: links.length > 0 ? links : undefined,
-      });
+      } as { sectionId: string; content: string; links?: { url: string }[]; images?: { url: string }[] };
+
+      if (links.length > 0) {
+        payload.links = links;
+      }
+      if (images.length > 0) {
+        payload.images = images;
+      }
+
+      const response = await api.createPost(payload);
 
       const createdPost =
         linkMetadata && uploadedUrls.length === 0

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -336,7 +336,7 @@ describe('PostForm', () => {
     expect(screen.getByText('Images must be 10 MB or smaller.')).toBeInTheDocument();
   });
 
-  it('uploads an image and includes it in the post links', async () => {
+  it('uploads an image and includes it in the post images', async () => {
     setAuthenticated();
     setActiveSection();
     uploadImage.mockImplementation(async (_file: File, onProgress?: (progress: number) => void) => {
@@ -363,7 +363,7 @@ describe('PostForm', () => {
     expect(createPost).toHaveBeenCalledWith({
       sectionId: 'section-1',
       content: '',
-      links: [{ url: '/api/v1/uploads/user-1/photo.png' }],
+      images: [{ url: '/api/v1/uploads/user-1/photo.png' }],
     });
     expect(screen.getByText('Uploaded')).toBeInTheDocument();
   });

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -112,12 +112,14 @@ describe('api client', () => {
       sectionId: 'section-1',
       content: 'Hello',
       links: [{ url: 'https://example.com' }],
+      images: [{ url: '/api/v1/uploads/user-1/photo.png' }],
     });
 
     const postCall = findCall('/posts');
     const body = JSON.parse(postCall?.[1]?.body as string);
     expect(body.section_id).toBe('section-1');
     expect(body.content).toBe('Hello');
+    expect(body.images).toEqual([{ url: '/api/v1/uploads/user-1/photo.png' }]);
     expect(response.post.createdAt).toBe('2025-01-01T00:00:00Z');
     expect(response.post.userId).toBe('user-1');
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -412,6 +412,11 @@ class ApiClient {
       section_id: data.sectionId,
       content: data.content,
       links: data.links,
+      images: data.images?.map((image) => ({
+        url: image.url,
+        caption: image.caption,
+        alt_text: image.altText,
+      })),
     });
     return { post: mapApiPost(response.post) };
   }

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -50,6 +50,7 @@ export interface CreatePostRequest {
   sectionId: string;
   content: string;
   links?: { url: string }[];
+  images?: { url: string; caption?: string; altText?: string }[];
 }
 
 interface PostState {


### PR DESCRIPTION
## Summary
- keep image reply actions visible for all post image types (including link-based)
- allow image reply context to render without a stored image id
- add coverage for image reply visibility on posts and image comments

## Testing
- npm run check
- npm run test -- src/components/__tests__/PostCard.test.ts src/components/comments/__tests__/CommentThread.test.ts

Closes #595