### PR TITLE
Investigate and fix Loki log shipping from backend

### DIFF
--- a/backend/internal/observability/observability.go
+++ b/backend/internal/observability/observability.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -43,6 +44,7 @@ func Init(ctx context.Context) (func(context.Context) error, http.Handler, error
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceVersionKey.String(serviceVersion),
+			attribute.String("job", serviceName),
 		),
 	)
 	if err != nil {

--- a/loki.yml
+++ b/loki.yml
@@ -17,6 +17,28 @@ common:
     kvstore:
       store: inmemory
 
+distributor:
+  otlp_config:
+    default_resource_attributes_as_index_labels:
+      - service.name
+      - service.namespace
+      - service.instance.id
+      - deployment.environment
+      - cloud.region
+      - cloud.availability_zone
+      - k8s.cluster.name
+      - k8s.namespace.name
+      - k8s.pod.name
+      - k8s.container.name
+      - container.name
+      - k8s.replicaset.name
+      - k8s.deployment.name
+      - k8s.statefulset.name
+      - k8s.daemonset.name
+      - k8s.cronjob.name
+      - k8s.job.name
+      - job
+
 schema_config:
   configs:
     - from: 2020-10-24
@@ -33,6 +55,7 @@ compactor:
   delete_request_store: filesystem
 
 limits_config:
+  allow_structured_metadata: true
   retention_period: 336h
 
 ruler:


### PR DESCRIPTION
## Summary
- add `job` resource attribute to backend OTel logging
- promote `job` to a Loki OTLP index label and allow structured metadata
- keep default OTLP resource labels to preserve existing log queries

Closes #631