### PR TITLE
Extend PostService to include recipe stats

### DIFF
--- a/backend/internal/handlers/post_test.go
+++ b/backend/internal/handlers/post_test.go
@@ -35,12 +35,12 @@ func TestGetPostSuccess(t *testing.T) {
 		"id", "user_id", "section_id", "content",
 		"created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
-		"comment_count",
+		"comment_count", "type",
 	}).AddRow(
 		postID, userID, sectionID, "Test post content",
 		now, nil, nil, nil,
 		userID, "testuser", "test@example.com", nil, nil, false, now,
-		5,
+		5, "general",
 	)
 
 	mock.ExpectQuery("SELECT").WithArgs(postID).WillReturnRows(rows)
@@ -301,6 +301,9 @@ func TestGetFeedSuccess(t *testing.T) {
 	now := time.Now()
 	earlier := now.Add(-time.Hour)
 
+	mock.ExpectQuery("SELECT type FROM sections").WithArgs(sectionID).
+		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("general"))
+
 	// Mock the posts query (returns 2 posts + 1 extra to determine hasMore)
 	rows := mock.NewRows([]string{
 		"id", "user_id", "section_id", "content",
@@ -382,6 +385,9 @@ func TestGetFeedWithCursor(t *testing.T) {
 	postID := uuid.New()
 	userID := uuid.New()
 	now := time.Now()
+
+	mock.ExpectQuery("SELECT type FROM sections").WithArgs(sectionID).
+		WillReturnRows(sqlmock.NewRows([]string{"type"}).AddRow("general"))
 
 	// Mock the posts query
 	rows := mock.NewRows([]string{
@@ -789,12 +795,12 @@ func TestUpdatePostSuccess(t *testing.T) {
 		"id", "user_id", "section_id", "content",
 		"created_at", "updated_at", "deleted_at", "deleted_by_user_id",
 		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at",
-		"comment_count",
+		"comment_count", "type",
 	}).AddRow(
 		postID, userID, sectionID, "Updated content",
 		now, updatedAt, nil, nil,
 		userID, "testuser", "test@example.com", nil, nil, false, now,
-		0,
+		0, "general",
 	)
 	mock.ExpectQuery("SELECT").WithArgs(postID).WillReturnRows(rows)
 

--- a/backend/internal/handlers/search_test.go
+++ b/backend/internal/handlers/search_test.go
@@ -199,10 +199,10 @@ func TestSearchSectionScopeUsesContextSectionID(t *testing.T) {
 
 	postRows := sqlmock.NewRows([]string{
 		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
-		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count", "type",
 	}).AddRow(
 		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
-		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0, "general",
 	)
 
 	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).
@@ -348,10 +348,10 @@ func TestSearchSuccessGlobal(t *testing.T) {
 
 	postRows := sqlmock.NewRows([]string{
 		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
-		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count", "type",
 	}).AddRow(
 		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
-		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0, "general",
 	)
 
 	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -1010,7 +1010,7 @@ func (s *PostService) GetFeed(ctx context.Context, sectionID uuid.UUID, cursor *
 		argIndex++
 	}
 
-	query += fmt.Sprintf(" GROUP BY p.id, u.id ORDER BY p.created_at DESC LIMIT $%d", argIndex)
+	query += fmt.Sprintf(" GROUP BY p.id, u.id, s.type ORDER BY p.created_at DESC LIMIT $%d", argIndex)
 	args = append(args, limit+1) // Fetch one extra to determine if hasMore
 
 	rows, err := s.db.QueryContext(ctx, query, args...)

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -1010,7 +1010,7 @@ func (s *PostService) GetFeed(ctx context.Context, sectionID uuid.UUID, cursor *
 		argIndex++
 	}
 
-	query += fmt.Sprintf(" GROUP BY p.id, u.id, s.type ORDER BY p.created_at DESC LIMIT $%d", argIndex)
+	query += fmt.Sprintf(" GROUP BY p.id, u.id ORDER BY p.created_at DESC LIMIT $%d", argIndex)
 	args = append(args, limit+1) // Fetch one extra to determine if hasMore
 
 	rows, err := s.db.QueryContext(ctx, query, args...)

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -1010,7 +1010,7 @@ func (s *PostService) GetFeed(ctx context.Context, sectionID uuid.UUID, cursor *
 		argIndex++
 	}
 
-	query += fmt.Sprintf(" GROUP BY p.id, u.id, s.type ORDER BY p.created_at DESC LIMIT $%d", argIndex)
+	query += fmt.Sprintf(" GROUP BY p.id, u.id ORDER BY p.created_at DESC LIMIT $%d", argIndex)
 	args = append(args, limit+1) // Fetch one extra to determine if hasMore
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -1364,7 +1364,7 @@ func (s *PostService) GetPostsByUserID(ctx context.Context, targetUserID uuid.UU
 		argIndex++
 	}
 
-	query += fmt.Sprintf(" GROUP BY p.id, u.id ORDER BY p.created_at DESC LIMIT $%d", argIndex)
+	query += fmt.Sprintf(" GROUP BY p.id, u.id, s.type ORDER BY p.created_at DESC LIMIT $%d", argIndex)
 	args = append(args, limit+1) // Fetch one extra to determine if hasMore
 
 	rows, err := s.db.QueryContext(ctx, query, args...)

--- a/backend/internal/services/search_test.go
+++ b/backend/internal/services/search_test.go
@@ -39,10 +39,10 @@ func TestSearchServiceGlobal(t *testing.T) {
 
 	postRows := sqlmock.NewRows([]string{
 		"id", "user_id", "section_id", "content", "created_at", "updated_at", "deleted_at", "deleted_by_user_id",
-		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count",
+		"id", "username", "email", "profile_picture_url", "bio", "is_admin", "created_at", "comment_count", "type",
 	}).AddRow(
 		postID, userID, sectionID, "post content", postCreated, nil, nil, nil,
-		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0,
+		userID, "alice", "alice@example.com", nil, nil, false, userCreated, 0, "general",
 	)
 
 	mock.ExpectQuery(regexp.QuoteMeta("FROM posts p")).


### PR DESCRIPTION
## Summary
- add recipe stats aggregation (save/cook counts, avg rating, viewer flags/categories) to recipe post retrieval
- batch recipe stats loading for recipe feeds and user posts
- add/adjust tests and sqlmock fixtures for section type and recipe stats behavior

Closes #670