### PR TITLE
Grafana Sentry datasource errors when org slug is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ ENVIRONMENT=development
 LOG_LEVEL=debug
 
 # Grafana Sentry datasource (optional)
+# Leave ORG or AUTH_TOKEN empty to disable Sentry provisioning (no dashboard/datasource).
 GRAFANA_SENTRY_URL=https://sentry.io
 GRAFANA_SENTRY_ORG=
 GRAFANA_SENTRY_AUTH_TOKEN=

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -63,18 +63,6 @@ datasources:
       lokiSearch:
         datasourceUid: loki
 
-  - name: Sentry
-    type: grafana-sentry-datasource
-    uid: sentry
-    access: proxy
-    url: ${GRAFANA_SENTRY_URL}
-    isDefault: false
-    editable: true
-    jsonData:
-      organization: ${GRAFANA_SENTRY_ORG}
-    secureJsonData:
-      authToken: ${GRAFANA_SENTRY_AUTH_TOKEN}
-
   - name: Alertmanager
     type: alertmanager
     uid: alertmanager

--- a/grafana/datasources/sentry.yml
+++ b/grafana/datasources/sentry.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Sentry
+    type: grafana-sentry-datasource
+    uid: sentry
+    access: proxy
+    url: ${GRAFANA_SENTRY_URL}
+    isDefault: false
+    editable: true
+    jsonData:
+      organization: ${GRAFANA_SENTRY_ORG}
+    secureJsonData:
+      authToken: ${GRAFANA_SENTRY_AUTH_TOKEN}

--- a/grafana/entrypoint.sh
+++ b/grafana/entrypoint.sh
@@ -15,14 +15,20 @@ if [ -d /var/lib/grafana/plugins ]; then
   done
 fi
 
-# Ensure the Sentry datasource plugin is available for the frontend errors dashboard.
-if [ -z "$GF_PLUGINS_PREINSTALL" ]; then
-  export GF_PLUGINS_PREINSTALL="grafana-sentry-datasource"
+# Provision Sentry only when fully configured to avoid invalid org slug errors.
+if [ -z "$GRAFANA_SENTRY_URL" ] || [ -z "$GRAFANA_SENTRY_ORG" ] || [ -z "$GRAFANA_SENTRY_AUTH_TOKEN" ]; then
+  rm -f /etc/grafana/provisioning/datasources/sentry.yml
+  rm -f /etc/grafana/provisioning/dashboards/frontend-errors.json
 else
-  case ",$GF_PLUGINS_PREINSTALL," in
-    *,grafana-sentry-datasource,*) ;;
-    *) export GF_PLUGINS_PREINSTALL="$GF_PLUGINS_PREINSTALL,grafana-sentry-datasource" ;;
-  esac
+  # Ensure the Sentry datasource plugin is available for the frontend errors dashboard.
+  if [ -z "$GF_PLUGINS_PREINSTALL" ]; then
+    export GF_PLUGINS_PREINSTALL="grafana-sentry-datasource"
+  else
+    case ",$GF_PLUGINS_PREINSTALL," in
+      *,grafana-sentry-datasource,*) ;;
+      *) export GF_PLUGINS_PREINSTALL="$GF_PLUGINS_PREINSTALL,grafana-sentry-datasource" ;;
+    esac
+  fi
 fi
 
 exec /run.sh "$@"


### PR DESCRIPTION
## Summary
- split Sentry provisioning into its own datasource file
- skip Sentry datasource/dashboard provisioning when required env vars are empty
- document Sentry provisioning behavior in `.env.example`

Closes #646