### PR TITLE
Configure all third-party services to log in JSON

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -88,7 +88,7 @@ services:
       - "-c"
       - "logging_collector=on"
       - "-c"
-      - "log_directory=/var/lib/postgresql/data/log"
+      - "log_directory=/var/lib/postgresql/log"
       - "-c"
       - "log_filename=postgresql-%Y-%m-%d.json"
     environment:
@@ -97,6 +97,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - postgres_logs:/var/lib/postgresql/log
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 10s
@@ -210,7 +211,7 @@ services:
     volumes:
       - ./vector/vector.toml:/etc/vector/vector.toml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - postgres_data:/var/lib/postgresql/data:ro
+      - postgres_logs:/var/lib/postgresql/log:ro
       - vector_data:/var/lib/vector
     depends_on:
       - loki
@@ -225,6 +226,7 @@ services:
 
 volumes:
   postgres_data:
+  postgres_logs:
   redis_data:
   loki_data:
   prometheus_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,16 @@ services:
     image: postgres:16
     container_name: clubhouse-postgres
     restart: unless-stopped
+    command:
+      - "postgres"
+      - "-c"
+      - "log_destination=jsonlog"
+      - "-c"
+      - "logging_collector=on"
+      - "-c"
+      - "log_directory=/var/lib/postgresql/data/log"
+      - "-c"
+      - "log_filename=postgresql-%Y-%m-%d.json"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -99,7 +109,7 @@ services:
     image: redis:7-alpine
     container_name: clubhouse-redis
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+    command: redis-server --requirepass ${REDIS_PASSWORD} --loglevel notice --logfile /proc/1/fd/1
     volumes:
       - redis_data:/data
     healthcheck:
@@ -129,6 +139,8 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=30d'
+      - '--log.level=${LOG_LEVEL:-info}'
+      - '--log.format=json'
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/alerts:/etc/prometheus/alerts:ro
@@ -146,6 +158,7 @@ services:
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--log.level=${LOG_LEVEL:-info}'
+      - '--log.format=json'
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     networks:
@@ -173,6 +186,9 @@ services:
       GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL}
       GF_SERVER_SERVE_FROM_SUB_PATH: ${GF_SERVER_SERVE_FROM_SUB_PATH:-false}
       GF_PLUGINS_PREINSTALL: ${GF_PLUGINS_PREINSTALL:-}
+      GF_LOG_LEVEL: ${GF_LOG_LEVEL:-warn}
+      GF_LOG_CONSOLE_FORMAT: json
+      GF_LOG_FILE_FORMAT: json
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/entrypoint.sh:/etc/grafana/entrypoint.sh:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -202,6 +202,27 @@ services:
       - tempo
       - alertmanager
 
+  vector:
+    image: timberio/vector:0.38.0-alpine
+    container_name: clubhouse-vector
+    restart: unless-stopped
+    command: ["-c", "/etc/vector/vector.toml"]
+    volumes:
+      - ./vector/vector.toml:/etc/vector/vector.toml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - postgres_data:/var/lib/postgresql/data:ro
+      - vector_data:/var/lib/vector
+    depends_on:
+      - loki
+      - postgres
+      - redis
+      - prometheus
+      - alertmanager
+      - tempo
+      - grafana
+    networks:
+      - clubhouse
+
 volumes:
   postgres_data:
   redis_data:
@@ -212,6 +233,7 @@ volumes:
   caddy_data:
   caddy_config:
   uploads_data:
+  vector_data:
 
 networks:
   clubhouse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "-c"
       - "logging_collector=on"
       - "-c"
-      - "log_directory=/var/lib/postgresql/data/log"
+      - "log_directory=/var/lib/postgresql/log"
       - "-c"
       - "log_filename=postgresql-%Y-%m-%d.json"
     environment:
@@ -21,6 +21,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - postgres_logs:/var/lib/postgresql/log
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U clubhouse"]
       interval: 10s
@@ -148,7 +149,7 @@ services:
     volumes:
       - ./vector/vector.toml:/etc/vector/vector.toml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - postgres_data:/var/lib/postgresql/data:ro
+      - postgres_logs:/var/lib/postgresql/log:ro
       - vector_data:/var/lib/vector
     depends_on:
       - loki
@@ -218,6 +219,7 @@ services:
 
 volumes:
   postgres_data:
