### PR TITLE
Frontend: Add MusicLinksContainer component and integrate into App

### DIFF
--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -77,3 +77,22 @@ test('create post with highlights', async ({ page }) => {
   await expect(page.getByText('01:15')).toBeVisible();
   await expect(page.getByText('Intro')).toBeVisible();
 });
+
+test('music link appears in the recent links container', async ({ page }) => {
+  await login(page);
+  const nav = page.getByRole('navigation', { name: 'Main navigation' });
+  const sectionButton = nav.getByRole('button', { name: sectionName });
+  await expect(sectionButton).toBeVisible();
+  await sectionButton.click();
+
+  const linkUrl = `https://example.com/music-${Date.now()}`;
+  await page.getByRole('button', { name: 'Add link' }).click();
+  const linkInput = page.getByLabel('Link URL');
+  await linkInput.fill(linkUrl);
+  await linkInput.press('Enter');
+
+  await page.getByRole('button', { name: 'Post' }).click();
+
+  await expect(page.getByRole('button', { name: /Recent Music Links/i })).toBeVisible();
+  await expect(page.locator(`a[href=\"${linkUrl}\"]`)).toBeVisible();
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,6 +3,7 @@
   import { onMount, onDestroy } from 'svelte';
   import './styles/globals.css';
   import { Layout, PostForm, SectionFeed, SearchResults, InstallPrompt } from './components';
+  import MusicLinksContainer from './components/MusicLinksContainer.svelte';
   import ThreadView from './components/ThreadView.svelte';
   import UserProfile from './components/UserProfile.svelte';
   import { Login, Register, AdminPanel, PasswordReset, Settings } from './routes';
@@ -343,6 +344,8 @@
           <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
             <PostForm />
           </div>
+
+          <MusicLinksContainer />
 
           {#if $isSearching || $searchError || $lastSearchQuery.trim().length > 0}
             <SearchResults />

--- a/frontend/src/components/MusicLinksContainer.svelte
+++ b/frontend/src/components/MusicLinksContainer.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import {
+    activeSection,
+    sectionLinks,
+    isLoadingSectionLinks,
+    hasMoreSectionLinks,
+    sectionLinksStore,
+  } from '../stores';
+  import { loadSectionLinks, loadMoreSectionLinks } from '../stores/sectionLinksFeedStore';
+  import type { SectionLink } from '../stores/sectionLinksStore';
+  import { looksLikeImageUrl } from '../services/linkUtils';
+  import RelativeTime from './RelativeTime.svelte';
+
+  let isExpanded = true;
+  let lastSectionId: string | null = null;
+
+  $: isMusicSection = $activeSection?.type === 'music';
+  $: linkCount = $sectionLinks.length;
+
+  $: if (isMusicSection && $activeSection?.id && $activeSection.id !== lastSectionId) {
+    lastSectionId = $activeSection.id;
+    isExpanded = true;
+    loadSectionLinks($activeSection.id);
+  }
+
+  $: if (!isMusicSection && lastSectionId) {
+    lastSectionId = null;
+    sectionLinksStore.reset();
+  }
+
+  onDestroy(() => {
+    sectionLinksStore.reset();
+  });
+
+  function toggleExpanded() {
+    isExpanded = !isExpanded;
+  }
+
+  function getThumbnailUrl(link: SectionLink): string | null {
+    const metadata = link.metadata;
+    const metadataType = typeof metadata?.type === 'string' ? metadata.type.toLowerCase() : '';
+    const isImage =
+      metadataType === 'image' || metadataType.startsWith('image/') || looksLikeImageUrl(link.url);
+    return metadata?.image ?? (isImage ? link.url : null);
+  }
+
+  function getProviderLabel(link: SectionLink): string {
+    const provider = link.metadata?.provider?.trim();
+    if (provider) return provider;
+    try {
+      return new URL(link.url).hostname.replace(/^www\./, '');
+    } catch {
+      return 'Link';
+    }
+  }
+
+  function getProviderInitial(link: SectionLink): string {
+    const label = getProviderLabel(link);
+    return label.charAt(0).toUpperCase();
+  }
+
+  function getTitle(link: SectionLink): string {
+    return link.metadata?.title?.trim() || link.metadata?.description?.trim() || link.url;
+  }
+
+  async function handleLoadMore() {
+    if ($isLoadingSectionLinks) return;
+    await loadMoreSectionLinks();
+  }
+</script>
+
+{#if isMusicSection}
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200">
+    <button
+      type="button"
+      class="w-full flex items-center justify-between px-4 py-3"
+      on:click={toggleExpanded}
+      aria-expanded={isExpanded}
+    >
+      <div class="flex items-center gap-2">
+        <svg
+          class={`h-4 w-4 text-gray-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.21 4.21a.75.75 0 011.06.02l4 4a.75.75 0 010 1.06l-4 4a.75.75 0 11-1.06-1.06L10.69 8 7.23 4.27a.75.75 0 01-.02-1.06z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span class="text-sm font-semibold text-gray-900">Recent Music Links</span>
+        <span
+          class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-semibold text-indigo-700"
+        >
+          {linkCount}
+        </span>
+      </div>
+    </button>
+
+    {#if isExpanded}
+      <div class="border-t border-gray-200 px-4 pb-4 pt-3 space-y-3">
+        {#if $sectionLinksStore.error}
+          <div class="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-700">
+            {$sectionLinksStore.error}
+          </div>
+        {/if}
+
+        {#if $isLoadingSectionLinks && $sectionLinks.length === 0}
+          <div class="flex items-center gap-2 text-sm text-gray-500">
+            <svg
+              class="animate-spin h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <span>Loading links...</span>
+          </div>
+        {:else if $sectionLinks.length === 0}
+          <p class="text-sm text-gray-500">No music links yet.</p>
+        {:else}
+          <ul class="space-y-2 max-h-64 overflow-y-auto pr-1">
+            {#each $sectionLinks as link (link.id || link.url)}
+              {@const thumbnailUrl = getThumbnailUrl(link)}
+              {@const title = getTitle(link)}
+              <li>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50 p-2 hover:bg-gray-100"
+                >
+                  <div
+                    class="h-10 w-10 flex-shrink-0 overflow-hidden rounded-md bg-gray-200 flex items-center justify-center"
+                  >
+                    {#if thumbnailUrl}
+                      <img
+                        src={thumbnailUrl}
+                        alt={link.metadata?.title || 'Link thumbnail'}
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    {:else}
+                      <span class="text-sm font-semibold text-gray-600">
+                        {getProviderInitial(link)}
+                      </span>
+                    {/if}
+                  </div>
+
+                  <div class="min-w-0 flex-1">
+                    <div class="text-sm font-semibold text-gray-900 truncate">{title}</div>
+                    <div class="flex items-center gap-2 text-xs text-gray-500">
+                      <span class="truncate">@{link.username}</span>
+                      <span class="text-gray-300">•</span>
+                      <RelativeTime
+                        dateString={link.createdAt}
+                        className="text-xs text-gray-400"
+                      />
+                    </div>
+                  </div>
+
+                  <svg
+                    class="h-4 w-4 text-gray-400"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M12.293 2.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-7 7a1 1 0 01-.707.293H6a1 1 0 01-1-1v-3a1 1 0 01.293-.707l7-7z"
+                    />
+                    <path d="M5 13v3h3l-3-3z" />
+                  </svg>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        {#if $hasMoreSectionLinks}
+          <button
+            type="button"
+            class="w-full rounded-md border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            on:click={handleLoadMore}
+            disabled={$isLoadingSectionLinks}
+          >
+            {#if $isLoadingSectionLinks}
+              Loading...
+            {:else}
+              Load more
+            {/if}
+          </button>
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/components/__tests__/MusicLinksContainer.test.ts
+++ b/frontend/src/components/__tests__/MusicLinksContainer.test.ts
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sectionStore } from '../../stores/sectionStore';
+import { sectionLinksStore, type SectionLink } from '../../stores/sectionLinksStore';
+
+const loadSectionLinks = vi.hoisted(() => vi.fn());
+const loadMoreSectionLinks = vi.hoisted(() => vi.fn());
+
+vi.mock('../../stores/sectionLinksFeedStore', () => ({
+  loadSectionLinks,
+  loadMoreSectionLinks,
+}));
+
+const { default: MusicLinksContainer } = await import('../MusicLinksContainer.svelte');
+
+const baseLink: SectionLink = {
+  id: 'link-1',
+  url: 'https://example.com',
+  metadata: {
+    url: 'https://example.com',
+    title: 'Example Song',
+    provider: 'Example',
+  },
+  postId: 'post-1',
+  userId: 'user-1',
+  username: 'sander',
+  createdAt: '2026-01-29T08:00:00Z',
+};
+
+function setActiveSection(type: 'music' | 'general') {
+  sectionStore.setActiveSection({
+    id: 'section-1',
+    name: type === 'music' ? 'Music' : 'General',
+    type,
+    icon: type === 'music' ? '🎵' : '💬',
+    slug: type === 'music' ? 'music' : 'general',
+  });
+}
+
+beforeEach(() => {
+  loadSectionLinks.mockReset();
+  loadMoreSectionLinks.mockReset();
+  sectionLinksStore.reset();
+  sectionStore.setActiveSection(null);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MusicLinksContainer', () => {
+  it('does not render outside the music section', () => {
+    setActiveSection('general');
+    render(MusicLinksContainer);
+
+    expect(screen.queryByText('Recent Music Links')).not.toBeInTheDocument();
+    expect(loadSectionLinks).not.toHaveBeenCalled();
+  });
+
+  it('shows music links with a count badge', () => {
+    setActiveSection('music');
+    sectionLinksStore.setLinks([baseLink, { ...baseLink, id: 'link-2', url: 'https://song.two' }], null, false, 'section-1');
+
+    render(MusicLinksContainer);
+
+    expect(screen.getByText('Recent Music Links')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getAllByText('Example Song')).toHaveLength(2);
+    expect(screen.getAllByText('@sander')).toHaveLength(2);
+  });
+
+  it('collapses the list when the header is clicked', async () => {
+    setActiveSection('music');
+    sectionLinksStore.setLinks([baseLink], null, false, 'section-1');
+
+    render(MusicLinksContainer);
+
+    const toggle = screen.getByRole('button', { name: /Recent Music Links/i });
+    await fireEvent.click(toggle);
+
+    expect(screen.queryByText('Example Song')).not.toBeInTheDocument();
+  });
+
+  it('calls loadMoreSectionLinks when load more is clicked', async () => {
+    setActiveSection('music');
+    sectionLinksStore.setLinks([baseLink], 'cursor-1', true, 'section-1');
+
+    render(MusicLinksContainer);
+
+    const button = screen.getByRole('button', { name: 'Load more' });
+    await fireEvent.click(button);
+
+    expect(loadMoreSectionLinks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/posts/PostForm.svelte
+++ b/frontend/src/components/posts/PostForm.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher, onDestroy, tick } from 'svelte';
   import { api } from '../../services/api';
   import { activeSection, postStore, currentUser } from '../../stores';
+  import { loadSectionLinks } from '../../stores/sectionLinksFeedStore';
   import type { Highlight, Link, LinkMetadata } from '../../stores/postStore';
   import LinkPreview from './LinkPreview.svelte';
   import MentionTextarea from '../mentions/MentionTextarea.svelte';
@@ -364,6 +365,9 @@
           : response.post;
 
       postStore.addPost(createdPost);
+      if (isMusicSection && links.length > 0) {
+        loadSectionLinks($activeSection.id);
+      }
 
       content = '';
       mentionUsernames = [];

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -7,6 +7,7 @@ import { afterEach } from 'vitest';
 const createPost = vi.hoisted(() => vi.fn());
 const previewLink = vi.hoisted(() => vi.fn());
 const uploadImage = vi.hoisted(() => vi.fn());
+const loadSectionLinks = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../services/api', () => ({
   api: {
@@ -14,6 +15,10 @@ vi.mock('../../../services/api', () => ({
     previewLink,
     uploadImage,
   },
+}));
+
+vi.mock('../../../stores/sectionLinksFeedStore', () => ({
+  loadSectionLinks,
 }));
 
 const { default: PostForm } = await import('../PostForm.svelte');
@@ -42,6 +47,7 @@ beforeEach(() => {
   createPost.mockReset();
   previewLink.mockReset();
   uploadImage.mockReset();
+  loadSectionLinks.mockReset();
   authStore.setUser(null);
   sectionStore.setActiveSection(null);
   postStore.reset();

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -6,6 +6,7 @@ export * from './feedStore';
 export * from './commentStore';
 export * from './commentFeedStore';
 export * from './sectionLinksStore';
+export * from './sectionLinksFeedStore';
 export * from './websocketStore';
 export * from './searchStore';
 export * from './pwaStore';

--- a/frontend/src/stores/sectionLinksFeedStore.ts
+++ b/frontend/src/stores/sectionLinksFeedStore.ts
@@ -1,0 +1,36 @@
+import { get } from 'svelte/store';
+import { api } from '../services/api';
+import { sectionLinksStore } from './sectionLinksStore';
+
+const LINKS_PAGE_SIZE = 20;
+
+export async function loadSectionLinks(sectionId: string): Promise<void> {
+  sectionLinksStore.setLoading(true);
+
+  try {
+    const response = await api.getSectionLinks(sectionId, LINKS_PAGE_SIZE);
+    sectionLinksStore.setLinks(response.links, response.nextCursor, response.hasMore, sectionId);
+  } catch (err) {
+    sectionLinksStore.setError(
+      err instanceof Error ? err.message : 'Failed to load section links'
+    );
+  }
+}
+
+export async function loadMoreSectionLinks(): Promise<void> {
+  const state = get(sectionLinksStore);
+  if (state.isLoading || !state.hasMore || !state.cursor || !state.sectionId) {
+    return;
+  }
+
+  sectionLinksStore.setLoading(true);
+
+  try {
+    const response = await api.getSectionLinks(state.sectionId, LINKS_PAGE_SIZE, state.cursor);
+    sectionLinksStore.appendLinks(response.links, response.nextCursor, response.hasMore);
+  } catch (err) {
+    sectionLinksStore.setError(
+      err instanceof Error ? err.message : 'Failed to load more links'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add MusicLinksContainer with collapsible header, scrollable list, and load more
- wire section links loader store and refresh music links after new post
- integrate container into section view and add component + e2e tests

## Testing
- npm run test -- -t "MusicLinksContainer|PostForm"
- npm run check

Closes #658