### PR TITLE
Fix @mention behavior for nonexistent users

### DIFF
--- a/backend/internal/handlers/comment.go
+++ b/backend/internal/handlers/comment.go
@@ -108,7 +108,7 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	publishCtx, cancel := publishContext()
 	_ = h.notify.CreateNotificationForPostComment(publishCtx, comment.PostID, comment.ID, userID)
-	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, comment.Content, userID)
+	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, req.MentionUsernames, comment.Content, userID)
 	_ = publishEvent(publishCtx, h.redis, formatChannel(postPrefix, comment.PostID), "new_comment", commentEventData{Comment: comment})
 	if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, comment.PostID); err == nil {
 		_ = h.notify.CreateMentionNotifications(publishCtx, mentionedUserIDs, userID, sectionID, comment.PostID, &comment.ID)
@@ -203,7 +203,7 @@ func (h *CommentHandler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	publishCtx, cancel := publishContext()
-	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, comment.Content, userID)
+	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, req.MentionUsernames, comment.Content, userID)
 	if comment.SectionID != nil {
 		_ = h.notify.CreateMentionNotifications(publishCtx, mentionedUserIDs, userID, *comment.SectionID, comment.PostID, &comment.ID)
 	} else if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, comment.PostID); err == nil {

--- a/backend/internal/handlers/post.go
+++ b/backend/internal/handlers/post.go
@@ -108,7 +108,7 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 
 	publishCtx, cancel := publishContext()
 	_ = h.notify.CreateNotificationsForNewPost(publishCtx, post.ID, post.SectionID, userID)
-	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, post.Content, userID)
+	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, req.MentionUsernames, post.Content, userID)
 	_ = h.notify.CreateMentionNotifications(publishCtx, mentionedUserIDs, userID, post.SectionID, post.ID, nil)
 	_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, post.SectionID), "new_post", postEventData{Post: post})
 	_ = publishMentions(publishCtx, h.redis, mentionedUserIDs, userID, &post.ID, nil, mentioningUser, contentExcerpt)
@@ -201,7 +201,7 @@ func (h *PostHandler) UpdatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	publishCtx, cancel := publishContext()
-	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, post.Content, userID)
+	mentionedUserIDs, _ := resolveMentionedUserIDs(publishCtx, h.userService, req.MentionUsernames, post.Content, userID)
 	_ = h.notify.CreateMentionNotifications(publishCtx, mentionedUserIDs, userID, post.SectionID, post.ID, nil)
 	mentioningUser := userSummaryFromUser(post.User)
 	if mentioningUser == nil {

--- a/backend/internal/handlers/user_test.go
+++ b/backend/internal/handlers/user_test.go
@@ -192,11 +192,39 @@ func TestLookupUserByUsername(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
+	if response.User == nil {
+		t.Fatalf("expected user, got nil")
+	}
 	if response.User.ID != userID {
 		t.Errorf("expected user ID %s, got %s", userID, response.User.ID)
 	}
 	if response.User.Username != "Sander" {
 		t.Errorf("expected username Sander, got %s", response.User.Username)
+	}
+}
+
+func TestLookupUserByUsernameNotFoundReturnsEmpty(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewUserHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/users/lookup?username=ghost", nil)
+	w := httptest.NewRecorder()
+
+	handler.LookupUserByUsername(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response models.UserLookupResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.User != nil {
+		t.Fatalf("expected user to be nil, got %+v", response.User)
 	}
 }
 

--- a/backend/internal/models/comment.go
+++ b/backend/internal/models/comment.go
@@ -33,6 +33,8 @@ type CreateCommentRequest struct {
 	ImageID         *string       `json:"image_id,omitempty"`
 	Content         string        `json:"content"`
 	Links           []LinkRequest `json:"links,omitempty"`
+	// MentionUsernames contains explicitly selected mentions from the client.
+	MentionUsernames []string `json:"mention_usernames,omitempty"`
 }
 
 // CreateCommentResponse represents the response for creating a comment
@@ -44,6 +46,8 @@ type CreateCommentResponse struct {
 type UpdateCommentRequest struct {
 	Content string         `json:"content"`
 	Links   *[]LinkRequest `json:"links,omitempty"`
+	// MentionUsernames contains explicitly selected mentions from the client.
+	MentionUsernames []string `json:"mention_usernames,omitempty"`
 }
 
 // GetCommentResponse represents the response for getting a single comment

--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -51,6 +51,8 @@ type CreatePostRequest struct {
 	Content   string             `json:"content"`
 	Links     []LinkRequest      `json:"links,omitempty"`
 	Images    []PostImageRequest `json:"images,omitempty"`
+	// MentionUsernames contains explicitly selected mentions from the client.
+	MentionUsernames []string `json:"mention_usernames,omitempty"`
 }
 
 // LinkRequest represents a link in the request
@@ -70,6 +72,8 @@ type UpdatePostRequest struct {
 	Content string              `json:"content"`
 	Links   *[]LinkRequest      `json:"links,omitempty"`
 	Images  *[]PostImageRequest `json:"images,omitempty"`
+	// MentionUsernames contains explicitly selected mentions from the client.
+	MentionUsernames []string `json:"mention_usernames,omitempty"`
 }
 
 // CreatePostResponse represents the response for creating a post

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -105,7 +105,7 @@ type UserAutocompleteResponse struct {
 
 // UserLookupResponse represents the response from /users/lookup.
 type UserLookupResponse struct {
-	User UserSummary `json:"user"`
+	User *UserSummary `json:"user"`
 }
 
 // ApproveUserResponse represents the response from approving a user

--- a/frontend/src/components/LinkifiedText.svelte
+++ b/frontend/src/components/LinkifiedText.svelte
@@ -95,8 +95,8 @@
         }
         const task = api
           .lookupUserByUsername(username, { suppressNotFound: true })
-          .then(() => {
-            mentionValidationCache.set(username, true);
+          .then((response) => {
+            mentionValidationCache.set(username, Boolean(response.user));
           })
           .catch(() => {
             mentionValidationCache.set(username, false);

--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -142,6 +142,9 @@
         resolvedUserId = identifier;
       } else {
         const response = await api.lookupUserByUsername(identifier);
+        if (!response.user) {
+          throw new Error('User not found.');
+        }
         resolvedUserId = response.user.id;
       }
     } catch (error) {

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -255,6 +255,7 @@ describe('PostCard', () => {
         { url: 'https://example.com/article' },
         { url: 'https://example.com/extra' },
       ],
+      mentionUsernames: [],
     });
   });
 
@@ -300,6 +301,7 @@ describe('PostCard', () => {
         { url: 'https://example.com/article' },
         { url: 'https://cdn.example.com/uploads/new.png' },
       ],
+      mentionUsernames: [],
     });
   });
 
