### PR TITLE
Add admin notification for new user registrations

### DIFF
--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -699,7 +699,8 @@ func (s *UserService) ApproveUser(ctx context.Context, userID uuid.UUID, adminUs
 
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE notifications
-		SET read_at = now()
+		SET read_at = now(),
+		    related_user_id = NULL
 		WHERE type = 'user_registration_pending'
 		  AND related_user_id = $1
 		  AND read_at IS NULL

--- a/backend/internal/services/user.go
+++ b/backend/internal/services/user.go
@@ -699,11 +699,10 @@ func (s *UserService) ApproveUser(ctx context.Context, userID uuid.UUID, adminUs
 
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE notifications
-		SET read_at = now(),
+		SET read_at = COALESCE(read_at, now()),
 		    related_user_id = NULL
 		WHERE type = 'user_registration_pending'
 		  AND related_user_id = $1
-		  AND read_at IS NULL
 	`, userID); err != nil {
 		recordSpanError(span, err)
 		return nil, fmt.Errorf("failed to resolve registration notifications: %w", err)

--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -1,5 +1,15 @@
 <script lang="ts">
-  import { sections, activeSection, sectionStore, uiStore, isAdmin, activeView, isAuthenticated, threadRouteStore } from '../stores';
+  import {
+    sections,
+    activeSection,
+    sectionStore,
+    uiStore,
+    isAdmin,
+    activeView,
+    isAuthenticated,
+    threadRouteStore,
+    unreadRegistrationCount,
+  } from '../stores';
   import { buildAdminHref, buildSectionHref, pushPath } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
   import NotificationSettings from './NotificationSettings.svelte';
@@ -62,6 +72,14 @@
       >
         <span class="text-lg" aria-hidden="true">🛡️</span>
         <span>Moderation</span>
+        {#if $unreadRegistrationCount > 0}
+          <span
+            class="ml-auto rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white"
+            aria-label="Pending registrations"
+          >
+            {$unreadRegistrationCount > 99 ? '99+' : $unreadRegistrationCount}
+          </span>
+        {/if}
       </button>
     </div>
   {/if}

--- a/frontend/src/components/admin/PendingUsers.svelte
+++ b/frontend/src/components/admin/PendingUsers.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { api } from '../../services/api';
-  import { displayTimezone } from '../../stores';
+  import { displayTimezone, loadNotifications } from '../../stores';
   import { formatInTimezone } from '../../lib/time';
 
   interface PendingUser {
@@ -80,6 +80,7 @@
     try {
       await api.patch(`/admin/users/${userId}/approve`);
       pendingUsers = pendingUsers.filter((user) => user.id !== userId);
+      loadNotifications();
     } catch (error) {
       errorMessage = error instanceof Error ? error.message : 'Failed to approve user.';
     } finally {
@@ -93,6 +94,7 @@
     try {
       await api.delete(`/admin/users/${userId}`);
       pendingUsers = pendingUsers.filter((user) => user.id !== userId);
+      loadNotifications();
     } catch (error) {
       errorMessage = error instanceof Error ? error.message : 'Failed to reject user.';
     } finally {

--- a/frontend/src/components/notifications/NotificationMenu.svelte
+++ b/frontend/src/components/notifications/NotificationMenu.svelte
@@ -8,7 +8,7 @@
     markAllNotificationsRead,
   } from '../../stores';
   import type { Notification } from '../../stores';
-  import { buildStandaloneThreadHref, pushPath } from '../../services/routeNavigation';
+  import { buildAdminHref, buildStandaloneThreadHref, pushPath } from '../../services/routeNavigation';
   import RelativeTime from '../RelativeTime.svelte';
 
   let menuOpen = false;
@@ -18,6 +18,7 @@
     new_comment: 'New comment',
     mention: 'Mention',
     reaction: 'Reaction',
+    user_registration_pending: 'Registration pending',
   };
 
   function toggleMenu() {
@@ -48,6 +49,8 @@
         return `${actor} mentioned you`;
       case 'reaction':
         return `${actor} reacted to your ${notification.relatedCommentId ? 'comment' : 'post'}`;
+      case 'user_registration_pending':
+        return `${actor} requested to join`;
       default:
         return typeLabels[notification.type] ?? 'Notification';
     }
@@ -63,12 +66,17 @@
         return '🔔';
       case 'reaction':
         return '❤️';
+      case 'user_registration_pending':
+        return '🧑‍💼';
       default:
         return '🔔';
     }
   }
 
   function buildNotificationHref(notification: Notification): string | null {
+    if (notification.type === 'user_registration_pending') {
+      return buildAdminHref();
+    }
     if (!notification.relatedPostId) {
       return null;
     }

--- a/frontend/src/stores/notificationStore.ts
+++ b/frontend/src/stores/notificationStore.ts
@@ -1,4 +1,4 @@
-import { get, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import { api } from '../services/api';
 import { logWarn } from '../lib/observability/logger';
 import { isAuthenticated } from './authStore';
@@ -219,6 +219,12 @@ function createNotificationStore() {
 }
 
 export const notificationStore = createNotificationStore();
+
+export const unreadRegistrationCount = derived(notificationStore, ($store) =>
+  $store.notifications.filter(
+    (notification) => notification.type === 'user_registration_pending' && !notification.readAt
+  ).length
+);
 
 let initialized = false;
 let authUnsub: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- create admin registration notifications with realtime/push payloads
- clear registration notifications when users are approved or rejected
- show moderation badge for unread registration notifications and route to admin
- add backend/frontend tests for registration notifications

Closes #618