### PR TITLE
Add database metrics instrumentation to backend

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -69,6 +69,8 @@ func main() {
 	}
 	defer dbConn.Close()
 
+	go observability.StartDBStatsReporter(ctx, dbConn, 15*time.Second)
+
 	if err := services.InitConfigService(ctx, dbConn); err != nil {
 		observability.LogError(ctx, observability.ErrorLog{
 			Message:    "failed to initialize config service",

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -48,6 +48,8 @@ func Init(ctx context.Context) (*sql.DB, error) {
 		otelsql.WithAttributes(attribute.String("db.system", "postgresql")),
 		otelsql.WithMeterProvider(otel.GetMeterProvider()),
 		otelsql.WithTracerProvider(otel.GetTracerProvider()),
+		otelsql.WithInstrumentAttributesGetter(instrumentAttributesGetter),
+		otelsql.WithInstrumentErrorAttributesGetter(instrumentErrorAttributesGetter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register otel driver: %w", err)

--- a/backend/internal/db/metrics.go
+++ b/backend/internal/db/metrics.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"strings"
+
+	"github.com/XSAM/otelsql"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func instrumentAttributesGetter(ctx context.Context, method otelsql.Method, query string, _ []driver.NamedValue) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2)
+
+	queryType := queryTypeFromSQL(query)
+	if queryType != "" {
+		attrs = append(attrs, attribute.String("query_type", queryType))
+	}
+
+	table := tableFromSQL(query)
+	if table != "" {
+		attrs = append(attrs, attribute.String("table", table))
+	}
+
+	switch method {
+	case otelsql.MethodTxCommit:
+		observability.RecordDBTransaction(ctx, "commit")
+	case otelsql.MethodTxRollback:
+		observability.RecordDBTransaction(ctx, "rollback")
+	}
+
+	return attrs
+}
+
+func instrumentErrorAttributesGetter(err error) []attribute.KeyValue {
+	errorType := errorTypeFromDBError(err)
+	if errorType == "" {
+		errorType = "unknown"
+	}
+	observability.RecordDBQueryError(context.Background(), "unknown", errorType)
+	return []attribute.KeyValue{
+		attribute.String("error_type", errorType),
+	}
+}
+
+func queryTypeFromSQL(query string) string {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.TrimLeft(trimmed, " (")
+	lower := strings.ToLower(trimmed)
+	fields := strings.Fields(lower)
+	if len(fields) == 0 {
+		return ""
+	}
+	switch fields[0] {
+	case "select", "insert", "update", "delete":
+		return fields[0]
+	case "with":
+		for _, token := range fields[1:] {
+			switch token {
+			case "select", "insert", "update", "delete":
+				return token
+			}
+		}
+		return "with"
+	default:
+		return fields[0]
+	}
+}
+
+func tableFromSQL(query string) string {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return ""
+	}
+	lower := strings.ToLower(trimmed)
+	fields := strings.Fields(lower)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	switch fields[0] {
+	case "select", "with":
+		for i, token := range fields {
+			if token == "from" && i+1 < len(fields) {
+				return sanitizeTableToken(fields[i+1])
+			}
+		}
+	case "insert":
+		for i, token := range fields {
+			if token == "into" && i+1 < len(fields) {
+				return sanitizeTableToken(fields[i+1])
+			}
+		}
+	case "update":
+		if len(fields) > 1 {
+			return sanitizeTableToken(fields[1])
+		}
+	case "delete":
+		for i, token := range fields {
+			if token == "from" && i+1 < len(fields) {
+				return sanitizeTableToken(fields[i+1])
+			}
+		}
+	}
+
+	return ""
+}
+
+func sanitizeTableToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	token = strings.Trim(token, ",;()")
+	token = strings.Trim(token, "\"`")
+	if token == "" {
+		return ""
+	}
+	if strings.Contains(token, ".") {
+		parts := strings.Split(token, ".")
+		token = parts[len(parts)-1]
+	}
+	return token
+}
+
+func errorTypeFromDBError(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, sql.ErrNoRows):
+		return "no_rows"
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout"):
+		return "timeout"
+	case strings.Contains(msg, "deadlock"):
+		return "deadlock"
+	case strings.Contains(msg, "duplicate"):
+		return "duplicate"
+	case strings.Contains(msg, "connection"):
+		return "connection"
+	default:
+		return "unknown"
+	}
+}