+  postgres_logs:
   redis_data:
   loki_data:
   prometheus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,27 @@ services:
       - tempo
       - alertmanager
 
+  # Vector (Log Forwarder)
+  vector:
+    image: timberio/vector:0.38.0-alpine
+    container_name: clubhouse-vector
+    command: ["-c", "/etc/vector/vector.toml"]
+    volumes:
+      - ./vector/vector.toml:/etc/vector/vector.toml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - postgres_data:/var/lib/postgresql/data:ro
+      - vector_data:/var/lib/vector
+    depends_on:
+      - loki
+      - postgres
+      - redis
+      - prometheus
+      - alertmanager
+      - tempo
+      - grafana
+    networks:
+      - clubhouse
+
   # Backend API
   backend:
     build:
@@ -203,6 +224,7 @@ volumes:
   tempo_data:
   grafana_data:
   uploads_data:
+  vector_data:
 
 networks:
   clubhouse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,16 @@ services:
   postgres:
     image: postgres:16
     container_name: clubhouse-postgres
+    command:
+      - "postgres"
+      - "-c"
+      - "log_destination=jsonlog"
+      - "-c"
+      - "logging_collector=on"
+      - "-c"
+      - "log_directory=/var/lib/postgresql/data/log"
+      - "-c"
+      - "log_filename=postgresql-%Y-%m-%d.json"
     environment:
       POSTGRES_USER: clubhouse
       POSTGRES_PASSWORD: changeme
@@ -23,7 +33,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: clubhouse-redis
-    command: redis-server --requirepass changeme
+    command: redis-server --requirepass changeme --loglevel notice --logfile /proc/1/fd/1
     ports:
       - "6379:6379"
     volumes:
@@ -79,6 +89,7 @@ services:
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--log.level=${LOG_LEVEL:-info}'
+      - '--log.format=json'
     ports:
       - "9093:9093"
     volumes:
@@ -111,7 +122,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: admin
       # Optional plugin preinstall list (e.g. "grafana-piechart-panel")
       GF_PLUGINS_PREINSTALL: ${GF_PLUGINS_PREINSTALL:-}
-      GF_LOG_LEVEL: warn
+      GF_LOG_LEVEL: ${GF_LOG_LEVEL:-warn}
       GF_LOG_CONSOLE_FORMAT: json
       GF_LOG_FILE_FORMAT: json
     ports:

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -191,7 +191,8 @@ The backup/restore scripts source `.env.production` automatically when present.
 Third-party services in the Docker Compose stack are configured for JSON logging where supported.
 Postgres uses `jsonlog` and writes structured logs under `/var/lib/postgresql/data/log` in the data volume.
 Prometheus, Alertmanager, Loki, Tempo, and Grafana emit JSON logs to stdout/stderr.
-Redis logs to stdout with a consistent level and is ready for JSON conversion in the log pipeline.
+Redis does not support JSON output; a Vector log forwarder wraps Redis logs as JSON before sending to Loki.
+Vector also tails Postgres jsonlog files so Postgres logs reach Loki in JSON form.
 
 Grafana dashboards are provisioned from `grafana/dashboards`.
 The Grafana entrypoint ensures `/usr/share/grafana/plugins-bundled` exists to avoid startup warnings.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -188,6 +188,11 @@ The backup/restore scripts source `.env.production` automatically when present.
 - Metrics: `/metrics` scraped by Prometheus
 - Retention: 7 days of traces (`tempo.yml`), 14 days of logs (`loki.yml`), and 30 days of metrics (`--storage.tsdb.retention.time=30d`)
 
+Third-party services in the Docker Compose stack are configured for JSON logging where supported.
+Postgres uses `jsonlog` and writes structured logs under `/var/lib/postgresql/data/log` in the data volume.
+Prometheus, Alertmanager, Loki, Tempo, and Grafana emit JSON logs to stdout/stderr.
+Redis logs to stdout with a consistent level and is ready for JSON conversion in the log pipeline.
+
 Grafana dashboards are provisioned from `grafana/dashboards`.
 The Grafana entrypoint ensures `/usr/share/grafana/plugins-bundled` exists to avoid startup warnings.
 Grafana startup removes any legacy external xychart plugin from the data volume to avoid duplicate registration with the built-in panel.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -189,7 +189,7 @@ The backup/restore scripts source `.env.production` automatically when present.
 - Retention: 7 days of traces (`tempo.yml`), 14 days of logs (`loki.yml`), and 30 days of metrics (`--storage.tsdb.retention.time=30d`)
 
 Third-party services in the Docker Compose stack are configured for JSON logging where supported.
