### PR TITLE
Implement cook log HTTP handlers

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -147,6 +147,7 @@ func main() {
 	commentHandler := handlers.NewCommentHandler(dbConn, redisConn, pushService)
 	adminHandler := handlers.NewAdminHandler(dbConn, redisConn)
 	reactionHandler := handlers.NewReactionHandler(dbConn, redisConn, pushService)
+	cookLogHandler := handlers.NewCookLogHandler(dbConn)
 	userHandler := handlers.NewUserHandler(dbConn)
 	sectionHandler := handlers.NewSectionHandler(dbConn)
 	searchHandler := handlers.NewSearchHandler(dbConn)
@@ -288,6 +289,10 @@ func main() {
 		addReactionToPost:      reactionHandler.AddReactionToPost,
 		removeReactionFromPost: reactionHandler.RemoveReactionFromPost,
 		getReactions:           reactionHandler.GetPostReactions,
+		logCook:                cookLogHandler.LogCook,
+		updateCookLog:          cookLogHandler.UpdateCookLog,
+		removeCookLog:          cookLogHandler.RemoveCookLog,
+		getCookLogs:            cookLogHandler.GetPostCookLogs,
 		getPost:                postHandler.GetPost,
 		updatePost:             postHandler.UpdatePost,
 		deletePost:             postHandler.DeletePost,
@@ -308,6 +313,9 @@ func main() {
 
 	// Search routes (protected)
 	mux.Handle("/api/v1/search", requireAuth(http.HandlerFunc(searchHandler.Search)))
+
+	// Cook log routes (protected)
+	mux.Handle("/api/v1/me/cook-logs", requireAuth(http.HandlerFunc(cookLogHandler.GetMyCookLogs)))
 
 	// Link preview route (protected with CSRF - POST only, prevents SSRF)
 	mux.Handle("/api/v1/links/preview", requireAuthCSRF(http.HandlerFunc(linkHandler.PreviewLink)))

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -15,6 +15,10 @@ type postRouteDeps struct {
 	addReactionToPost      http.HandlerFunc
 	removeReactionFromPost http.HandlerFunc
 	getReactions           http.HandlerFunc
+	logCook                http.HandlerFunc
+	updateCookLog          http.HandlerFunc
+	removeCookLog          http.HandlerFunc
+	getCookLogs            http.HandlerFunc
 	getPost                http.HandlerFunc
 	updatePost             http.HandlerFunc
 	deletePost             http.HandlerFunc
@@ -45,6 +49,26 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/reactions") {
 			// GET /api/v1/posts/{id}/reactions
 			requireAuth(http.HandlerFunc(deps.getReactions)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/cook-logs") {
+			// GET /api/v1/posts/{id}/cook-logs
+			requireAuth(http.HandlerFunc(deps.getCookLogs)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/cook-log") {
+			// POST /api/v1/posts/{id}/cook-log
+			requireAuthCSRF(http.HandlerFunc(deps.logCook)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/cook-log") {
+			// PUT /api/v1/posts/{id}/cook-log
+			requireAuthCSRF(http.HandlerFunc(deps.updateCookLog)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cook-log") {
+			// DELETE /api/v1/posts/{id}/cook-log
+			requireAuthCSRF(http.HandlerFunc(deps.removeCookLog)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPatch && isPostIDPath(r.URL.Path) {

--- a/backend/cmd/server/routes_test.go
+++ b/backend/cmd/server/routes_test.go
@@ -34,6 +34,18 @@ func TestPostRouteHandlerDeletePost(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
 		},
@@ -96,6 +108,18 @@ func TestPostRouteHandlerUpdatePost(t *testing.T) {
 		getReactions: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getReactions should not be called")
 		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
 		},
@@ -145,6 +169,18 @@ func TestPostRouteHandlerMethodNotAllowed(t *testing.T) {
 		},
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
+		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
 		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
@@ -202,6 +238,18 @@ func TestPostRouteHandlerDeletePostReactionsMissingEmoji(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
 		},
@@ -258,6 +306,18 @@ func TestPostRouteHandlerDeletePostCommentsPath(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
 		},
@@ -313,6 +373,18 @@ func TestPostRouteHandlerGetThreadRequiresAuth(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
 		getPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getPost should not be called")
 		},
@@ -327,6 +399,139 @@ func TestPostRouteHandlerGetThreadRequiresAuth(t *testing.T) {
 	handler := newPostRouteHandler(requireAuth, requireAuth, deps)
 	postID := uuid.New()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID.String()+"/comments", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Fatalf("expected status %v, got %v", http.StatusUnauthorized, status)
+	}
+
+	if !authCalled {
+		t.Fatal("expected auth middleware to be called")
+	}
+}
+
+func TestPostRouteHandlerCookLogUsesCSRF(t *testing.T) {
+	authCalled := false
+	logCalled := false
+
+	requireAuth := func(next http.Handler) http.Handler {
+		return next
+	}
+	requireAuthCSRF := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authCalled = true
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	deps := postRouteDeps{
+		getThread: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getThread should not be called")
+		},
+		restorePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("restorePost should not be called")
+		},
+		addReactionToPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("addReactionToPost should not be called")
+		},
+		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeReactionFromPost should not be called")
+		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			logCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
+		getPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPost should not be called")
+		},
+		updatePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updatePost should not be called")
+		},
+		deletePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("deletePost should not be called")
+		},
+	}
+
+	handler := newPostRouteHandler(requireAuth, requireAuthCSRF, deps)
+	postID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID.String()+"/cook-log", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("expected status %v, got %v", http.StatusOK, status)
+	}
+
+	if !authCalled {
+		t.Fatal("expected CSRF auth middleware to be called")
+	}
+
+	if !logCalled {
+		t.Fatal("expected cook log handler to be called")
+	}
+}
+
+func TestPostRouteHandlerGetCookLogsRequiresAuth(t *testing.T) {
+	authCalled := false
+
+	requireAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authCalled = true
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	deps := postRouteDeps{
+		getThread: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getThread should not be called")
+		},
+		restorePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("restorePost should not be called")
+		},
+		addReactionToPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("addReactionToPost should not be called")
+		},
+		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeReactionFromPost should not be called")
+		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called without auth")
+		},
+		getPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPost should not be called")
+		},
+		updatePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updatePost should not be called")
+		},
+		deletePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("deletePost should not be called")
+		},
+	}
+
+	handler := newPostRouteHandler(requireAuth, requireAuth, deps)
+	postID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID.String()+"/cook-logs", nil)
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)

