### PR TITLE
Observability: emit metrics/logs for admin suspend/unsuspend actions

### DIFF
--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -291,6 +291,13 @@ func (h *AdminHandler) SuspendUser(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
+	observability.RecordAdminAction(r.Context(), "suspend_user")
+
+	observability.LogInfo(r.Context(), "user suspended",
+		"user_id", userID.String(),
+		"admin_user_id", adminUserID.String(),
+		"reason", req.Reason,
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -340,6 +347,12 @@ func (h *AdminHandler) UnsuspendUser(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	observability.RecordAdminAction(r.Context(), "unsuspend_user")
+
+	observability.LogInfo(r.Context(), "user unsuspended",
+		"user_id", userID.String(),
+		"admin_user_id", adminUserID.String(),
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- record admin action metrics for suspend/unsuspend success paths
- add info logs for suspend/unsuspend including user/admin IDs (and reason on suspend)

## Testing
- `go build ./...`
- `go test ./internal/handlers -run "TestSuspendUser|TestUnsuspendUser" -v` (skipped: `CLUBHOUSE_TEST_DATABASE_URL` not set)

Closes #693