### PR TITLE
Display image reply indicator on posted comments

### DIFF
--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -690,6 +690,32 @@
                             </div>
                           {/if}
                         </div>
+                        {#if reply.imageId}
+                          {@const imageRef = resolveImageReference(reply.imageId)}
+                          <div class="mb-2">
+                            {#if imageRef}
+                              <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs text-blue-700 hover:bg-blue-100"
+                                aria-label={`View image ${imageRef.index + 1}`}
+                                on:click={() => handleImageReferenceClick(imageRef.index)}
+                              >
+                                <img
+                                  src={imageRef.url}
+                                  alt={imageRef.altText ?? `Image ${imageRef.index + 1}`}
+                                  class="h-6 w-6 rounded-md object-cover border border-blue-200 bg-white"
+                                />
+                                <span>Image {imageRef.index + 1}</span>
+                              </button>
+                            {:else}
+                              <span
+                                class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs text-gray-600"
+                              >
+                                Image
+                              </span>
+                            {/if}
+                          </div>
+                        {/if}
                         {#if editingCommentId === reply.id}
                           <div class="space-y-2">
                               <MentionTextarea

--- a/frontend/src/components/comments/__tests__/CommentThread.test.ts
+++ b/frontend/src/components/comments/__tests__/CommentThread.test.ts
@@ -228,6 +228,51 @@ describe('CommentThread', () => {
     expect(screen.getByText('Image 1')).toBeInTheDocument();
   });
 
+  it('shows image indicator for replies that reference images', () => {
+    commentStore.setThread('post-1', [
+      {
+        id: 'comment-1',
+        postId: 'post-1',
+        userId: 'user-1',
+        content: 'Parent',
+        createdAt: 'now',
+        user: { id: 'user-1', username: 'Sander' },
+        replies: [
+          {
+            id: 'reply-1',
+            postId: 'post-1',
+            userId: 'user-2',
+            content: 'Replying to image',
+            imageId: 'image-2',
+            createdAt: 'now',
+            user: { id: 'user-2', username: 'Alex' },
+            replies: [],
+          },
+        ],
+      },
+    ], null, false);
+
+    render(CommentThread, {
+      postId: 'post-1',
+      commentCount: 1,
+      imageItems: [
+        {
+          id: 'image-1',
+          url: 'https://cdn.example.com/uploads/photo-1.png',
+          title: 'Image 1',
+        },
+        {
+          id: 'image-2',
+          url: 'https://cdn.example.com/uploads/photo-2.png',
+          title: 'Image 2',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('button', { name: 'View image 2' })).toBeInTheDocument();
+    expect(screen.getByText('Image 2')).toBeInTheDocument();
+  });
+
   it('saves edits with ctrl+enter', async () => {
     authStore.setUser({
       id: 'user-1',


### PR DESCRIPTION
## Summary
- show image reply indicators for nested replies in comment threads
- add coverage for reply image indicators in CommentThread tests

Closes #617