### PR TITLE
Frontend: Integrate highlights into PostForm and PostCard

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -49,3 +49,31 @@ test('create text-only post', async ({ page }) => {
 
   await expect(page.getByText(content)).toBeVisible();
 });
+
+test('create post with highlights', async ({ page }) => {
+  await login(page);
+  const nav = page.getByRole('navigation', { name: 'Main navigation' });
+  const sectionButton = nav.getByRole('button', { name: sectionName });
+  await expect(sectionButton).toBeVisible();
+  await sectionButton.click();
+
+  const content = `E2E highlight post ${Date.now()}`;
+  await page.getByLabel('Post content').fill(content);
+
+  await page.getByRole('button', { name: 'Add link' }).click();
+  const linkInput = page.getByLabel('Link URL');
+  await linkInput.fill('https://example.com');
+  await linkInput.press('Enter');
+
+  const timestampInput = page.getByLabel('Timestamp (mm:ss)');
+  await expect(timestampInput).toBeVisible();
+  await timestampInput.fill('01:15');
+  await page.getByLabel('Label (optional)').fill('Intro');
+  await page.getByRole('button', { name: 'Add highlight' }).click();
+
+  await page.getByRole('button', { name: 'Post' }).click();
+
+  await expect(page.getByText(content)).toBeVisible();
+  await expect(page.getByText('01:15')).toBeVisible();
+  await expect(page.getByText('Intro')).toBeVisible();
+});

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -8,6 +8,7 @@
   import EditedBadge from './EditedBadge.svelte';
   import ReactionBar from './reactions/ReactionBar.svelte';
   import RelativeTime from './RelativeTime.svelte';
+  import HighlightDisplay from './posts/HighlightDisplay.svelte';
   import { buildProfileHref, handleProfileNavigation } from '../services/profileNavigation';
   import { buildThreadHref } from '../services/routeNavigation';
   import LinkifiedText from './LinkifiedText.svelte';
@@ -648,7 +649,10 @@
     });
   }
 
-  function buildEditLinksPayload(): { url: string }[] | null | undefined {
+  function buildEditLinksPayload():
+    | { url: string; highlights?: { timestamp: number; label?: string }[] }[]
+    | null
+    | undefined {
     if (editImages.length === 0) {
       return undefined;
     }
@@ -678,16 +682,20 @@
       imageIndexByLinkIndex.set(linkIndex, imageIndex);
     });
 