@@ -328,6 +330,7 @@ describe('PostCard', () => {
     expect(apiUpdatePost).toHaveBeenCalledWith('post-1', {
       content: 'Hello world',
       links: undefined,
+      mentionUsernames: [],
     });
   });
 

--- a/frontend/src/components/comments/CommentForm.svelte
+++ b/frontend/src/components/comments/CommentForm.svelte
@@ -21,6 +21,7 @@
   const dispatch = createEventDispatcher<{ submit: Comment }>();
 
   let content = '';
+  let mentionUsernames: string[] = [];
   let isSubmitting = false;
   let error: string | null = null;
 
@@ -37,6 +38,7 @@
         postId,
         imageId: imageContext?.id,
         content: content.trim(),
+        mentionUsernames,
       });
       const comment = mapApiComment(response.comment);
       const skipIncrement = commentStore.consumeSeenComment(postId, comment.id);
@@ -45,6 +47,7 @@
         postStore.incrementCommentCount(postId, 1);
       }
       content = '';
+      mentionUsernames = [];
       onClearImageContext?.();
       dispatch('submit', comment);
     } catch (err) {
@@ -87,6 +90,7 @@
   <MentionTextarea
     id="comment-content"
     bind:value={content}
+    bind:mentionUsernames
     on:keydown={(event) => handleKeyDown(event.detail)}
     ariaLabel="Add a comment"
     placeholder="Add a comment..."

--- a/frontend/src/components/comments/ReplyForm.svelte
+++ b/frontend/src/components/comments/ReplyForm.svelte
@@ -13,6 +13,7 @@
   const dispatch = createEventDispatcher<{ submit: Comment; cancel: void }>();
 
   let content = '';
+  let mentionUsernames: string[] = [];
   let isSubmitting = false;
   let error: string | null = null;
 
@@ -29,6 +30,7 @@
         postId,
         parentCommentId,
         content: content.trim(),
+        mentionUsernames,
       });
       const reply = mapApiComment(response.comment);
       const skipIncrement = commentStore.consumeSeenComment(postId, reply.id);
@@ -37,6 +39,7 @@
         postStore.incrementCommentCount(postId, 1);
       }
       content = '';
