### PR TITLE
Backend: Add section links service and handler

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -180,6 +180,7 @@ func main() {
 		listSections: sectionHandler.ListSections,
 		getSection:   sectionHandler.GetSection,
 		getFeed:      postHandler.GetFeed,
+		getLinks:     sectionHandler.GetSectionLinks,
 	})
 	mux.Handle("/api/v1/sections/", sectionRouteHandler)
 

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -70,10 +70,15 @@ type sectionRouteDeps struct {
 	listSections http.HandlerFunc
 	getSection   http.HandlerFunc
 	getFeed      http.HandlerFunc
+	getLinks     http.HandlerFunc
 }
 
 func newSectionRouteHandler(requireAuth authMiddleware, deps sectionRouteDeps) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/links") {
+			requireAuth(http.HandlerFunc(deps.getLinks)).ServeHTTP(w, r)
+			return
+		}
 		if strings.Contains(r.URL.Path, "/feed") {
 			requireAuth(http.HandlerFunc(deps.getFeed)).ServeHTTP(w, r)
 			return

--- a/backend/internal/handlers/section_test.go
+++ b/backend/internal/handlers/section_test.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sanderginn/clubhouse/internal/models"
 	"github.com/sanderginn/clubhouse/internal/testutil"
@@ -131,5 +133,146 @@ func TestGetSectionInvalidID(t *testing.T) {
 
 	if response.Code != "INVALID_SECTION_ID" {
 		t.Errorf("expected error code INVALID_SECTION_ID, got %s", response.Code)
+	}
+}
+
+func TestGetSectionLinksSuccess(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "sectionlinks", "sectionlinks@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Links Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post with links")
+
+	now := time.Now().UTC()
+	older := now.Add(-2 * time.Hour)
+	newer := now.Add(-1 * time.Hour)
+
+	insertTestSectionLink(t, db, postID, "https://example.com/older", nil, older)
+	insertTestSectionLink(t, db, postID, "https://example.com/newer", nil, newer)
+
+	handler := NewSectionHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/sections/"+sectionID+"/links?limit=1", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetSectionLinks(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response models.SectionLinksResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(response.Links))
+	}
+
+	if response.Links[0].URL != "https://example.com/newer" {
+		t.Errorf("expected newest link first, got %s", response.Links[0].URL)
+	}
+
+	if response.NextCursor == nil || !response.HasMore {
+		t.Fatalf("expected next cursor and hasMore true")
+	}
+}
+
+func TestGetSectionLinksInvalidCursor(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	sectionID := testutil.CreateTestSection(t, db, "Links Section", "general")
+	handler := NewSectionHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/sections/"+sectionID+"/links?cursor=not-a-time", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetSectionLinks(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_CURSOR" {
+		t.Errorf("expected error code INVALID_CURSOR, got %s", response.Code)
+	}
+}
+
+func TestGetSectionLinksNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewSectionHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/sections/00000000-0000-0000-0000-000000000000/links", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetSectionLinks(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "SECTION_NOT_FOUND" {
+		t.Errorf("expected error code SECTION_NOT_FOUND, got %s", response.Code)
+	}
+}
+
+func TestGetSectionLinksInvalidID(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewSectionHandler(db)
+
+	req := httptest.NewRequest("GET", "/api/v1/sections/not-a-uuid/links", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetSectionLinks(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Code != "INVALID_SECTION_ID" {
+		t.Errorf("expected error code INVALID_SECTION_ID, got %s", response.Code)
+	}
+}
+
+func insertTestSectionLink(t *testing.T, db *sql.DB, postID, url string, metadata map[string]interface{}, createdAt time.Time) {
+	t.Helper()
+
+	var metadataValue interface{}
+	if metadata != nil {
+		bytes, err := json.Marshal(metadata)
+		if err != nil {
+			t.Fatalf("failed to marshal metadata: %v", err)
+		}
+		metadataValue = string(bytes)
+	}
+
+	_, err := db.Exec(
+		`INSERT INTO links (id, post_id, url, metadata, created_at) VALUES (gen_random_uuid(), $1, $2, $3, $4)`,
+		postID, url, metadataValue, createdAt,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert link: %v", err)
 	}
 }

--- a/backend/internal/services/section.go
+++ b/backend/internal/services/section.go
@@ -3,7 +3,10 @@ package services
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/sanderginn/clubhouse/internal/models"
@@ -87,4 +90,113 @@ func (s *SectionService) GetSectionByID(ctx context.Context, id uuid.UUID) (*mod
 	}
 
 	return &section, nil
+}
+
+func (s *SectionService) GetSectionLinks(ctx context.Context, sectionID uuid.UUID, cursor *string, limit int) (*models.SectionLinksResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.sections").Start(ctx, "SectionService.GetSectionLinks")
+	span.SetAttributes(
+		attribute.String("section_id", sectionID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && *cursor != ""),
+	)
+	defer span.End()
+
+	if limit <= 0 {
+		limit = 15
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	var exists bool
+	err := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM sections WHERE id = $1)", sectionID).Scan(&exists)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	if !exists {
+		notFoundErr := errors.New("section not found")
+		recordSpanError(span, notFoundErr)
+		return nil, notFoundErr
+	}
+
+	query := `
+		SELECT
+			l.id, l.url, l.metadata, l.post_id,
+			p.user_id, u.username, l.created_at
+		FROM links l
+		JOIN posts p ON l.post_id = p.id
+		JOIN users u ON p.user_id = u.id
+		WHERE p.section_id = $1 AND p.deleted_at IS NULL
+	`
+
+	args := []interface{}{sectionID}
+	argIndex := 2
+
+	if cursor != nil && *cursor != "" {
+		parsedCursor, err := time.Parse(time.RFC3339Nano, *cursor)
+		if err != nil {
+			invalidErr := errors.New("invalid cursor")
+			recordSpanError(span, invalidErr)
+			return nil, invalidErr
+		}
+
+		query += " AND l.created_at < $" + fmt.Sprintf("%d", argIndex)
+		args = append(args, parsedCursor)
+		argIndex++
+	}
+
+	query += " ORDER BY l.created_at DESC LIMIT $" + fmt.Sprintf("%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var links []models.SectionLink
+	for rows.Next() {
+		var link models.SectionLink
+		var metadataJSON sql.NullString
+		if err := rows.Scan(&link.ID, &link.URL, &metadataJSON, &link.PostID, &link.UserID, &link.Username, &link.CreatedAt); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+
+		if metadataJSON.Valid {
+			if err := json.Unmarshal([]byte(metadataJSON.String), &link.Metadata); err != nil {
+				link.Metadata = nil
+			}
+		}
+
+		links = append(links, link)
+	}
+
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	hasMore := len(links) > limit
+	if hasMore {
+		links = links[:limit]
+	}
+
+	var nextCursor *string
+	if hasMore && len(links) > 0 {
+		cursorStr := links[len(links)-1].CreatedAt.Format("2006-01-02T15:04:05.000Z07:00")
+		nextCursor = &cursorStr
+	}
+
+	if links == nil {
+		links = []models.SectionLink{}
+	}
+
+	return &models.SectionLinksResponse{
+		Links:      links,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	}, nil
 }

--- a/backend/internal/services/section_test.go
+++ b/backend/internal/services/section_test.go
@@ -2,8 +2,12 @@ package services
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/sanderginn/clubhouse/internal/testutil"
 )
 