--- a/backend/internal/observability/metrics.go
+++ b/backend/internal/observability/metrics.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"time"
@@ -64,13 +65,31 @@ type metrics struct {
 	frontendWebsocketDuration metric.Float64Histogram
 	frontendAssetDuration     metric.Float64Histogram
 	frontendComponentDuration metric.Float64Histogram
+	dbConnectionsOpen         metric.Int64UpDownCounter
+	dbConnectionsInUse        metric.Int64UpDownCounter
+	dbConnectionsIdle         metric.Int64UpDownCounter
+	dbConnectionWaitCount     metric.Int64Counter
+	dbConnectionWaitDuration  metric.Float64Counter
+	dbQueryErrors             metric.Int64Counter
+	dbTransactions            metric.Int64Counter
 }
 
 var (
 	metricsOnce     sync.Once
 	metricsInitErr  error
 	metricsInstance *metrics
+	dbStatsMu       sync.Mutex
+	dbStatsSnapshot dbStatsState
 )
+
+type dbStatsState struct {
+	initialized bool
+	open        int64
+	inUse       int64
+	idle        int64
+	waitCount   int64
+	waitSeconds float64
+}
 
 func initMetrics() error {
 	metricsOnce.Do(func() {
@@ -550,6 +569,70 @@ func initMetrics() error {
 			return
 		}
 
+		dbConnectionsOpen, err := meter.Int64UpDownCounter(
+			"clubhouse_db_connections_open",
+			metric.WithDescription("Number of open database connections"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbConnectionsInUse, err := meter.Int64UpDownCounter(
+			"clubhouse_db_connections_in_use",
+			metric.WithDescription("Number of database connections currently in use"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbConnectionsIdle, err := meter.Int64UpDownCounter(
+			"clubhouse_db_connections_idle",
+			metric.WithDescription("Number of idle database connections in the pool"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbConnectionWaitCount, err := meter.Int64Counter(
+			"clubhouse_db_connection_wait_count",
+			metric.WithDescription("Total number of connections waited for"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbConnectionWaitDuration, err := meter.Float64Counter(
+			"clubhouse_db_connection_wait_duration_seconds",
+			metric.WithDescription("Total time blocked waiting for new connections in seconds"),
+			metric.WithUnit("s"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbQueryErrors, err := meter.Int64Counter(
+			"clubhouse_db_query_errors_total",
+			metric.WithDescription("Total number of database query errors"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		dbTransactions, err := meter.Int64Counter(
+			"clubhouse_db_transactions_total",
+			metric.WithDescription("Total number of database transactions"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
 		metricsInstance = &metrics{
 			httpRequestCount:          httpRequestCount,
 			httpRequestDuration:       httpRequestDuration,
@@ -602,6 +685,13 @@ func initMetrics() error {
 			frontendWebsocketDuration: frontendWebsocketDuration,
 			frontendAssetDuration:     frontendAssetDuration,
 			frontendComponentDuration: frontendComponentDuration,
+			dbConnectionsOpen:         dbConnectionsOpen,
+			dbConnectionsInUse:        dbConnectionsInUse,
+			dbConnectionsIdle:         dbConnectionsIdle,
+			dbConnectionWaitCount:     dbConnectionWaitCount,
+			dbConnectionWaitDuration:  dbConnectionWaitDuration,
+			dbQueryErrors:             dbQueryErrors,
+			dbTransactions:            dbTransactions,
 		}
 	})
 
@@ -756,6 +846,120 @@ func RecordAuthSessionExpired(ctx context.Context, reason string, count int64) {
 		return
 	}
 	m.authSessionsExpired.Add(ctx, count, metric.WithAttributes(attrs...))
+}
+
+// UpdateDBStats records database connection pool statistics.
+func UpdateDBStats(ctx context.Context, db *sql.DB) {
+	m := getMetrics()
+	if m == nil || db == nil {
+		return
+	}
+
+	stats := db.Stats()
+	dbStatsMu.Lock()
+	defer dbStatsMu.Unlock()
+
+	open := int64(stats.OpenConnections)
+	inUse := int64(stats.InUse)
+	idle := int64(stats.Idle)
+	waitCount := int64(stats.WaitCount)
+	waitSeconds := stats.WaitDuration.Seconds()
+
+	if !dbStatsSnapshot.initialized {
+		m.dbConnectionsOpen.Add(ctx, open)
+		m.dbConnectionsInUse.Add(ctx, inUse)
+		m.dbConnectionsIdle.Add(ctx, idle)
+		if waitCount > 0 {
+			m.dbConnectionWaitCount.Add(ctx, waitCount)
+		}
+		if waitSeconds > 0 {
+			m.dbConnectionWaitDuration.Add(ctx, waitSeconds)
+		}
+		dbStatsSnapshot = dbStatsState{
+			initialized: true,
+			open:        open,
+			inUse:       inUse,
+			idle:        idle,
+			waitCount:   waitCount,
+			waitSeconds: waitSeconds,
+		}
+		return
+	}
+
+	m.dbConnectionsOpen.Add(ctx, open-dbStatsSnapshot.open)
+	m.dbConnectionsInUse.Add(ctx, inUse-dbStatsSnapshot.inUse)
+	m.dbConnectionsIdle.Add(ctx, idle-dbStatsSnapshot.idle)
+
+	waitDelta := waitCount - dbStatsSnapshot.waitCount
+	if waitDelta > 0 {
+		m.dbConnectionWaitCount.Add(ctx, waitDelta)
+	}
+	waitSecondsDelta := waitSeconds - dbStatsSnapshot.waitSeconds
+	if waitSecondsDelta > 0 {
+		m.dbConnectionWaitDuration.Add(ctx, waitSecondsDelta)
+	}
+
+	dbStatsSnapshot.open = open
+	dbStatsSnapshot.inUse = inUse
+	dbStatsSnapshot.idle = idle
+	dbStatsSnapshot.waitCount = waitCount
+	dbStatsSnapshot.waitSeconds = waitSeconds
+}
+
+// StartDBStatsReporter periodically updates database stats until the context is done.
+func StartDBStatsReporter(ctx context.Context, db *sql.DB, interval time.Duration) {
+	if db == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	UpdateDBStats(ctx, db)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			UpdateDBStats(ctx, db)
+		}
+	}
+}
+
+// RecordDBQueryError increments the database query error counter.
+func RecordDBQueryError(ctx context.Context, queryType, errorType string) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{}
+	if strings.TrimSpace(queryType) != "" {
+		attrs = append(attrs, attribute.String("query_type", queryType))
+	}
+	if strings.TrimSpace(errorType) != "" {
+		attrs = append(attrs, attribute.String("error_type", errorType))
+	}
+	if len(attrs) == 0 {
+		m.dbQueryErrors.Add(ctx, 1)
+		return
+	}
+	m.dbQueryErrors.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RecordDBTransaction increments the database transaction counter.
+func RecordDBTransaction(ctx context.Context, status string) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	if strings.TrimSpace(status) == "" {
+		return
+	}
+	m.dbTransactions.Add(ctx, 1, metric.WithAttributes(attribute.String("status", status)))
 }
 
 // RecordAuthTOTPVerification increments the TOTP verification counter.

--- a/backend/internal/observability/observability.go
+++ b/backend/internal/observability/observability.go
@@ -74,6 +74,16 @@ func Init(ctx context.Context) (func(context.Context) error, http.Handler, error
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(exporter),
+		sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{
+				Name: "db.client.operation.duration",
+			},
+			sdkmetric.Stream{
+				Name:        "clubhouse_db_query_duration_seconds",
+				Description: "Database query duration in seconds",
+				Unit:        "s",
+			},
+		)),
 	)
 	otel.SetMeterProvider(mp)
 


### PR DESCRIPTION
## Summary
- add database pool metrics and query error/transaction counters in observability
- map OTel query duration metric to `clubhouse_db_query_duration_seconds`
- record DB stats on a background ticker during server startup

Closes #629