### PR TITLE
Loki query cancellations from Grafana dashboards

### DIFF
--- a/grafana/dashboards/error-logs.json
+++ b/grafana/dashboards/error-logs.json
@@ -91,7 +91,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format trace_id=\"{{ index .attributes \\\"trace_id\\\" }}\" | label_format handler=\"{{ index .attributes \\\"http.route\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [1m]))",
+          "expr": "sum(count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format trace_id=\"{{ index .attributes \\\"trace_id\\\" }}\" | label_format handler=\"{{ index .attributes \\\"http.route\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [2m]))",
           "legendFormat": "Errors",
           "range": true,
           "refId": "A"
@@ -182,7 +182,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(rate({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format trace_id=\"{{ index .attributes \\\"trace_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [1m]))",
+          "expr": "sum(rate({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format trace_id=\"{{ index .attributes \\\"trace_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [2m]))",
           "legendFormat": "Errors/sec",
           "range": true,
           "refId": "A"
@@ -272,7 +272,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum by (severity) (count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format severity=\"{{.severity}}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [5m]))",
+          "expr": "sum by (severity) (count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format severity=\"{{.severity}}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [10m]))",
           "legendFormat": "{{severity}}",
           "range": true,
           "refId": "A"
@@ -362,7 +362,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (error_code) (count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [5m])))",
+          "expr": "topk(10, sum by (error_code) (count_over_time({job=\"clubhouse\"} | json | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [10m])))",
           "legendFormat": "{{error_code}}",
           "range": true,
           "refId": "A"
@@ -452,7 +452,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (handler) (count_over_time({job=\"clubhouse\"} | json | label_format handler=\"{{ index .attributes \\\"http.route\\\" }}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [5m])))",
+          "expr": "topk(10, sum by (handler) (count_over_time({job=\"clubhouse\"} | json | label_format handler=\"{{ index .attributes \\\"http.route\\\" }}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [10m])))",
           "legendFormat": "{{handler}}",
           "range": true,
           "refId": "A"
@@ -542,7 +542,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (user_id) (count_over_time({job=\"clubhouse\"} | json | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [5m])))",
+          "expr": "topk(10, sum by (user_id) (count_over_time({job=\"clubhouse\"} | json | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [10m])))",
           "legendFormat": "{{user_id}}",
           "range": true,
           "refId": "A"
@@ -632,7 +632,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (message) (count_over_time({job=\"clubhouse\"} | json | label_format message=\"{{.message}}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [5m])))",
+          "expr": "topk(10, sum by (message) (count_over_time({job=\"clubhouse\"} | json | label_format message=\"{{.message}}\" | label_format error_code=\"{{ index .attributes \\\"error.code\\\" }}\" | label_format user_id=\"{{ index .attributes \\\"user_id\\\" }}\" | severity=~\"$severity\" | error_code=~\"$error_code\" | user_id=~\"$user_id\" [10m])))",
           "legendFormat": "{{message}}",
           "range": true,
           "refId": "A"
@@ -826,7 +826,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({job=\"clubhouse\"} | json | severity=~\"$severity\" [1m]))",
+          "expr": "sum(count_over_time({job=\"clubhouse\"} | json | severity=~\"$severity\" [2m]))",
           "legendFormat": "Error Log Volume",
           "range": true,
           "refId": "A"
@@ -920,7 +920,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -16,6 +16,8 @@ datasources:
     isDefault: false
     editable: true
     access: proxy
+    jsonData:
+      timeout: 120
 
   - name: Tempo
     type: tempo

--- a/loki.yml
+++ b/loki.yml
@@ -56,6 +56,7 @@ compactor:
 
 limits_config:
   allow_structured_metadata: true
+  query_timeout: 2m
   retention_period: 336h
   volume_enabled: true
 


### PR DESCRIPTION
## Summary
- reduce error-logs dashboard default range and aggregation windows to lighten Loki queries
- set Loki datasource timeout in Grafana to align with server limits
- configure Loki query_timeout to avoid noisy cancellations

Closes #647