### PR TITLE
Frontend: Add section links store and API client method

### DIFF
--- a/frontend/src/lib/observability/tracing.ts
+++ b/frontend/src/lib/observability/tracing.ts
@@ -1,7 +1,6 @@
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -37,11 +36,11 @@ export function initTracing(): void {
   const exporter = new OTLPTraceExporter({ url: exporterUrl });
   const provider = new WebTracerProvider({
     resource: resourceFromAttributes({
-      [SemanticResourceAttributes.SERVICE_NAME]:
+      'service.name':
         (import.meta.env.VITE_OTEL_SERVICE_NAME as string | undefined) ?? 'clubhouse-frontend',
-      [SemanticResourceAttributes.SERVICE_VERSION]:
+      'service.version':
         (import.meta.env.VITE_APP_VERSION as string | undefined) ?? 'unknown',
-      [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: import.meta.env.MODE,
+      'deployment.environment': import.meta.env.MODE,
     }),
     spanProcessors: [new BatchSpanProcessor(exporter)],
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,6 @@
 import type { Post, CreatePostRequest, LinkMetadata } from '../stores/postStore';
 import type { CreateCommentRequest, Comment } from '../stores/commentStore';
+import type { SectionLink } from '../stores/sectionLinksStore';
 import { mapApiComment, type ApiComment } from '../stores/commentMapper';
 import { mapApiPost, type ApiPost } from '../stores/postMapper';
 import { logError, logWarn } from '../lib/observability/logger';
@@ -29,6 +30,12 @@ interface ApiResponse<T> {
     cursor?: string;
     hasMore?: boolean;
   };
+}
+
+interface SectionLinksResponse {
+  links: SectionLink[];
+  has_more?: boolean;
+  next_cursor?: string | null;
 }
 
 interface LogOptions {
@@ -160,7 +167,7 @@ class ApiClient {
       }
 
       propagation.inject(context.active(), headers, {
-        set: (carrier, key, value) => {
+        set: (carrier: Headers, key: string, value: string) => {
           carrier.set(key, value);
         },
       });
@@ -435,6 +442,16 @@ class ApiClient {
     const params = new URLSearchParams({ limit: String(limit) });
     if (cursor) params.set('cursor', cursor);
     return this.get(`/sections/${sectionId}/feed?${params}`);
+  }
+
+  async getSectionLinks(
+    sectionId: string,
+    limit = 20,
+    cursor?: string
+  ): Promise<SectionLinksResponse> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (cursor) params.set('cursor', cursor);
+    return this.get(`/sections/${sectionId}/links?${params}`);
   }
 
   async deletePost(postId: string): Promise<void> {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -32,10 +32,38 @@ interface ApiResponse<T> {
   };
 }
 
-interface SectionLinksResponse {
-  links: SectionLink[];
+interface ApiSectionLink {
+  id: string;
+  url: string;
+  metadata?: LinkMetadata;
+  post_id: string;
+  user_id: string;
+  username: string;
+  created_at: string;
+}
+
+interface ApiSectionLinksResponse {
+  links: ApiSectionLink[];
   has_more?: boolean;
   next_cursor?: string | null;
+}
+
+interface SectionLinksResponse {
+  links: SectionLink[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+function mapApiSectionLink(link: ApiSectionLink): SectionLink {
+  return {
+    id: link.id,
+    url: link.url,
+    metadata: link.metadata,
+    postId: link.post_id,
+    userId: link.user_id,
+    username: link.username,
+    createdAt: link.created_at,
+  };
 }
 
 interface LogOptions {
@@ -451,7 +479,14 @@ class ApiClient {
   ): Promise<SectionLinksResponse> {
     const params = new URLSearchParams({ limit: String(limit) });
     if (cursor) params.set('cursor', cursor);
-    return this.get(`/sections/${sectionId}/links?${params}`);
+    const response = await this.get<ApiSectionLinksResponse>(
+      `/sections/${sectionId}/links?${params}`
+    );
+    return {
+      links: (response.links ?? []).map(mapApiSectionLink),
+      hasMore: response.has_more ?? false,
+      nextCursor: response.next_cursor ?? null,
+    };
   }
 
   async deletePost(postId: string): Promise<void> {

--- a/frontend/src/stores/__tests__/sectionLinksStore.test.ts
+++ b/frontend/src/stores/__tests__/sectionLinksStore.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  sectionLinksStore,
+  sectionLinks,
+  isLoadingSectionLinks,
+  hasMoreSectionLinks,
+} from '../sectionLinksStore';
+
+const makeLink = (id: string) => ({
+  id,
+  url: `https://example.com/${id}`,
+  postId: `post-${id}`,
+  userId: `user-${id}`,
+  username: `user-${id}`,
+  createdAt: '2026-02-02T00:00:00Z',
+});
+
+beforeEach(() => {
+  sectionLinksStore.reset();
+});
+
+describe('sectionLinksStore', () => {
+  it('setLinks sets links, cursor, section, and clears loading/error', () => {
+    sectionLinksStore.setLoading(true);
+    sectionLinksStore.setLinks([makeLink('1')], 'cursor-1', true, 'section-1');
+
+    const state = get(sectionLinksStore);
+    expect(state.links).toHaveLength(1);
+    expect(state.cursor).toBe('cursor-1');
+    expect(state.hasMore).toBe(true);
+    expect(state.sectionId).toBe('section-1');
+    expect(state.isLoading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('appendLinks adds new links without duplicating ids', () => {
+    sectionLinksStore.setLinks([makeLink('1')], 'cursor-1', true, 'section-1');
+    sectionLinksStore.appendLinks([makeLink('1'), makeLink('2')], 'cursor-2', false);
+
+    const state = get(sectionLinksStore);
+    expect(state.links).toHaveLength(2);
+    expect(state.links.map((link) => link.id)).toEqual(['1', '2']);
+    expect(state.cursor).toBe('cursor-2');
+    expect(state.hasMore).toBe(false);
+  });
+
+  it('setLoading clears error when loading', () => {
+    sectionLinksStore.setError('boom');
+    sectionLinksStore.setLoading(true);
+
+    const state = get(sectionLinksStore);
+    expect(state.isLoading).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  it('setError stops loading', () => {
+    sectionLinksStore.setLoading(true);
+    sectionLinksStore.setError('failed');
+
+    const state = get(sectionLinksStore);
+    expect(state.isLoading).toBe(false);
+    expect(state.error).toBe('failed');
+  });
+
+  it('reset returns to initial state', () => {
+    sectionLinksStore.setLinks([makeLink('1')], 'cursor-1', false, 'section-1');
+    sectionLinksStore.reset();
+
+    const state = get(sectionLinksStore);
+    expect(state.links).toEqual([]);
+    expect(state.cursor).toBeNull();
+    expect(state.hasMore).toBe(true);
+    expect(state.sectionId).toBeNull();
+  });
+
+  it('derived stores expose state slices', () => {
+    sectionLinksStore.setLinks([makeLink('1')], null, true, 'section-1');
+    sectionLinksStore.setLoading(true);
+
+    expect(get(sectionLinks)).toHaveLength(1);
+    expect(get(isLoadingSectionLinks)).toBe(true);
+    expect(get(hasMoreSectionLinks)).toBe(true);
+  });
+});

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -5,6 +5,7 @@ export * from './postStore';
 export * from './feedStore';
 export * from './commentStore';
 export * from './commentFeedStore';
+export * from './sectionLinksStore';
 export * from './websocketStore';
 export * from './searchStore';
 export * from './pwaStore';

--- a/frontend/src/stores/sectionLinksStore.ts
+++ b/frontend/src/stores/sectionLinksStore.ts
@@ -1,0 +1,90 @@
+import { writable, derived } from 'svelte/store';
+import type { LinkMetadata } from './postStore';
+
+export interface SectionLink {
+  id: string;
+  url: string;
+  metadata?: LinkMetadata;
+  postId: string;
+  userId: string;
+  username: string;
+  createdAt: string;
+}
+
+export interface SectionLinksState {
+  links: SectionLink[];
+  isLoading: boolean;
+  error: string | null;
+  cursor: string | null;
+  hasMore: boolean;
+  sectionId: string | null;
+}
+
+const initialState: SectionLinksState = {
+  links: [],
+  isLoading: false,
+  error: null,
+  cursor: null,
+  hasMore: true,
+  sectionId: null,
+};
+
+function createSectionLinksStore() {
+  const { subscribe, set, update } = writable<SectionLinksState>({ ...initialState });
+
+  return {
+    subscribe,
+    setLinks: (
+      links: SectionLink[],
+      cursor: string | null,
+      hasMore: boolean,
+      sectionId: string | null
+    ) =>
+      update((state) => ({
+        ...state,
+        links,
+        cursor,
+        hasMore,
+        sectionId,
+        isLoading: false,
+        error: null,
+      })),
+    appendLinks: (links: SectionLink[], cursor: string | null, hasMore: boolean) =>
+      update((state) => {
+        const seen = new Set(state.links.map((link) => link.id));
+        const unique = links.filter((link) => {
+          if (!link.id) return true;
+          if (seen.has(link.id)) return false;
+          seen.add(link.id);
+          return true;
+        });
+        return {
+          ...state,
+          links: [...state.links, ...unique],
+          cursor,
+          hasMore,
+          isLoading: false,
+          error: null,
+        };
+      }),
+    setLoading: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setError: (error: string | null) =>
+      update((state) => ({
+        ...state,
+        error,
+        isLoading: false,
+      })),
+    reset: () => set({ ...initialState }),
+  };
+}
+
+export const sectionLinksStore = createSectionLinksStore();
+
+export const sectionLinks = derived(sectionLinksStore, ($store) => $store.links);
+export const isLoadingSectionLinks = derived(sectionLinksStore, ($store) => $store.isLoading);
+export const hasMoreSectionLinks = derived(sectionLinksStore, ($store) => $store.hasMore);


### PR DESCRIPTION
## Summary
- add section links store with pagination actions and derived selectors
- add api client method for section links and export store index entry
- cover store behavior with unit tests
- align frontend tracing attributes and API header injection typing for check

## Tests
- npm run check
- npm run test -- src/stores/__tests__/sectionLinksStore.test.ts

Closes #657