-    const nextLinks: { url: string }[] = [];
+    const nextLinks: { url: string; highlights?: { timestamp: number; label?: string }[] }[] = [];
     originalLinks.forEach((item, linkIndex) => {
+      const baseLink = {
+        url: item.url,
+        ...(item.highlights && item.highlights.length > 0 ? { highlights: item.highlights } : {}),
+      };
       const imageIndex = imageIndexByLinkIndex.get(linkIndex);
       if (imageIndex === undefined) {
-        nextLinks.push({ url: item.url });
+        nextLinks.push(baseLink);
         return;
       }
       const editState = editImages[imageIndex];
       if (!editState || editState.action === 'keep') {
-        nextLinks.push({ url: item.url });
+        nextLinks.push(baseLink);
         return;
       }
       if (editState.action === 'remove') {
@@ -1254,6 +1262,12 @@
           <span>🔗</span>
           <span class="underline">{primaryLink.url}</span>
         </a>
+      {/if}
+
+      {#if !isEditing && primaryLink?.highlights?.length}
+        <div class="mt-2">
+          <HighlightDisplay highlights={primaryLink.highlights} />
+        </div>
       {/if}
 
       <div class="mt-3 flex flex-wrap items-center gap-2">

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -79,6 +79,26 @@ describe('PostCard', () => {
     expect(screen.getByText('Example')).toBeInTheDocument();
   });
 
+  it('renders highlights when link includes them', () => {
+    const postWithHighlights: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://example.com',
+          metadata: {
+            url: 'https://example.com',
+            title: 'Example',
+          },
+          highlights: [{ timestamp: 75, label: 'Intro' }],
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithHighlights });
+    expect(screen.getByText('01:15')).toBeInTheDocument();
+    expect(screen.getByText('Intro')).toBeInTheDocument();
+  });
+
   it('shows a posted in label when section pill label is enabled', () => {
     sectionStore.setSections([
       {

--- a/frontend/src/components/posts/PostForm.svelte
+++ b/frontend/src/components/posts/PostForm.svelte
@@ -25,7 +25,7 @@
   let linkInputError: string | null = null;
   let linkInputRef: HTMLInputElement | null = null;
   let highlights: Highlight[] = [];
-  let lastHighlightLink = '';
+  let lastHighlightLinkInput = '';
 
   let fileInput: HTMLInputElement;
   type UploadItem = {
@@ -49,10 +49,10 @@
   $: hasLink = Boolean((linkMetadata && linkMetadata.url) || linkUrl.trim());
   $: isMusicSection = $activeSection?.type === 'music';
   $: showHighlightEditor = isMusicSection && hasLink;
-  $: activeLinkUrl = (linkMetadata?.url ?? linkUrl).trim();
-  $: if (activeLinkUrl !== lastHighlightLink) {
+  $: linkInputValueNormalized = linkUrl.trim();
+  $: if (linkInputValueNormalized !== lastHighlightLinkInput) {
     highlights = [];
-    lastHighlightLink = activeLinkUrl;
+    lastHighlightLinkInput = linkInputValueNormalized;
   }
   $: if (!showHighlightEditor && highlights.length > 0) {
     highlights = [];
@@ -162,7 +162,7 @@
     linkInputError = null;
     isLinkInputVisible = false;
     highlights = [];
-    lastHighlightLink = '';
+    lastHighlightLinkInput = '';
   }
 
   function isValidUrl(value: string): boolean {
@@ -373,7 +373,7 @@
       linkInputError = null;
       isLinkInputVisible = false;
       highlights = [];
-      lastHighlightLink = '';
+      lastHighlightLinkInput = '';
       selectedFiles.forEach(revokePreviewUrl);
       selectedFiles = [];
       uploadLimitError = null;

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -28,13 +28,13 @@ function setAuthenticated() {
   });
 }
 
-function setActiveSection() {
+function setActiveSection(type: 'music' | 'general' = 'music') {
   sectionStore.setActiveSection({
     id: 'section-1',
-    name: 'Music',
-    type: 'music',
-    icon: '🎵',
-    slug: 'music',
+    name: type === 'music' ? 'Music' : 'General',
+    type,
+    icon: type === 'music' ? '🎵' : '💬',
+    slug: type === 'music' ? 'music' : 'general',
   });
 }
 
@@ -233,6 +233,75 @@ describe('PostForm', () => {
       sectionId: 'section-1',
       content: '',
       links: [{ url: 'https://example.com' }],
+      mentionUsernames: [],
+    });
+  });
+
+  it('shows highlight editor only for music sections with a link', async () => {
+    setAuthenticated();
+    setActiveSection('general');
+    previewLink.mockResolvedValue({
+      metadata: {
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    });
+
+    render(PostForm);
+
+    const addLinkButton = screen.getByLabelText('Add link');
+    await fireEvent.click(addLinkButton);
+
+    const linkInput = screen.getByLabelText('Link URL');
+    await fireEvent.input(linkInput, { target: { value: 'example.com' } });
+    await fireEvent.keyDown(linkInput, { key: 'Enter' });
+    await tick();
+
+    expect(screen.queryByLabelText('Timestamp (mm:ss)')).not.toBeInTheDocument();
+
+    setActiveSection();
+    await tick();
+
+    expect(screen.getByLabelText('Timestamp (mm:ss)')).toBeInTheDocument();
+  });
+
+  it('includes highlights in link payload when added', async () => {
+    setAuthenticated();
+    setActiveSection();
+    previewLink.mockResolvedValue({
+      metadata: {
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    });
+    createPost.mockResolvedValue({
+      post: { id: 'post-1', userId: 'user-1', sectionId: 'section-1', content: '', createdAt: 'now' },
+    });
+
+    const { container } = render(PostForm);
+    const addLinkButton = screen.getByLabelText('Add link');
+    await fireEvent.click(addLinkButton);
+
+    const linkInput = screen.getByLabelText('Link URL');
+    await fireEvent.input(linkInput, { target: { value: 'example.com' } });
+    await fireEvent.keyDown(linkInput, { key: 'Enter' });
+    await tick();
+
+    const timestampInput = screen.getByLabelText('Timestamp (mm:ss)');
+    const labelInput = screen.getByLabelText('Label (optional)');
+    await fireEvent.input(timestampInput, { target: { value: '01:30' } });
+    await fireEvent.input(labelInput, { target: { value: 'Intro' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Add highlight' }));
+
+    const form = container.querySelector('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+    await tick();
+
+    expect(createPost).toHaveBeenCalledWith({
+      sectionId: 'section-1',
+      content: '',
+      links: [{ url: 'https://example.com', highlights: [{ timestamp: 90, label: 'Intro' }] }],
       mentionUsernames: [],
     });
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -495,7 +495,11 @@ class ApiClient {
 
   async updatePost(
     postId: string,
-    data: { content: string; links?: { url: string }[] | null; mentionUsernames?: string[] }
+    data: {
+      content: string;
+      links?: { url: string; highlights?: { timestamp: number; label?: string }[] }[] | null;
+      mentionUsernames?: string[];
+    }
   ): Promise<{ post: Post }> {
     const response = await this.patch<{ post: ApiPost }>(`/posts/${postId}`, {
       content: data.content,

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -55,7 +55,7 @@ export interface Post {
 export interface CreatePostRequest {
   sectionId: string;
   content: string;
-  links?: { url: string }[];
+  links?: { url: string; highlights?: Highlight[] }[];
   images?: { url: string; caption?: string; altText?: string }[];
   mentionUsernames?: string[];
 }


### PR DESCRIPTION
## Summary
- integrate the highlight editor in the post form for music links and include highlights in the link payload
- render highlight display on post cards and preserve highlights when updating links
- add unit tests plus an e2e flow for highlight creation/display

## Testing
- cd frontend && npm run test -- --run src/components/posts/__tests__/PostForm.test.ts src/components/__tests__/PostCard.test.ts
- cd frontend && npm run check

Closes #654