### PR TITLE
Add business metrics instrumentation to backend

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -140,6 +140,7 @@ func (h *AdminHandler) ApproveUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	observability.RecordAdminAction(r.Context(), "approve_user")
+	observability.RecordUserApproved(r.Context())
 
 	observability.LogInfo(r.Context(), "user approved",
 		"user_id", userID.String(),

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -136,6 +136,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	recordAttempt("success")
+	observability.RecordUserRegistered(ctx)
 
 	if h.notificationService != nil {
 		if err := h.notificationService.CreateAdminNotificationsForRegistration(ctx, user.ID); err != nil {

--- a/backend/internal/handlers/comment_test.go
+++ b/backend/internal/handlers/comment_test.go
@@ -249,9 +249,9 @@ func TestCreateCommentHandlerInvalidImageID(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT section_id FROM posts").
+	mock.ExpectQuery("SELECT p.section_id, s.name FROM posts").
 		WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"section_id"}).AddRow(sectionID))
+		WillReturnRows(sqlmock.NewRows([]string{"section_id", "name"}).AddRow(sectionID, "General"))
 
 	req, err := http.NewRequest(http.MethodPost, "/api/v1/comments", bytes.NewReader(body))
 	if err != nil {
@@ -304,9 +304,9 @@ func TestCreateCommentHandlerImageNotFound(t *testing.T) {
 		t.Fatalf("failed to marshal body: %v", err)
 	}
 
-	mock.ExpectQuery("SELECT section_id FROM posts").
+	mock.ExpectQuery("SELECT p.section_id, s.name FROM posts").
 		WithArgs(postID).
-		WillReturnRows(sqlmock.NewRows([]string{"section_id"}).AddRow(sectionID))
+		WillReturnRows(sqlmock.NewRows([]string{"section_id", "name"}).AddRow(sectionID, "General"))
 	mock.ExpectQuery("SELECT EXISTS\\(SELECT 1 FROM post_images").
 		WithArgs(imageID, postID).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))

--- a/backend/internal/handlers/reaction.go
+++ b/backend/internal/handlers/reaction.go
@@ -98,7 +98,7 @@ func (h *ReactionHandler) AddReactionToPost(w http.ResponseWriter, r *http.Reque
 			Emoji:  reaction.Emoji,
 		})
 	}
-	observability.RecordReactionAdded(publishCtx, "post")
+	observability.RecordReactionAdded(publishCtx, reaction.Emoji)
 	cancel()
 
 	observability.LogInfo(r.Context(), "reaction added",
@@ -220,7 +220,7 @@ func (h *ReactionHandler) RemoveReactionFromPost(w http.ResponseWriter, r *http.
 			Emoji:  emoji,
 		})
 	}
-	observability.RecordReactionRemoved(publishCtx, "post")
+	observability.RecordReactionRemoved(publishCtx, emoji)
 	cancel()
 
 	observability.LogInfo(r.Context(), "reaction removed",
@@ -295,7 +295,7 @@ func (h *ReactionHandler) AddReactionToComment(w http.ResponseWriter, r *http.Re
 			Emoji:     reaction.Emoji,
 		})
 	}
-	observability.RecordReactionAdded(publishCtx, "comment")
+	observability.RecordReactionAdded(publishCtx, reaction.Emoji)
 	cancel()
 
 	observability.LogInfo(r.Context(), "reaction added",
@@ -418,7 +418,7 @@ func (h *ReactionHandler) RemoveReactionFromComment(w http.ResponseWriter, r *ht
 			Emoji:     emoji,
 		})
 	}
-	observability.RecordReactionRemoved(publishCtx, "comment")
+	observability.RecordReactionRemoved(publishCtx, emoji)
 	cancel()
 
 	observability.LogInfo(r.Context(), "reaction removed",


### PR DESCRIPTION
## Summary
- add Prometheus-friendly business counters for posts, comments, reactions, content deletes/restores, and user lifecycle events
- include section/emoji/type labels and hook metrics into post/comment creation, reactions, and approvals/registration
- update comment handler tests for section name lookup

## Testing
- go build ./...
- go test ./internal/services -v
- go test ./internal/handlers -v

Closes #630