-Postgres uses `jsonlog` and writes structured logs under `/var/lib/postgresql/data/log` in the data volume.
+Postgres uses `jsonlog` and writes structured logs under `/var/lib/postgresql/log` in the dedicated `postgres_logs` volume.
 Prometheus, Alertmanager, Loki, Tempo, and Grafana emit JSON logs to stdout/stderr.
 Redis does not support JSON output; a Vector log forwarder wraps Redis logs as JSON before sending to Loki.
 Vector also tails Postgres jsonlog files so Postgres logs reach Loki in JSON form.

--- a/loki.yml
+++ b/loki.yml
@@ -3,6 +3,7 @@ auth_enabled: false
 server:
   http_listen_port: 3100
   log_level: warn
+  log_format: json
 
 common:
   instance_addr: 127.0.0.1

--- a/vector/vector.toml
+++ b/vector/vector.toml
@@ -16,9 +16,18 @@ inputs = ["third_party_docker"]
 source = '''
 service = .container_name
 ts = .timestamp
-parsed = parse_json(.message)
+parsed = parse_json(.message) ?? null
 if is_object(parsed) {
   . = parsed
+}
+if service == "clubhouse-redis" && !is_object(parsed) {
+  redis_match = parse_regex(.message, r'^(?P<pid>\d+):(?P<role>[A-Z]) (?P<date>\d{2} \w{3} \d{4}) (?P<time>\d{2}:\d{2}:\d{2}\.\d{3}) (?P<level>[#*.-]) (?P<msg>.*)$') ?? null
+  if is_object(redis_match) {
+    .redis_pid = redis_match.pid
+    .redis_role = redis_match.role
+    .redis_level = redis_match.level
+    .message = redis_match.msg
+  }
 }
 .timestamp = ts
 .service = service
@@ -28,7 +37,7 @@ if is_object(parsed) {
 
 [sources.postgres_json]
 type = "file"
-include = ["/var/lib/postgresql/data/log/*.json"]
+include = ["/var/lib/postgresql/log/*.json"]
 read_from = "end"
 
 [transforms.normalize_postgres]

--- a/vector/vector.toml
+++ b/vector/vector.toml
@@ -1,0 +1,52 @@
+data_dir = "/var/lib/vector"
+
+[sources.docker_logs]
+type = "docker_logs"
+docker_host = "unix:///var/run/docker.sock"
+exclude_containers = ["clubhouse-vector"]
+
+[transforms.third_party_docker]
+type = "filter"
+inputs = ["docker_logs"]
+condition = '.container_name == "clubhouse-redis" || .container_name == "clubhouse-prometheus" || .container_name == "clubhouse-alertmanager" || .container_name == "clubhouse-tempo" || .container_name == "clubhouse-loki" || .container_name == "clubhouse-grafana" || .container_name == "clubhouse-caddy"'
+
+[transforms.normalize_docker]
+type = "remap"
+inputs = ["third_party_docker"]
+source = '''
+service = .container_name
+ts = .timestamp
+parsed = parse_json(.message)
+if is_object(parsed) {
+  . = parsed
+}
+.timestamp = ts
+.service = service
+.container = service
+.source = "docker"
+'''
+
+[sources.postgres_json]
+type = "file"
+include = ["/var/lib/postgresql/data/log/*.json"]
+read_from = "end"
+
+[transforms.normalize_postgres]
+type = "remap"
+inputs = ["postgres_json"]
+source = '''
+parsed = parse_json(.message)
+if is_object(parsed) {
+  . = parsed
+}
+.service = "postgres"
+.container = "clubhouse-postgres"
+.source = "postgres-jsonlog"
+'''
+
+[sinks.loki]
+type = "loki"
+inputs = ["normalize_docker", "normalize_postgres"]
+endpoint = "http://loki:3100"
+labels = { service = "{{ service }}", source = "{{ source }}" }
+encoding.codec = "json"


### PR DESCRIPTION
## Summary
- configure Postgres to emit JSON logs (jsonlog) and set Loki log_format to json
- set Prometheus/Alertmanager/Grafana to JSON log output in dev + prod compose
- normalize Redis logging to stdout at notice level and document log formats in production docs

Closes #604