### PR TITLE
Tempo Trace Search panel TraceQL parse errors

### DIFF
--- a/grafana/dashboards/traces.json
+++ b/grafana/dashboards/traces.json
@@ -490,7 +490,7 @@
             "uid": "tempo"
           },
           "queryType": "traceql",
-          "query": "{resource.service.name=~\"$service\" && span.name=~\"$operation\" && status.code=~\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] =~ \"$tag_value\"",
+          "query": "{resource[\"service.name\"]=~\"$service\" && span[\"name\"]=~\"$operation\" && span[\"status.code\"]=~\"$status\"} | duration > ${min_duration_ms}ms | span[\"$tag_key\"] =~ \"$tag_value\"",
           "limit": 200,
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
- update Trace Search TraceQL to use bracket attribute syntax for dotted keys
- align status filter with Tempo 2.6.1 parser requirements

Closes #645