@@ -32,4 +36,112 @@ func TestSectionServiceListSections(t *testing.T) {
 	if len(sections) == 0 {
 		t.Error("expected at least one section")
 	}
+}
+
+func TestSectionServiceGetSectionLinksPagination(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "sectionlinksuser", "sectionlinksuser@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Links Section", "general")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Post with links")
+	deletedPostID := testutil.CreateTestPost(t, db, userID, sectionID, "Deleted post")
+
+	_, err := db.Exec(`UPDATE posts SET deleted_at = now(), deleted_by_user_id = $1 WHERE id = $2`, userID, deletedPostID)
+	if err != nil {
+		t.Fatalf("failed to delete post: %v", err)
+	}
+
+	now := time.Now().UTC()
+	older := now.Add(-2 * time.Hour)
+	newer := now.Add(-1 * time.Hour)
+
+	insertTestSectionLink(t, db, postID, "https://example.com/older", map[string]interface{}{"title": "Older"}, older)
+	insertTestSectionLink(t, db, postID, "https://example.com/newer", map[string]interface{}{"title": "Newer"}, newer)
+	insertTestSectionLink(t, db, deletedPostID, "https://example.com/deleted", nil, now.Add(1*time.Minute))
+
+	service := NewSectionService(db)
+
+	response, err := service.GetSectionLinks(context.Background(), uuid.MustParse(sectionID), nil, 1)
+	if err != nil {
+		t.Fatalf("GetSectionLinks failed: %v", err)
+	}
+
+	if len(response.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(response.Links))
+	}
+
+	if response.Links[0].URL != "https://example.com/newer" {
+		t.Errorf("expected newest link first, got %s", response.Links[0].URL)
+	}
+
+	if response.NextCursor == nil || !response.HasMore {
+		t.Fatalf("expected next cursor and hasMore true")
+	}
+
+	nextResponse, err := service.GetSectionLinks(context.Background(), uuid.MustParse(sectionID), response.NextCursor, 10)
+	if err != nil {
+		t.Fatalf("GetSectionLinks with cursor failed: %v", err)
+	}
+
+	if len(nextResponse.Links) != 1 {
+		t.Fatalf("expected 1 link on second page, got %d", len(nextResponse.Links))
+	}
+
+	if nextResponse.Links[0].URL != "https://example.com/older" {
+		t.Errorf("expected older link on second page, got %s", nextResponse.Links[0].URL)
+	}
+
+	if nextResponse.HasMore || nextResponse.NextCursor != nil {
+		t.Errorf("expected no more results after second page")
+	}
+}
+
+func TestSectionServiceGetSectionLinksInvalidCursor(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	sectionID := testutil.CreateTestSection(t, db, "Cursor Section", "general")
+
+	service := NewSectionService(db)
+	_, err := service.GetSectionLinks(context.Background(), uuid.MustParse(sectionID), ptr("not-a-time"), 10)
+	if err == nil || err.Error() != "invalid cursor" {
+		t.Fatalf("expected invalid cursor error, got %v", err)
+	}
+}
+
+func TestSectionServiceGetSectionLinksNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	service := NewSectionService(db)
+	_, err := service.GetSectionLinks(context.Background(), uuid.New(), nil, 10)
+	if err == nil || err.Error() != "section not found" {
+		t.Fatalf("expected section not found error, got %v", err)
+	}
+}
+
+func insertTestSectionLink(t *testing.T, db *sql.DB, postID, url string, metadata map[string]interface{}, createdAt time.Time) {
+	t.Helper()
+
+	var metadataValue interface{}
+	if metadata != nil {
+		bytes, err := json.Marshal(metadata)
+		if err != nil {
+			t.Fatalf("failed to marshal metadata: %v", err)
+		}
+		metadataValue = string(bytes)
+	}
+
+	_, err := db.Exec(
+		`INSERT INTO links (id, post_id, url, metadata, created_at) VALUES (gen_random_uuid(), $1, $2, $3, $4)`,
+		postID, url, metadataValue, createdAt,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert link: %v", err)
+	}
+}
+
+func ptr(value string) *string {
+	return &value
 }


### PR DESCRIPTION
## Summary
- add section links service query with cursor pagination and deleted post filtering
- add handler and route wiring for `/api/v1/sections/{id}/links`
- add service and handler tests for pagination and error cases

## Testing
- `go build ./...`
- `go test ./internal/services -run TestSectionService -v` (skipped: `CLUBHOUSE_TEST_DATABASE_URL` not set)
- `go test ./internal/handlers -run TestGetSectionLinks -v` (skipped: `CLUBHOUSE_TEST_DATABASE_URL` not set)

Closes #656