### PR TITLE
Observability: add push subscription lifecycle metrics/logs

### DIFF
--- a/backend/internal/handlers/push.go
+++ b/backend/internal/handlers/push.go
@@ -89,6 +89,9 @@ func (h *PushHandler) Subscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	observability.RecordPushSubscriptionCreated(r.Context())
+	observability.LogInfo(r.Context(), "push subscription created", "user_id", userID.String())
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -109,6 +112,9 @@ func (h *PushHandler) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 		writeError(r.Context(), w, http.StatusInternalServerError, "UNSUBSCRIBE_FAILED", "Failed to remove push subscription")
 		return
 	}
+
+	observability.RecordPushSubscriptionDeleted(r.Context())
+	observability.LogInfo(r.Context(), "push subscription deleted", "user_id", userID.String())
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/observability/metrics.go
+++ b/backend/internal/observability/metrics.go
@@ -48,6 +48,8 @@ type metrics struct {
 	notificationsCreated      metric.Int64Counter
 	notificationsDelivered    metric.Int64Counter
 	notificationsFailed       metric.Int64Counter
+	pushSubscriptionsCreated  metric.Int64Counter
+	pushSubscriptionsDeleted  metric.Int64Counter
 	linkMetadataFetchAttempts metric.Int64Counter
 	linkMetadataFetchSuccess  metric.Int64Counter
 	linkMetadataFetchFailures metric.Int64Counter
@@ -417,6 +419,24 @@ func initMetrics() error {
 			return
 		}
 
+		pushSubscriptionsCreated, err := meter.Int64Counter(
+			"clubhouse.push.subscriptions.created",
+			metric.WithDescription("Number of push subscriptions created"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		pushSubscriptionsDeleted, err := meter.Int64Counter(
+			"clubhouse.push.subscriptions.deleted",
+			metric.WithDescription("Number of push subscriptions deleted"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
 		linkMetadataFetchAttempts, err := meter.Int64Counter(
 			"clubhouse.links.metadata.fetch.attempts",
 			metric.WithDescription("Number of link metadata fetch attempts"),
@@ -712,6 +732,8 @@ func initMetrics() error {
 			notificationsCreated:      notificationsCreated,
 			notificationsDelivered:    notificationsDelivered,
 			notificationsFailed:       notificationsFailed,
+			pushSubscriptionsCreated:  pushSubscriptionsCreated,
+			pushSubscriptionsDeleted:  pushSubscriptionsDeleted,
 			linkMetadataFetchAttempts: linkMetadataFetchAttempts,
 			linkMetadataFetchSuccess:  linkMetadataFetchSuccess,
 			linkMetadataFetchFailures: linkMetadataFetchFailures,
@@ -1220,6 +1242,24 @@ func RecordNotificationDeliveryFailed(ctx context.Context, channel string, error
 		attrs = append(attrs, attribute.String("error_type", errorType))
 	}
 	m.notificationsFailed.Add(ctx, count, metric.WithAttributes(attrs...))
+}
+
+// RecordPushSubscriptionCreated increments the push subscription created counter.
+func RecordPushSubscriptionCreated(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.pushSubscriptionsCreated.Add(ctx, 1)
+}
+
+// RecordPushSubscriptionDeleted increments the push subscription deleted counter.
+func RecordPushSubscriptionDeleted(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.pushSubscriptionsDeleted.Add(ctx, 1)
 }
 
 // RecordLinkMetadataFetchAttempt increments the link metadata fetch attempt counter.

--- a/backend/internal/observability/metrics_test.go
+++ b/backend/internal/observability/metrics_test.go
@@ -1,0 +1,64 @@
+package observability
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRecordPushSubscriptionMetrics(t *testing.T) {
+	metricsOnce = sync.Once{}
+	metricsInstance = nil
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+
+	if err := initMetrics(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
+
+	ctx := context.Background()
+	RecordPushSubscriptionCreated(ctx)
+	RecordPushSubscriptionDeleted(ctx)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("failed to collect metrics: %v", err)
+	}
+
+	if got := findInt64SumMetric(t, rm, "clubhouse.push.subscriptions.created"); got != 1 {
+		t.Fatalf("expected created metric to be 1, got %d", got)
+	}
+	if got := findInt64SumMetric(t, rm, "clubhouse.push.subscriptions.deleted"); got != 1 {
+		t.Fatalf("expected deleted metric to be 1, got %d", got)
+	}
+}
+
+func findInt64SumMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s is not int64 sum", name)
+			}
+			var total int64
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+
+	t.Fatalf("metric %s not found", name)
+	return 0
+}


### PR DESCRIPTION
## Summary
- add push subscription create/delete counters in observability metrics
- record push subscription metrics and info logs on subscribe/unsubscribe
- add metrics unit test for push subscription counters

## Testing
- go build ./...
- go test ./internal/handlers -run Push -v
- go test ./internal/observability -run PushSubscription -v

Closes #694