### PR TITLE
Make posts clickable on user profile Posts tab

### DIFF
--- a/frontend/src/components/UserProfile.svelte
+++ b/frontend/src/components/UserProfile.svelte
@@ -509,7 +509,9 @@
             <p class="text-gray-500 text-sm">No posts yet.</p>
           {:else}
             {#each posts as post (post.id)}
-              <PostCard {post} showSectionPill={true} showSectionLabel={true} />
+              <a href={buildThreadLink(post)} class="block hover:opacity-90 transition-opacity cursor-pointer">
+                <PostCard {post} showSectionPill={true} showSectionLabel={true} />
+              </a>
             {/each}
           {/if}
 


### PR DESCRIPTION
## Summary
- wrap profile Posts tab cards with links to their thread pages
- add hover/cursor affordance to indicate clickability

Closes #620