### PR TITLE
Frontend: Add Highlight types and editor/display components

### DIFF
--- a/frontend/src/components/posts/HighlightDisplay.svelte
+++ b/frontend/src/components/posts/HighlightDisplay.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Highlight } from '../../stores/postStore';
+
+  export let highlights: Highlight[] = [];
+
+  const formatTimestamp = (seconds: number) => {
+    const safeSeconds = Math.max(0, Math.floor(seconds));
+    const minutes = Math.floor(safeSeconds / 60);
+    const remainder = safeSeconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
+  };
+</script>
+
+{#if highlights?.length}
+  <div class="flex flex-wrap gap-2" aria-label="Highlights">
+    {#each highlights as highlight (highlight.timestamp + '-' + (highlight.label ?? ''))}
+      <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
+        <span class="font-medium text-gray-800">{formatTimestamp(highlight.timestamp)}</span>
+        {#if highlight.label}
+          <span class="ml-1 text-gray-600">{highlight.label}</span>
+        {/if}
+      </span>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/components/posts/HighlightEditor.svelte
+++ b/frontend/src/components/posts/HighlightEditor.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import type { Highlight } from '../../stores/postStore';
+
+  const maxHighlights = 20;
+
+  export let highlights: Highlight[] = [];
+  export let disabled = false;
+
+  let timestampInput = '';
+  let labelInput = '';
+  let error: string | null = null;
+
+  const formatTimestamp = (seconds: number) => {
+    const safeSeconds = Math.max(0, Math.floor(seconds));
+    const minutes = Math.floor(safeSeconds / 60);
+    const remainder = safeSeconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
+  };
+
+  const parseTimestamp = (value: string) => {
+    const match = value.trim().match(/^(\d{1,3}):([0-5]\d)$/);
+    if (!match) return null;
+    const minutes = Number(match[1]);
+    const seconds = Number(match[2]);
+    return minutes * 60 + seconds;
+  };
+
+  const isAtMax = () => highlights.length >= maxHighlights;
+
+  const addHighlight = () => {
+    if (disabled) return;
+    error = null;
+
+    if (isAtMax()) {
+      error = `Maximum of ${maxHighlights} highlights reached.`;
+      return;
+    }
+
+    const parsedSeconds = parseTimestamp(timestampInput);
+    if (parsedSeconds === null) {
+      error = 'Enter a timestamp in mm:ss format.';
+      return;
+    }
+
+    const label = labelInput.trim();
+    if (label.length > 100) {
+      error = 'Label must be 100 characters or fewer.';
+      return;
+    }
+
+    highlights = [...highlights, ...(label ? [{ timestamp: parsedSeconds, label }] : [{ timestamp: parsedSeconds }])];
+    timestampInput = '';
+    labelInput = '';
+  };
+
+  const removeHighlight = (index: number) => {
+    highlights = highlights.filter((_, idx) => idx !== index);
+    error = null;
+  };
+</script>
+
+<div class="space-y-3">
+  <div class="grid gap-3 md:grid-cols-2">
+    <div class="space-y-1">
+      <label class="text-xs font-medium text-gray-600" for="highlight-timestamp">Timestamp (mm:ss)</label>
+      <input
+        id="highlight-timestamp"
+        type="text"
+        inputmode="numeric"
+        placeholder="03:15"
+        class="w-full rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+        bind:value={timestampInput}
+        disabled={disabled}
+        aria-invalid={error?.includes('timestamp')}
+      />
+    </div>
+
+    <div class="space-y-1">
+      <label class="text-xs font-medium text-gray-600" for="highlight-label">Label (optional)</label>
+      <input
+        id="highlight-label"
+        type="text"
+        maxlength="100"
+        placeholder="Intro, drop, chorus"
+        class="w-full rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+        bind:value={labelInput}
+        disabled={disabled}
+      />
+    </div>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-3">
+    <button
+      type="button"
+      class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white transition disabled:bg-gray-300"
+      on:click={addHighlight}
+      disabled={disabled || isAtMax()}
+    >
+      Add highlight
+    </button>
+    {#if isAtMax()}
+      <p class="text-xs text-amber-600">Maximum of {maxHighlights} highlights reached.</p>
+    {/if}
+    {#if error && !isAtMax()}
+      <p class="text-xs text-red-500">{error}</p>
+    {/if}
+  </div>
+
+  {#if highlights.length > 0}
+    <ul class="space-y-2">
+      {#each highlights as highlight, index}
+        <li class="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm">
+          <div class="flex items-center gap-2">
+            <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+              {formatTimestamp(highlight.timestamp)}
+            </span>
+            {#if highlight.label}
+              <span class="text-gray-700">{highlight.label}</span>
+            {/if}
+          </div>
+          <button
+            type="button"
+            class="text-xs text-gray-400 hover:text-gray-600"
+            on:click={() => removeHighlight(index)}
+            disabled={disabled}
+            aria-label={`Remove highlight ${formatTimestamp(highlight.timestamp)}`}
+          >
+            Remove
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+const { default: HighlightDisplay } = await import('../HighlightDisplay.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('HighlightDisplay', () => {
+  it('renders formatted timestamps with labels', () => {
+    const { getByText } = render(HighlightDisplay, {
+      highlights: [{ timestamp: 75, label: 'Intro' }],
+    });
+
+    expect(getByText('01:15')).toBeInTheDocument();
+    expect(getByText('Intro')).toBeInTheDocument();
+  });
+
+  it('renders timestamps without labels', () => {
+    const { getByText, queryByText } = render(HighlightDisplay, {
+      highlights: [{ timestamp: 5 }],
+    });
+
+    expect(getByText('00:05')).toBeInTheDocument();
+    expect(queryByText('Intro')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when highlights are empty', () => {
+    const { queryByLabelText } = render(HighlightDisplay, {
+      highlights: [],
+    });
+
+    expect(queryByLabelText('Highlights')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/posts/__tests__/HighlightEditor.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightEditor.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const { default: HighlightEditor } = await import('../HighlightEditor.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('HighlightEditor', () => {
+  it('adds a highlight from mm:ss input', async () => {
+    const { getByLabelText, getByText } = render(HighlightEditor, {
+      highlights: [],
+    });
+
+    const timestampInput = getByLabelText('Timestamp (mm:ss)');
+    const labelInput = getByLabelText('Label (optional)');
+
+    await fireEvent.input(timestampInput, { target: { value: '01:30' } });
+    await fireEvent.input(labelInput, { target: { value: 'Intro' } });
+    await fireEvent.click(getByText('Add highlight'));
+
+    expect(getByText('01:30')).toBeInTheDocument();
+    expect(getByText('Intro')).toBeInTheDocument();
+  });
+
+  it('removes a highlight', async () => {
+    const { getByLabelText, queryByText } = render(HighlightEditor, {
+      highlights: [
+        { timestamp: 30, label: 'Intro' },
+        { timestamp: 90, label: 'Drop' },
+      ],
+    });
+
+    await fireEvent.click(getByLabelText('Remove highlight 00:30'));
+
+    expect(queryByText('00:30')).not.toBeInTheDocument();
+    expect(queryByText('Intro')).not.toBeInTheDocument();
+  });
+
+  it('shows max highlights message and disables add', () => {
+    const { getByText } = render(HighlightEditor, {
+      highlights: Array.from({ length: 20 }, (_, index) => ({
+        timestamp: index,
+        label: `Label ${index}`,
+      })),
+    });
+
+    const addButton = getByText('Add highlight') as HTMLButtonElement;
+
+    expect(addButton.disabled).toBe(true);
+    expect(getByText('Maximum of 20 highlights reached.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/posts/index.ts
+++ b/frontend/src/components/posts/index.ts
@@ -1,2 +1,4 @@
 export { default as PostForm } from './PostForm.svelte';
 export { default as LinkPreview } from './LinkPreview.svelte';
+export { default as HighlightEditor } from './HighlightEditor.svelte';
+export { default as HighlightDisplay } from './HighlightDisplay.svelte';

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -1,9 +1,15 @@
 import { writable, derived } from 'svelte/store';
 
+export interface Highlight {
+  timestamp: number;
+  label?: string;
+}
+
 export interface Link {
   id?: string;
   url: string;
   metadata?: LinkMetadata;
+  highlights?: Highlight[];
 }
 
 export interface LinkMetadata {


### PR DESCRIPTION
## Summary
- add Highlight type and link highlights typing
- add HighlightEditor and HighlightDisplay Svelte components with validation and formatting
- add component tests for highlight editor/display

## Testing
- npm run check
- npm run test -- -t "Highlight"

Closes #653