### PR TITLE
Grafana Traces dashboard: Trace Search panel has invalid TraceQL query

### DIFF
--- a/grafana/dashboards/traces.json
+++ b/grafana/dashboards/traces.json
@@ -490,7 +490,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=~\"$service\", span.name=~\"$operation\", status.code=~\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] =~ \"$tag_value\"",
+          "query": "{resource.service.name=~\"$service\" && span.name=~\"$operation\" && status.code=~\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] =~ \"$tag_value\"",
           "limit": 200,
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
- replace comma-separated TraceQL filters with boolean `&&` selector syntax
- keep existing Trace Search filters intact while avoiding parse errors

Closes #639