+      mentionUsernames = [];
       dispatch('submit', reply);
     } catch (err) {
       error = err instanceof Error ? err.message : 'Failed to add reply';
@@ -57,6 +60,7 @@
   <MentionTextarea
     id={`reply-${parentCommentId}`}
     bind:value={content}
+    bind:mentionUsernames
     on:keydown={(event) => handleKeyDown(event.detail)}
     ariaLabel="Write a reply"
     placeholder="Write a reply..."

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -272,7 +272,10 @@ describe('CommentThread', () => {
     }
     await fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
 
-    expect(apiUpdateComment).toHaveBeenCalledWith('comment-1', { content: 'Hello' });
+    expect(apiUpdateComment).toHaveBeenCalledWith('comment-1', {
+      content: 'Hello',
+      mentionUsernames: [],
+    });
   });
 
   it('ignores ctrl+enter when edit content is empty', async () => {

--- a/frontend/src/components/posts/PostForm.svelte
+++ b/frontend/src/components/posts/PostForm.svelte
@@ -11,6 +11,7 @@
   }>();
 
   let content = '';
+  let mentionUsernames: string[] = [];
   let isSubmitting = false;
   let error: string | null = null;
 
@@ -313,7 +314,14 @@
       const payload = {
         sectionId: $activeSection.id,
         content: trimmedContent,
-      } as { sectionId: string; content: string; links?: { url: string }[]; images?: { url: string }[] };
+        mentionUsernames,
+      } as {
+        sectionId: string;
+        content: string;
+        links?: { url: string }[];
+        images?: { url: string }[];
+        mentionUsernames?: string[];
+      };
 
       if (links.length > 0) {
         payload.links = links;
@@ -335,6 +343,7 @@
       postStore.addPost(createdPost);
 
       content = '';
+      mentionUsernames = [];
       linkUrl = '';
       linkMetadata = null;
       linkInputValue = '';
@@ -385,6 +394,7 @@
     <MentionTextarea
       id="post-content"
       bind:value={content}
+      bind:mentionUsernames
       on:input={handleContentChange}
       on:keydown={(event) => handleKeyDown(event.detail)}
       placeholder={$activeSection

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -233,6 +233,7 @@ describe('PostForm', () => {
       sectionId: 'section-1',
       content: '',
       links: [{ url: 'https://example.com' }],
+      mentionUsernames: [],
     });
   });
 
@@ -364,6 +365,7 @@ describe('PostForm', () => {
       sectionId: 'section-1',
       content: '',
       images: [{ url: '/api/v1/uploads/user-1/photo.png' }],
+      mentionUsernames: [],
     });
     expect(screen.getByText('Uploaded')).toBeInTheDocument();
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -287,7 +287,7 @@ class ApiClient {
   async lookupUserByUsername(
     username: string,
     options: { suppressNotFound?: boolean } = {}
-  ): Promise<{ user: ApiUserSummary }> {
+  ): Promise<{ user: ApiUserSummary | null }> {
     const params = new URLSearchParams({ username });
     const logOptions = options.suppressNotFound ? { suppressStatuses: [404] } : undefined;
     return this.request(`/users/lookup?${params.toString()}`, { method: 'GET' }, true, logOptions);
@@ -417,6 +417,7 @@ class ApiClient {
         caption: image.caption,
         alt_text: image.altText,
       })),
+      mention_usernames: data.mentionUsernames ?? [],
     });
     return { post: mapApiPost(response.post) };
   }
@@ -442,11 +443,12 @@ class ApiClient {
 
   async updatePost(
     postId: string,
-    data: { content: string; links?: { url: string }[] | null }
+    data: { content: string; links?: { url: string }[] | null; mentionUsernames?: string[] }
   ): Promise<{ post: Post }> {
     const response = await this.patch<{ post: ApiPost }>(`/posts/${postId}`, {
       content: data.content,
       links: data.links ?? undefined,
+      mention_usernames: data.mentionUsernames ?? [],
     });
     return { post: mapApiPost(response.post) };
   }
@@ -462,6 +464,7 @@ class ApiClient {
       image_id: data.imageId,
       content: data.content,
       links: data.links,
+      mention_usernames: data.mentionUsernames ?? [],
     });
   }
 
@@ -481,11 +484,12 @@ class ApiClient {
 
   async updateComment(
     commentId: string,
-    data: { content: string; links?: { url: string }[] | null }
+    data: { content: string; links?: { url: string }[] | null; mentionUsernames?: string[] }
   ): Promise<{ comment: Comment }> {
     const response = await this.patch<{ comment: ApiComment }>(`/comments/${commentId}`, {
       content: data.content,
       links: data.links ?? undefined,
+      mention_usernames: data.mentionUsernames ?? [],
     });
     return { comment: mapApiComment(response.comment) };
   }

--- a/frontend/src/stores/commentStore.ts
+++ b/frontend/src/stores/commentStore.ts
@@ -27,6 +27,7 @@ export interface CreateCommentRequest {
   imageId?: string;
   content: string;
   links?: { url: string }[];
+  mentionUsernames?: string[];
 }
 
 export interface CommentThreadState {

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -51,6 +51,7 @@ export interface CreatePostRequest {
   content: string;
   links?: { url: string }[];
   images?: { url: string; caption?: string; altText?: string }[];
+  mentionUsernames?: string[];
 }
 
 interface PostState {


### PR DESCRIPTION
## Summary
- add explicit mention username lists to post/comment create + update flows
- update mention resolution to respect explicit selections and normalize usernames
- return empty user lookups instead of 404s and adjust frontend handling

## Testing
- go test ./internal/handlers -run TestLookupUserByUsername -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- prek (via commit hooks)

Closes #596