--- a/backend/internal/handlers/cook_log.go
+++ b/backend/internal/handlers/cook_log.go
@@ -241,13 +241,9 @@ func (h *CookLogHandler) GetPostCookLogs(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	response := models.GetPostCookInfoResponse{
-		CookInfo: *info,
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	if err := json.NewEncoder(w).Encode(info); err != nil {
 		observability.LogError(r.Context(), observability.ErrorLog{
 			Message:    "failed to encode get post cook logs response",
 			Code:       "ENCODE_FAILED",

--- a/backend/internal/handlers/cook_log.go
+++ b/backend/internal/handlers/cook_log.go
@@ -1,0 +1,318 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// CookLogHandler handles cook log endpoints.
+type CookLogHandler struct {
+	cookLogService *services.CookLogService
+}
+
+// NewCookLogHandler creates a new cook log handler.
+func NewCookLogHandler(db *sql.DB) *CookLogHandler {
+	return &CookLogHandler{
+		cookLogService: services.NewCookLogService(db),
+	}
+}
+
+// LogCook handles POST /api/v1/posts/{postId}/cook-log.
+func (h *CookLogHandler) LogCook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.CreateCookLogRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	cookLog, err := h.cookLogService.LogCook(r.Context(), userID, postID, req.Rating, req.Notes)
+	if err != nil {
+		switch err.Error() {
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a recipe":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_RECIPE", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "COOK_LOG_CREATE_FAILED", "Failed to log cook")
+		}
+		return
+	}
+
+	observability.RecordCookLogCreated(r.Context())
+	observability.LogInfo(r.Context(), "cook log created",
+		"cook_log_id", cookLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"rating", strconv.Itoa(cookLog.Rating),
+	)
+
+	response := models.CreateCookLogResponse{
+		CookLog: *cookLog,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode create cook log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// UpdateCookLog handles PUT /api/v1/posts/{postId}/cook-log.
+func (h *CookLogHandler) UpdateCookLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only PUT requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.UpdateCookLogRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.Rating == nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "RATING_REQUIRED", "Rating is required")
+		return
+	}
+
+	cookLog, err := h.cookLogService.UpdateCookLog(r.Context(), userID, postID, *req.Rating, req.Notes)
+	if err != nil {
+		switch err.Error() {
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a recipe":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_RECIPE", err.Error())
+		case "cook log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "COOK_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "COOK_LOG_UPDATE_FAILED", "Failed to update cook log")
+		}
+		return
+	}
+
+	observability.RecordCookLogUpdated(r.Context())
+	observability.LogInfo(r.Context(), "cook log updated",
+		"cook_log_id", cookLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"rating", strconv.Itoa(cookLog.Rating),
+	)
+
+	response := models.UpdateCookLogResponse{
+		CookLog: *cookLog,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode update cook log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// RemoveCookLog handles DELETE /api/v1/posts/{postId}/cook-log.
+func (h *CookLogHandler) RemoveCookLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	if err := h.cookLogService.RemoveCookLog(r.Context(), userID, postID); err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a recipe":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_RECIPE", err.Error())
+		case "cook log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "COOK_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "COOK_LOG_DELETE_FAILED", "Failed to remove cook log")
+		}
+		return
+	}
+
+	observability.RecordCookLogRemoved(r.Context())
+	observability.LogInfo(r.Context(), "cook log removed",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPostCookLogs handles GET /api/v1/posts/{postId}/cook-logs.
+func (h *CookLogHandler) GetPostCookLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.cookLogService.GetPostCookLogs(r.Context(), postID, &userID)
+	if err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a recipe":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_RECIPE", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_COOK_LOGS_FAILED", "Failed to get cook logs")
+		}
+		return
+	}
+
+	response := models.GetPostCookInfoResponse{
+		CookInfo: *info,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode get post cook logs response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// GetMyCookLogs handles GET /api/v1/me/cook-logs.
+func (h *CookLogHandler) GetMyCookLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	limit := 20
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	cursor := r.URL.Query().Get("cursor")
+	var cursorPtr *string
+	if cursor != "" {
+		cursorPtr = &cursor
+	}
+
+	logs, hasMore, nextCursor, err := h.cookLogService.GetUserCookLogs(r.Context(), userID, limit, cursorPtr)
+	if err != nil {
+		switch err.Error() {
+		case "user not found":
+			writeError(r.Context(), w, http.StatusNotFound, "USER_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_COOK_LOGS_FAILED", "Failed to get cook logs")
+		}
+		return
+	}
+
+	response := models.ListCookLogsResponse{
+		CookLogs: logs,
+		Meta: models.PageMeta{
+			Cursor:  nextCursor,
+			HasMore: hasMore,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode list cook logs response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}

--- a/backend/internal/handlers/cook_log_test.go
+++ b/backend/internal/handlers/cook_log_test.go
@@ -159,29 +159,29 @@ func TestCookLogHandlerGetPostCookLogs(t *testing.T) {
 		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
 	}
 
-	var response models.GetPostCookInfoResponse
+	var response models.PostCookInfo
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	if response.CookInfo.CookCount != 2 {
-		t.Fatalf("expected cook_count 2, got %d", response.CookInfo.CookCount)
+	if response.CookCount != 2 {
+		t.Fatalf("expected cook_count 2, got %d", response.CookCount)
 	}
 
-	if response.CookInfo.AvgRating == nil || *response.CookInfo.AvgRating < 4.4 || *response.CookInfo.AvgRating > 4.6 {
-		t.Fatalf("expected avg_rating around 4.5, got %v", response.CookInfo.AvgRating)
+	if response.AvgRating == nil || *response.AvgRating < 4.4 || *response.AvgRating > 4.6 {
+		t.Fatalf("expected avg_rating around 4.5, got %v", response.AvgRating)
 	}
 
-	if len(response.CookInfo.Users) != 2 {
-		t.Fatalf("expected 2 users, got %d", len(response.CookInfo.Users))
+	if len(response.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(response.Users))
 	}
 
-	if !response.CookInfo.ViewerCooked || response.CookInfo.ViewerCookLog == nil {
+	if !response.ViewerCooked || response.ViewerCookLog == nil {
 		t.Fatalf("expected viewer cook log")
 	}
 
-	if response.CookInfo.ViewerCookLog.Rating != 5 {
-		t.Fatalf("expected viewer rating 5, got %d", response.CookInfo.ViewerCookLog.Rating)
+	if response.ViewerCookLog.Rating != 5 {
+		t.Fatalf("expected viewer rating 5, got %d", response.ViewerCookLog.Rating)
 	}
 }
 

--- a/backend/internal/handlers/cook_log_test.go
+++ b/backend/internal/handlers/cook_log_test.go
@@ -1,0 +1,232 @@
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestCookLogHandlerLogCook(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "cookloguser", "cooklog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipe Section", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+
+	handler := NewCookLogHandler(db)
+
+	body := bytes.NewBufferString(`{"rating":5,"notes":"Added extra garlic"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/cook-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "cookloguser", false))
+	w := httptest.NewRecorder()
+
+	handler.LogCook(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.CreateCookLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.CookLog.Rating != 5 {
+		t.Fatalf("expected rating 5, got %d", response.CookLog.Rating)
+	}
+
+	if response.CookLog.PostID != uuid.MustParse(postID) {
+		t.Fatalf("expected post_id %s, got %s", postID, response.CookLog.PostID.String())
+	}
+}
+
+func TestCookLogHandlerUpdateCookLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "cooklogupdateuser", "cooklogupdate@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipe Section", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+
+	_, err := db.Exec(`
+		INSERT INTO cook_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, uuid.New(), userID, postID, 3)
+	if err != nil {
+		t.Fatalf("failed to create cook log: %v", err)
+	}
+
+	handler := NewCookLogHandler(db)
+
+	body := bytes.NewBufferString(`{"rating":4,"notes":"Updated notes"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/cook-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "cooklogupdateuser", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateCookLog(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.UpdateCookLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.CookLog.Rating != 4 {
+		t.Fatalf("expected rating 4, got %d", response.CookLog.Rating)
+	}
+}
+
+func TestCookLogHandlerRemoveCookLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "cooklogdeleteuser", "cooklogdelete@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipe Section", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+
+	logID := uuid.New()
+	_, err := db.Exec(`
+		INSERT INTO cook_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, logID, userID, postID, 5)
+	if err != nil {
+		t.Fatalf("failed to create cook log: %v", err)
+	}
+
+	handler := NewCookLogHandler(db)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/cook-log", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "cooklogdeleteuser", false))
+	w := httptest.NewRecorder()
+
+	handler.RemoveCookLog(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var deletedAt sql.NullTime
+	if err := db.QueryRow(`SELECT deleted_at FROM cook_logs WHERE id = $1`, logID).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query deleted cook log: %v", err)
+	}
+	if !deletedAt.Valid {
+		t.Fatalf("expected deleted_at to be set")
+	}
+}
+
+func TestCookLogHandlerGetPostCookLogs(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "cookloglistuser1", "cookloglist1@test.com", false, true)
+	user2ID := testutil.CreateTestUser(t, db, "cookloglistuser2", "cookloglist2@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipe Section", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+
+	_, err := db.Exec(`
+		INSERT INTO cook_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now()), ($5, $6, $7, $8, now())
+	`,
+		uuid.New(), userID, postID, 5,
+		uuid.New(), user2ID, postID, 4,
+	)
+	if err != nil {
+		t.Fatalf("failed to create cook logs: %v", err)
+	}
+
+	handler := NewCookLogHandler(db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/cook-logs", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "cookloglistuser1", false))
+	w := httptest.NewRecorder()
+
+	handler.GetPostCookLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.GetPostCookInfoResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.CookInfo.CookCount != 2 {
+		t.Fatalf("expected cook_count 2, got %d", response.CookInfo.CookCount)
+	}
+
+	if response.CookInfo.AvgRating == nil || *response.CookInfo.AvgRating < 4.4 || *response.CookInfo.AvgRating > 4.6 {
+		t.Fatalf("expected avg_rating around 4.5, got %v", response.CookInfo.AvgRating)
+	}
+
+	if len(response.CookInfo.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(response.CookInfo.Users))
+	}
+
+	if !response.CookInfo.ViewerCooked || response.CookInfo.ViewerCookLog == nil {
+		t.Fatalf("expected viewer cook log")
+	}
+
+	if response.CookInfo.ViewerCookLog.Rating != 5 {
+		t.Fatalf("expected viewer rating 5, got %d", response.CookInfo.ViewerCookLog.Rating)
+	}
+}
+
+func TestCookLogHandlerGetMyCookLogs(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "cooklogmeuser", "cooklogme@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipe Section", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+	post2ID := testutil.CreateTestPost(t, db, userID, sectionID, "Another recipe")
+
+	_, err := db.Exec(`
+		INSERT INTO cook_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now()), ($5, $6, $7, $8, now())
+	`,
+		uuid.New(), userID, postID, 5,
+		uuid.New(), userID, post2ID, 4,
+	)
+	if err != nil {
+		t.Fatalf("failed to create cook logs: %v", err)
+	}
+
+	handler := NewCookLogHandler(db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/cook-logs", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "cooklogmeuser", false))
+	w := httptest.NewRecorder()
+
+	handler.GetMyCookLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ListCookLogsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.CookLogs) != 2 {
+		t.Fatalf("expected 2 cook logs, got %d", len(response.CookLogs))
+	}
+
+	if response.Meta.HasMore {
+		t.Fatalf("expected has_more to be false")
+	}
+}

--- a/backend/internal/models/cook_log.go
+++ b/backend/internal/models/cook_log.go
@@ -77,4 +77,5 @@ type GetPostCookInfoResponse struct {
 // ListCookLogsResponse represents the response for listing cook logs.
 type ListCookLogsResponse struct {
 	CookLogs []CookLogWithPost `json:"cook_logs"`
+	Meta     PageMeta          `json:"meta"`
 }

--- a/backend/internal/models/cook_log.go
+++ b/backend/internal/models/cook_log.go
@@ -69,11 +69,6 @@ type DeleteCookLogResponse struct {
 	Message string   `json:"message"`
 }
 
-// GetPostCookInfoResponse represents the response for cook tooltip data.
-type GetPostCookInfoResponse struct {
-	CookInfo PostCookInfo `json:"cook_info"`
-}
-
 // ListCookLogsResponse represents the response for listing cook logs.
 type ListCookLogsResponse struct {
 	CookLogs []CookLogWithPost `json:"cook_logs"`

--- a/backend/internal/observability/metrics.go
+++ b/backend/internal/observability/metrics.go
@@ -37,6 +37,9 @@ type metrics struct {
 	commentsCreated           metric.Int64Counter
 	reactionsAdded            metric.Int64Counter
 	reactionsRemoved          metric.Int64Counter
+	cookLogsCreated           metric.Int64Counter
+	cookLogsUpdated           metric.Int64Counter
+	cookLogsRemoved           metric.Int64Counter
 	postsDeleted              metric.Int64Counter
 	postsRestored             metric.Int64Counter
 	commentsDeleted           metric.Int64Counter
@@ -312,6 +315,33 @@ func initMetrics() error {
 		reactionsRemoved, err := meter.Int64Counter(
 			"clubhouse_reactions_removed_total",
 			metric.WithDescription("Total number of reactions removed"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		cookLogsCreated, err := meter.Int64Counter(
+			"clubhouse_cook_logs_created_total",
+			metric.WithDescription("Total number of cook logs created"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		cookLogsUpdated, err := meter.Int64Counter(
+			"clubhouse_cook_logs_updated_total",
+			metric.WithDescription("Total number of cook logs updated"),
+		)
+		if err != nil {
+			metricsInitErr = err
+			return
+		}
+
+		cookLogsRemoved, err := meter.Int64Counter(
+			"clubhouse_cook_logs_removed_total",
+			metric.WithDescription("Total number of cook logs removed"),
 		)
 		if err != nil {
 			metricsInitErr = err
@@ -741,6 +771,9 @@ func initMetrics() error {
 			commentsCreated:           commentsCreated,
 			reactionsAdded:            reactionsAdded,
 			reactionsRemoved:          reactionsRemoved,
+			cookLogsCreated:           cookLogsCreated,
+			cookLogsUpdated:           cookLogsUpdated,
+			cookLogsRemoved:           cookLogsRemoved,
 			postsDeleted:              postsDeleted,
 			postsRestored:             postsRestored,
 			commentsDeleted:           commentsDeleted,
@@ -1176,6 +1209,33 @@ func RecordReactionRemoved(ctx context.Context, emoji string) {
 		return
 	}
 	m.reactionsRemoved.Add(ctx, 1, metric.WithAttributes(attribute.String("emoji", emoji)))
+}
+
+// RecordCookLogCreated increments the cook log created counter.
+func RecordCookLogCreated(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.cookLogsCreated.Add(ctx, 1)
+}
+
+// RecordCookLogUpdated increments the cook log updated counter.
+func RecordCookLogUpdated(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.cookLogsUpdated.Add(ctx, 1)
+}
+
+// RecordCookLogRemoved increments the cook log removed counter.
+func RecordCookLogRemoved(ctx context.Context) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	m.cookLogsRemoved.Add(ctx, 1)
 }
 
 // RecordPostDeleted increments the post deleted counter.


### PR DESCRIPTION
## Summary
- add cook log handlers for create/update/delete and list endpoints
- wire cook log routes (including /api/v1/me/cook-logs) into the server router
- add cook log metrics and handler/route tests

Closes #672