### PR TITLE
Improve notification read status and counter behavior

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -312,6 +312,7 @@ func main() {
 
 	// Notification routes (protected)
 	mux.Handle("/api/v1/notifications", requireAuth(http.HandlerFunc(notificationHandler.GetNotifications)))
+	mux.Handle("/api/v1/notifications/read", requireAuthCSRF(http.HandlerFunc(notificationHandler.MarkAllNotificationsRead)))
 	mux.Handle("/api/v1/notifications/", requireAuthCSRF(http.HandlerFunc(notificationHandler.MarkNotificationRead)))
 
 	// Push routes (protected)

--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -37,3 +37,8 @@ type GetNotificationsResponse struct {
 type UpdateNotificationResponse struct {
 	Notification Notification `json:"notification"`
 }
+
+// MarkAllNotificationsReadResponse represents the response for marking all notifications read.
+type MarkAllNotificationsReadResponse struct {
+	UnreadCount int `json:"unread_count"`
+}

--- a/frontend/src/components/notifications/NotificationMenu.svelte
+++ b/frontend/src/components/notifications/NotificationMenu.svelte
@@ -5,14 +5,13 @@
     loadNotifications,
     loadMoreNotifications,
     markNotificationRead,
-    markVisibleNotificationsRead,
+    markAllNotificationsRead,
   } from '../../stores';
   import type { Notification } from '../../stores';
   import { buildStandaloneThreadHref, pushPath } from '../../services/routeNavigation';
   import RelativeTime from '../RelativeTime.svelte';
 
   let menuOpen = false;
-  let markedOnOpen = false;
 
   const typeLabels: Record<string, string> = {
     new_post: 'New post',
@@ -24,7 +23,6 @@
   function toggleMenu() {
     menuOpen = !menuOpen;
     if (menuOpen) {
-      markedOnOpen = false;
       if ($notificationStore.notifications.length === 0 && !$notificationStore.isLoading) {
         loadNotifications();
       }
@@ -96,12 +94,7 @@
   }
 
   function handleMarkAll() {
-    markVisibleNotificationsRead();
-  }
-
-  $: if (menuOpen && !markedOnOpen && $notificationStore.notifications.length > 0) {
-    markedOnOpen = true;
-    markVisibleNotificationsRead();
+    markAllNotificationsRead();
   }
 
 </script>
@@ -174,7 +167,12 @@
                   </span>
                   <div class="flex-1">
                     <div class="flex items-center justify-between gap-2">
-                      <p class="text-sm text-gray-900">{notificationTitle(notification)}</p>
+                      <div class="flex items-center gap-2">
+                        {#if !notification.readAt}
+                          <span class="h-2 w-2 rounded-full bg-blue-500" aria-label="Unread"></span>
+                        {/if}
+                        <p class="text-sm text-gray-900">{notificationTitle(notification)}</p>
+                      </div>
                       <RelativeTime
                         dateString={notification.createdAt}
                         className="text-xs text-gray-400"

--- a/frontend/src/components/notifications/__tests__/NotificationMenu.test.ts
+++ b/frontend/src/components/notifications/__tests__/NotificationMenu.test.ts
@@ -13,7 +13,7 @@ const storeRefs: {
   loadNotifications: ReturnType<typeof vi.fn>;
   loadMoreNotifications: ReturnType<typeof vi.fn>;
   markNotificationRead: ReturnType<typeof vi.fn>;
-  markVisibleNotificationsRead: ReturnType<typeof vi.fn>;
+  markAllNotificationsRead: ReturnType<typeof vi.fn>;
 } = {} as any;
 
 const routeRefs = {
@@ -36,7 +36,7 @@ vi.mock('../../../stores', () => {
   storeRefs.loadNotifications = vi.fn();
   storeRefs.loadMoreNotifications = vi.fn();
   storeRefs.markNotificationRead = vi.fn();
-  storeRefs.markVisibleNotificationsRead = vi.fn();
+  storeRefs.markAllNotificationsRead = vi.fn();
 
   return storeRefs;
 });
@@ -65,7 +65,7 @@ beforeEach(() => {
   storeRefs.loadNotifications.mockReset();
   storeRefs.loadMoreNotifications.mockReset();
   storeRefs.markNotificationRead.mockReset();
-  storeRefs.markVisibleNotificationsRead.mockReset();
+  storeRefs.markAllNotificationsRead.mockReset();
   routeRefs.buildStandaloneThreadHref.mockReset();
   routeRefs.pushPath.mockReset();
 });
@@ -82,10 +82,10 @@ describe('NotificationMenu', () => {
     await fireEvent.click(toggle);
 
     expect(storeRefs.loadNotifications).toHaveBeenCalledTimes(1);
-    expect(storeRefs.markVisibleNotificationsRead).not.toHaveBeenCalled();
+    expect(storeRefs.markAllNotificationsRead).not.toHaveBeenCalled();
   });
 
-  it('marks visible notifications when opening with items', async () => {
+  it('does not mark notifications when opening with items', async () => {
     storeRefs.notificationStore.set({
       ...baseState,
       notifications: [
@@ -105,7 +105,7 @@ describe('NotificationMenu', () => {
     await fireEvent.click(toggle);
     await tick();
 
-    expect(storeRefs.markVisibleNotificationsRead).toHaveBeenCalledTimes(1);
+    expect(storeRefs.markAllNotificationsRead).not.toHaveBeenCalled();
   });
 
   it('marks a notification read and navigates on click', async () => {
@@ -132,7 +132,7 @@ describe('NotificationMenu', () => {
     await fireEvent.click(toggle);
     await tick();
 
-    storeRefs.markVisibleNotificationsRead.mockClear();
+    storeRefs.markAllNotificationsRead.mockClear();
 
     const notificationButton = screen.getByText('Someone commented on your post');
     await fireEvent.click(notificationButton);
@@ -161,11 +161,11 @@ describe('NotificationMenu', () => {
     await fireEvent.click(toggle);
     await tick();
 
-    storeRefs.markVisibleNotificationsRead.mockClear();
+    storeRefs.markAllNotificationsRead.mockClear();
 
     const markAll = screen.getByText('Mark all as read');
     await fireEvent.click(markAll);
 
-    expect(storeRefs.markVisibleNotificationsRead).toHaveBeenCalledTimes(1);
+    expect(storeRefs.markAllNotificationsRead).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/stores/__tests__/notificationStore.test.ts
+++ b/frontend/src/stores/__tests__/notificationStore.test.ts
@@ -31,7 +31,7 @@ vi.mock('../authStore', () => {
   };
 });
 
-const { notificationStore, markNotificationRead, markVisibleNotificationsRead, handleRealtimeNotification } =
+const { notificationStore, markNotificationRead, markAllNotificationsRead, handleRealtimeNotification } =
   await import(
   '../notificationStore'
 );
@@ -137,7 +137,7 @@ describe('notificationStore', () => {
     expect(apiPatch).not.toHaveBeenCalled();
   });
 
-  it('reloads notifications when marking visible ones fails', async () => {
+  it('reloads notifications when marking all fails', async () => {
     notificationStore.setNotifications(
       [
         {
@@ -158,16 +158,7 @@ describe('notificationStore', () => {
       2
     );
 
-    apiPatch
-      .mockResolvedValueOnce({
-        notification: {
-          id: 'notif-4',
-          type: 'new_post',
-          created_at: '2026-01-01T00:00:00Z',
-          read_at: '2026-01-02T00:00:00Z',
-        },
-      })
-      .mockRejectedValueOnce(new Error('nope'));
+    apiPatch.mockRejectedValueOnce(new Error('nope'));
 
     apiGet.mockResolvedValue({
       notifications: [
@@ -191,9 +182,9 @@ describe('notificationStore', () => {
       },
     });
 
-    await markVisibleNotificationsRead();
+    await markAllNotificationsRead();
 
-    expect(apiPatch).toHaveBeenCalledTimes(2);
+    expect(apiPatch).toHaveBeenCalledTimes(1);
     expect(apiGet).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add mark-all notifications read endpoint with audit logging and unread count response
- stop auto-marking notifications on open; provide explicit mark-all action and unread indicator
- align notification store behavior and tests with new endpoint

## Testing
- cd backend && go build ./...
- cd backend && go test ./internal/handlers -run Notification -v
- cd frontend && npm run check
- cd frontend && npm run test -- -t "NotificationMenu|notificationStore"

Closes #598