### PR TITLE
Fix nested reply styling on user profile Comments tab

### DIFF
--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -306,16 +306,21 @@
   );
 
   function getHighlightClass(commentId: string, commentUserId: string, isNested: boolean): string {
-    if (!highlightIdSet.has(commentId)) {
-      return 'bg-white';
-    }
-    if (profileUserId && commentUserId !== profileUserId) {
-      return 'bg-white';
-    }
+    const isProfileContext = !!profileUserId;
+    const isHighlighted = highlightIdSet.has(commentId) && (!isProfileContext || commentUserId === profileUserId);
+
     if (isNested) {
-      return 'bg-amber-100 ring-2 ring-amber-400 rounded-lg p-2';
+      if (isHighlighted) {
+        return 'bg-amber-100 ring-2 ring-amber-400 rounded-lg p-2';
+      }
+      return isProfileContext ? 'bg-white rounded-lg p-2' : 'bg-white';
     }
-    return 'bg-amber-50 ring-2 ring-amber-300';
+
+    if (isHighlighted) {
+      return 'bg-amber-50 ring-2 ring-amber-300';
+    }
+
+    return 'bg-white';
   }
 </script>
 

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -446,6 +446,8 @@ describe('CommentThread', () => {
       expect(replyEl?.className).not.toContain('bg-amber');
       expect(replyEl?.className).not.toContain('ring-amber');
       expect(replyEl?.className).toContain('bg-white');
+      expect(replyEl?.className).toContain('rounded-lg');
+      expect(replyEl?.className).toContain('p-2');
     });
 
     it('highlights comments without profileUserId filter (backward compatibility)', () => {


### PR DESCRIPTION
## Summary
- add consistent container styling for non-highlighted nested replies in profile context
- keep highlight rules intact for profile user comments
- extend CommentThread test coverage for nested reply layout classes

Closes #619