### PR TITLE
Observability: track notification read events (single + mark all)

### DIFF
--- a/backend/internal/handlers/notification.go
+++ b/backend/internal/handlers/notification.go
@@ -132,6 +132,8 @@ func (h *NotificationHandler) MarkNotificationRead(w http.ResponseWriter, r *htt
 		return
 	}
 
+	observability.RecordNotificationRead(r.Context(), "single", 1)
+
 	response := models.UpdateNotificationResponse{
 		Notification: *notification,
 	}
@@ -161,11 +163,13 @@ func (h *NotificationHandler) MarkAllNotificationsRead(w http.ResponseWriter, r 
 		return
 	}
 
-	unreadCount, err := h.notificationService.MarkAllNotificationsRead(r.Context(), userID)
+	updatedCount, unreadCount, err := h.notificationService.MarkAllNotificationsRead(r.Context(), userID)
 	if err != nil {
 		writeError(r.Context(), w, http.StatusInternalServerError, "MARK_ALL_NOTIFICATIONS_READ_FAILED", "Failed to mark notifications as read")
 		return
 	}
+
+	observability.RecordNotificationRead(r.Context(), "all", updatedCount)
 
 	response := models.MarkAllNotificationsReadResponse{
 		UnreadCount: unreadCount,

--- a/backend/internal/observability/metrics_test.go
+++ b/backend/internal/observability/metrics_test.go
@@ -6,54 +6,91 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestRecordPushSubscriptionMetrics(t *testing.T) {
-	metricsOnce = sync.Once{}
-	metricsInstance = nil
-
+	ctx := context.Background()
 	reader := sdkmetric.NewManualReader()
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	otel.SetMeterProvider(mp)
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(previousProvider)
+	})
 
+	resetMetricsForTest()
 	if err := initMetrics(); err != nil {
 		t.Fatalf("failed to init metrics: %v", err)
 	}
 
-	ctx := context.Background()
 	RecordPushSubscriptionCreated(ctx)
 	RecordPushSubscriptionDeleted(ctx)
 
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(ctx, &rm); err != nil {
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &metrics); err != nil {
 		t.Fatalf("failed to collect metrics: %v", err)
 	}
 
-	if got := findInt64SumMetric(t, rm, "clubhouse.push.subscriptions.created"); got != 1 {
+	if got := findInt64SumMetric(t, metrics, "clubhouse.push.subscriptions.created"); got != 1 {
 		t.Fatalf("expected created metric to be 1, got %d", got)
 	}
-	if got := findInt64SumMetric(t, rm, "clubhouse.push.subscriptions.deleted"); got != 1 {
+	if got := findInt64SumMetric(t, metrics, "clubhouse.push.subscriptions.deleted"); got != 1 {
 		t.Fatalf("expected deleted metric to be 1, got %d", got)
 	}
 }
 
-func findInt64SumMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
+func TestRecordNotificationReadMetrics(t *testing.T) {
+	ctx := context.Background()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(previousProvider)
+	})
+
+	resetMetricsForTest()
+	if err := initMetrics(); err != nil {
+		t.Fatalf("failed to init metrics: %v", err)
+	}
+
+	RecordNotificationRead(ctx, "single", 1)
+	RecordNotificationRead(ctx, "all", 3)
+
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &metrics); err != nil {
+		t.Fatalf("failed to collect metrics: %v", err)
+	}
+
+	singleValue := findCounterValue(t, metrics, "clubhouse.notifications.read", attribute.String("action", "single"))
+	if singleValue != 1 {
+		t.Fatalf("expected single read count 1, got %d", singleValue)
+	}
+
+	allValue := findCounterValue(t, metrics, "clubhouse.notifications.read", attribute.String("action", "all"))
+	if allValue != 3 {
+		t.Fatalf("expected mark all read count 3, got %d", allValue)
+	}
+}
+
+func findInt64SumMetric(t *testing.T, metrics metricdata.ResourceMetrics, name string) int64 {
 	t.Helper()
 
-	for _, scope := range rm.ScopeMetrics {
-		for _, m := range scope.Metrics {
-			if m.Name != name {
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metricItem := range scope.Metrics {
+			if metricItem.Name != name {
 				continue
 			}
-			sum, ok := m.Data.(metricdata.Sum[int64])
+			sum, ok := metricItem.Data.(metricdata.Sum[int64])
 			if !ok {
 				t.Fatalf("metric %s is not int64 sum", name)
 			}
 			var total int64
-			for _, dp := range sum.DataPoints {
-				total += dp.Value
+			for _, dataPoint := range sum.DataPoints {
+				total += dataPoint.Value
 			}
 			return total
 		}
@@ -61,4 +98,47 @@ func findInt64SumMetric(t *testing.T, rm metricdata.ResourceMetrics, name string
 
 	t.Fatalf("metric %s not found", name)
 	return 0
+}
+
+func findCounterValue(t *testing.T, metrics metricdata.ResourceMetrics, name string, attrs ...attribute.KeyValue) int64 {
+	t.Helper()
+
+	for _, scopeMetrics := range metrics.ScopeMetrics {
+		for _, metricItem := range scopeMetrics.Metrics {
+			if metricItem.Name != name {
+				continue
+			}
+			sum, ok := metricItem.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s has unexpected data type %T", name, metricItem.Data)
+			}
+			for _, dataPoint := range sum.DataPoints {
+				if attributesMatch(dataPoint.Attributes, attrs) {
+					return dataPoint.Value
+				}
+			}
+		}
+	}
+
+	t.Fatalf("metric %s with attributes %v not found", name, attrs)
+	return 0
+}
+
+func attributesMatch(set attribute.Set, attrs []attribute.KeyValue) bool {
+	found := map[string]string{}
+	for _, kv := range set.ToSlice() {
+		found[string(kv.Key)] = kv.Value.AsString()
+	}
+	for _, kv := range attrs {
+		if found[string(kv.Key)] != kv.Value.AsString() {
+			return false
+		}
+	}
+	return true
+}
+
+func resetMetricsForTest() {
+	metricsOnce = sync.Once{}
+	metricsInitErr = nil
+	metricsInstance = nil
 }


### PR DESCRIPTION
## Summary
- add notification read counter with action attribute and helper function
- emit read metrics from single and mark-all notification endpoints
- cover notification read metric helper with new observability test

Closes #695