### PR TITLE
Implement saved recipe HTTP handlers

### DIFF
--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -15,6 +15,9 @@ type postRouteDeps struct {
 	addReactionToPost      http.HandlerFunc
 	removeReactionFromPost http.HandlerFunc
 	getReactions           http.HandlerFunc
+	saveRecipe             http.HandlerFunc
+	unsaveRecipe           http.HandlerFunc
+	getPostSaves           http.HandlerFunc
 	logCook                http.HandlerFunc
 	updateCookLog          http.HandlerFunc
 	removeCookLog          http.HandlerFunc
@@ -39,6 +42,21 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/reactions") {
 			// POST /api/v1/posts/{id}/reactions
 			requireAuthCSRF(http.HandlerFunc(deps.addReactionToPost)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/save") {
+			// POST /api/v1/posts/{id}/save
+			requireAuthCSRF(http.HandlerFunc(deps.saveRecipe)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/save") {
+			// DELETE /api/v1/posts/{id}/save
+			requireAuthCSRF(http.HandlerFunc(deps.unsaveRecipe)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/saves") {
+			// GET /api/v1/posts/{id}/saves
+			requireAuth(http.HandlerFunc(deps.getPostSaves)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {

--- a/backend/cmd/server/routes_test.go
+++ b/backend/cmd/server/routes_test.go
@@ -34,6 +34,15 @@ func TestPostRouteHandlerDeletePost(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
 		},
@@ -108,6 +117,15 @@ func TestPostRouteHandlerUpdatePost(t *testing.T) {
 		getReactions: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("getReactions should not be called")
 		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
 		},
@@ -169,6 +187,15 @@ func TestPostRouteHandlerMethodNotAllowed(t *testing.T) {
 		},
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
+		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
 		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
@@ -238,6 +265,15 @@ func TestPostRouteHandlerDeletePostReactionsMissingEmoji(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
 		},
@@ -306,6 +342,15 @@ func TestPostRouteHandlerDeletePostCommentsPath(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
 		},
@@ -373,6 +418,15 @@ func TestPostRouteHandlerGetThreadRequiresAuth(t *testing.T) {
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
 		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")
 		},
@@ -438,6 +492,15 @@ func TestPostRouteHandlerCookLogUsesCSRF(t *testing.T) {
 		},
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
+		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
 		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			logCalled = true
@@ -505,6 +568,15 @@ func TestPostRouteHandlerGetCookLogsRequiresAuth(t *testing.T) {
 		},
 		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("removeReactionFromPost should not be called")
+		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
 		},
 		logCook: func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("logCook should not be called")

--- a/backend/internal/handlers/saved_recipe.go
+++ b/backend/internal/handlers/saved_recipe.go
@@ -1,0 +1,449 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// SavedRecipeHandler handles saved recipe endpoints.
+type SavedRecipeHandler struct {
+	savedRecipeService *services.SavedRecipeService
+}
+
+// NewSavedRecipeHandler creates a new saved recipe handler.
+func NewSavedRecipeHandler(db *sql.DB) *SavedRecipeHandler {
+	return &SavedRecipeHandler{
+		savedRecipeService: services.NewSavedRecipeService(db),
+	}
+}
+
+// SaveRecipe handles POST /api/v1/posts/{postId}/save
+func (h *SavedRecipeHandler) SaveRecipe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.CreateSavedRecipeRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	savedRecipes, err := h.savedRecipeService.SaveRecipe(r.Context(), userID, postID, req.Categories)
+	if err != nil {
+		switch err.Error() {
+		case "recipe post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+		case "category not found":
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "SAVE_RECIPE_FAILED", "Failed to save recipe")
+		}
+		return
+	}
+
+	response := models.CreateSavedRecipeResponse{
+		SavedRecipes: savedRecipes,
+	}
+
+	observability.LogInfo(r.Context(), "recipe saved",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"category_count", strconv.Itoa(len(savedRecipes)),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode save recipe response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// UnsaveRecipe handles DELETE /api/v1/posts/{postId}/save
+func (h *SavedRecipeHandler) UnsaveRecipe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var category *string
+	if categoryParam := strings.TrimSpace(r.URL.Query().Get("category")); categoryParam != "" {
+		category = &categoryParam
+	}
+
+	if err := h.savedRecipeService.UnsaveRecipe(r.Context(), userID, postID, category); err != nil {
+		switch err.Error() {
+		case "recipe post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		case "saved recipe not found":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "UNSAVE_RECIPE_FAILED", "Failed to unsave recipe")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "recipe unsaved",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPostSaves handles GET /api/v1/posts/{postId}/saves
+func (h *SavedRecipeHandler) GetPostSaves(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.savedRecipeService.GetPostSaves(r.Context(), postID, &userID)
+	if err != nil {
+		if err.Error() == "recipe post not found" {
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_POST_SAVES_FAILED", "Failed to get post saves")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode post saves response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// ListSavedRecipes handles GET /api/v1/me/saved-recipes
+func (h *SavedRecipeHandler) ListSavedRecipes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categories, err := h.savedRecipeService.GetUserSavedRecipes(r.Context(), userID)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_SAVED_RECIPES_FAILED", "Failed to get saved recipes")
+		return
+	}
+
+	response := models.ListSavedRecipesResponse{
+		Categories: categories,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode saved recipes response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// ListRecipeCategories handles GET /api/v1/me/recipe-categories
+func (h *SavedRecipeHandler) ListRecipeCategories(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categories, err := h.savedRecipeService.GetUserCategories(r.Context(), userID)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_RECIPE_CATEGORIES_FAILED", "Failed to get recipe categories")
+		return
+	}
+
+	response := models.ListRecipeCategoriesResponse{
+		Categories: categories,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode recipe categories response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// CreateRecipeCategory handles POST /api/v1/me/recipe-categories
+func (h *SavedRecipeHandler) CreateRecipeCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	var req models.CreateRecipeCategoryRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_REQUIRED", "Category name is required")
+		return
+	}
+
+	category, err := h.savedRecipeService.CreateCategory(r.Context(), userID, req.Name)
+	if err != nil {
+		switch err.Error() {
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "CREATE_CATEGORY_FAILED", "Failed to create category")
+		}
+		return
+	}
+
+	response := models.CreateRecipeCategoryResponse{
+		Category: *category,
+	}
+
+	observability.LogInfo(r.Context(), "recipe category created",
+		"user_id", userID.String(),
+		"category_id", category.ID.String(),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode create recipe category response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// UpdateRecipeCategory handles PATCH /api/v1/me/recipe-categories/{id}
+func (h *SavedRecipeHandler) UpdateRecipeCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only PATCH requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categoryID, err := extractCategoryIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CATEGORY_ID", "Invalid category ID format")
+		return
+	}
+
+	var req models.UpdateRecipeCategoryRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.Name != nil && strings.TrimSpace(*req.Name) == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_REQUIRED", "Category name is required")
+		return
+	}
+
+	if err := h.savedRecipeService.UpdateCategory(r.Context(), userID, categoryID, req.Name, req.Position); err != nil {
+		switch err.Error() {
+		case "category not found":
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		case "no updates provided":
+			writeError(r.Context(), w, http.StatusBadRequest, "NO_UPDATES", "No updates provided")
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "UPDATE_CATEGORY_FAILED", "Failed to update category")
+		}
+		return
+	}
+
+	updated, err := h.fetchUserCategory(r.Context(), userID, categoryID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "UPDATE_CATEGORY_FAILED", "Failed to load updated category")
+		return
+	}
+
+	response := models.UpdateRecipeCategoryResponse{
+		Category: *updated,
+	}
+
+	observability.LogInfo(r.Context(), "recipe category updated",
+		"user_id", userID.String(),
+		"category_id", categoryID.String(),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode update recipe category response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// DeleteRecipeCategory handles DELETE /api/v1/me/recipe-categories/{id}
+func (h *SavedRecipeHandler) DeleteRecipeCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categoryID, err := extractCategoryIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CATEGORY_ID", "Invalid category ID format")
+		return
+	}
+
+	if err := h.savedRecipeService.DeleteCategory(r.Context(), userID, categoryID); err != nil {
+		if err.Error() == "category not found" {
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "DELETE_CATEGORY_FAILED", "Failed to delete category")
+		return
+	}
+
+	observability.LogInfo(r.Context(), "recipe category deleted",
+		"user_id", userID.String(),
+		"category_id", categoryID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *SavedRecipeHandler) fetchUserCategory(ctx context.Context, userID, categoryID uuid.UUID) (*models.RecipeCategory, error) {
+	categories, err := h.savedRecipeService.GetUserCategories(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, category := range categories {
+		if category.ID == categoryID {
+			return &category, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func extractCategoryIDFromPath(path string) (uuid.UUID, error) {
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part == "recipe-categories" && i+1 < len(pathParts) {
+			return uuid.Parse(pathParts[i+1])
+		}
+	}
+	return uuid.Nil, sql.ErrNoRows
+}

--- a/backend/internal/handlers/saved_recipe_test.go
+++ b/backend/internal/handlers/saved_recipe_test.go
@@ -23,6 +23,14 @@ func TestSaveRecipeHandlerSuccess(t *testing.T) {
 	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
 	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
 
+	service := services.NewSavedRecipeService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Favorites"); err != nil {
+		t.Fatalf("CreateCategory Favorites failed: %v", err)
+	}
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Weeknight Dinners"); err != nil {
+		t.Fatalf("CreateCategory Weeknight Dinners failed: %v", err)
+	}
+
 	handler := NewSavedRecipeHandler(db)
 
 	body := bytes.NewBufferString(`{"categories":["Favorites","Weeknight Dinners"]}`)
@@ -74,6 +82,9 @@ func TestUnsaveRecipeHandlerNoContent(t *testing.T) {
 	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
 
 	service := services.NewSavedRecipeService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Favorites"); err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
 	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID), []string{"Favorites"}); err != nil {
 		t.Fatalf("SaveRecipe failed: %v", err)
 	}
@@ -143,6 +154,9 @@ func TestListSavedRecipesHandler(t *testing.T) {
 	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
 
 	service := services.NewSavedRecipeService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Favorites"); err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
 	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID), []string{"Favorites"}); err != nil {
 		t.Fatalf("SaveRecipe failed: %v", err)
 	}

--- a/backend/internal/handlers/saved_recipe_test.go
+++ b/backend/internal/handlers/saved_recipe_test.go
@@ -1,0 +1,251 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestSaveRecipeHandlerSuccess(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "savehandleruser", "savehandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
+
+	handler := NewSavedRecipeHandler(db)
+
+	body := bytes.NewBufferString(`{"categories":["Favorites","Weeknight Dinners"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/save", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "savehandleruser", false))
+	rr := httptest.NewRecorder()
+
+	handler.SaveRecipe(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.CreateSavedRecipeResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.SavedRecipes) != 2 {
+		t.Fatalf("expected 2 saved recipes, got %d", len(response.SavedRecipes))
+	}
+
+	gotCategories := []string{response.SavedRecipes[0].Category, response.SavedRecipes[1].Category}
+	sort.Strings(gotCategories)
+	if gotCategories[0] != "Favorites" || gotCategories[1] != "Weeknight Dinners" {
+		t.Fatalf("unexpected categories: %v", gotCategories)
+	}
+}
+
+func TestSaveRecipeHandlerMissingUser(t *testing.T) {
+	handler := &SavedRecipeHandler{}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+uuid.New().String()+"/save", bytes.NewBufferString(`{"categories":["Favorites"]}`))
+	rr := httptest.NewRecorder()
+
+	handler.SaveRecipe(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestUnsaveRecipeHandlerNoContent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "unsavehandleruser", "unsavehandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
+
+	service := services.NewSavedRecipeService(db)
+	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID), []string{"Favorites"}); err != nil {
+		t.Fatalf("SaveRecipe failed: %v", err)
+	}
+
+	handler := NewSavedRecipeHandler(db)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/save", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "unsavehandleruser", false))
+	rr := httptest.NewRecorder()
+
+	handler.UnsaveRecipe(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rr.Code)
+	}
+}
+
+func TestGetPostSavesHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := testutil.CreateTestUser(t, db, "saveinfoa", "saveinfoa@test.com", false, true)
+	userB := testutil.CreateTestUser(t, db, "saveinfob", "saveinfob@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userA, sectionID, "Recipe post")
+
+	service := services.NewSavedRecipeService(db)
+	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userA), uuid.MustParse(postID), nil); err != nil {
+		t.Fatalf("SaveRecipe userA failed: %v", err)
+	}
+	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userB), uuid.MustParse(postID), nil); err != nil {
+		t.Fatalf("SaveRecipe userB failed: %v", err)
+	}
+
+	handler := NewSavedRecipeHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/saves", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userA), "saveinfoa", false))
+	rr := httptest.NewRecorder()
+
+	handler.GetPostSaves(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.PostSaveInfo
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.SaveCount != 2 {
+		t.Fatalf("expected save_count 2, got %d", response.SaveCount)
+	}
+	if !response.ViewerSaved {
+		t.Fatalf("expected viewer_saved true")
+	}
+	if len(response.ViewerCategories) != 1 {
+		t.Fatalf("expected 1 viewer category, got %d", len(response.ViewerCategories))
+	}
+}
+
+func TestListSavedRecipesHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "listsaveduser", "listsaved@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Recipe post")
+
+	service := services.NewSavedRecipeService(db)
+	if _, err := service.SaveRecipe(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID), []string{"Favorites"}); err != nil {
+		t.Fatalf("SaveRecipe failed: %v", err)
+	}
+
+	handler := NewSavedRecipeHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/saved-recipes", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "listsaveduser", false))
+	rr := httptest.NewRecorder()
+
+	handler.ListSavedRecipes(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.ListSavedRecipesResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Categories) != 1 {
+		t.Fatalf("expected 1 category, got %d", len(response.Categories))
+	}
+}
+
+func TestRecipeCategoryCRUDHandlers(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "categoryhandleruser", "categoryhandler@test.com", false, true)
+	handler := NewSavedRecipeHandler(db)
+
+	createBody := bytes.NewBufferString(`{"name":"Desserts"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/me/recipe-categories", createBody)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq = createReq.WithContext(createTestUserContext(createReq.Context(), uuid.MustParse(userID), "categoryhandleruser", false))
+	createRR := httptest.NewRecorder()
+
+	handler.CreateRecipeCategory(createRR, createReq)
+
+	if createRR.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", createRR.Code, createRR.Body.String())
+	}
+
+	var createResp models.CreateRecipeCategoryResponse
+	if err := json.NewDecoder(createRR.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	updateBody := bytes.NewBufferString(`{"name":"Quick Desserts","position":2}`)
+	updateReq := httptest.NewRequest(http.MethodPatch, "/api/v1/me/recipe-categories/"+createResp.Category.ID.String(), updateBody)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq = updateReq.WithContext(createTestUserContext(updateReq.Context(), uuid.MustParse(userID), "categoryhandleruser", false))
+	updateRR := httptest.NewRecorder()
+
+	handler.UpdateRecipeCategory(updateRR, updateReq)
+
+	if updateRR.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", updateRR.Code, updateRR.Body.String())
+	}
+
+	var updateResp models.UpdateRecipeCategoryResponse
+	if err := json.NewDecoder(updateRR.Body).Decode(&updateResp); err != nil {
+		t.Fatalf("failed to decode update response: %v", err)
+	}
+	if updateResp.Category.Name != "Quick Desserts" {
+		t.Fatalf("expected updated name, got %s", updateResp.Category.Name)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/v1/me/recipe-categories/"+createResp.Category.ID.String(), nil)
+	deleteReq = deleteReq.WithContext(createTestUserContext(deleteReq.Context(), uuid.MustParse(userID), "categoryhandleruser", false))
+	deleteRR := httptest.NewRecorder()
+
+	handler.DeleteRecipeCategory(deleteRR, deleteReq)
+
+	if deleteRR.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", deleteRR.Code)
+	}
+}
+
+func TestUpdateRecipeCategoryHandlerNoUpdates(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "noupdatesuser", "noupdates@test.com", false, true)
+	service := services.NewSavedRecipeService(db)
+	category, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Meals")
+	if err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
+
+	handler := NewSavedRecipeHandler(db)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/me/recipe-categories/"+category.ID.String(), bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "noupdatesuser", false))
+	rr := httptest.NewRecorder()
+
+	handler.UpdateRecipeCategory(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func reqContext() context.Context {
+	return context.Background()
+}

--- a/backend/internal/models/saved_recipe.go
+++ b/backend/internal/models/saved_recipe.go
@@ -25,10 +25,10 @@ type RecipeCategory struct {
 
 // PostSaveInfo represents save tooltip data for a post.
 type PostSaveInfo struct {
-	SaveCount      int            `json:"save_count"`
-	Users          []ReactionUser `json:"users"`
-	ViewerSaved    bool           `json:"viewer_saved"`
-	ViewerCategory *string        `json:"viewer_category,omitempty"`
+	SaveCount        int            `json:"save_count"`
+	Users            []ReactionUser `json:"users"`
+	ViewerSaved      bool           `json:"viewer_saved"`
+	ViewerCategories []string       `json:"viewer_categories,omitempty"`
 }
 
 type SavedRecipeCategory struct {
@@ -43,13 +43,12 @@ type SavedRecipeWithPost struct {
 
 // CreateSavedRecipeRequest represents the request body for saving a recipe.
 type CreateSavedRecipeRequest struct {
-	PostID   string  `json:"post_id"`
-	Category *string `json:"category,omitempty"`
+	Categories []string `json:"categories,omitempty"`
 }
 
 // CreateSavedRecipeResponse represents the response for saving a recipe.
 type CreateSavedRecipeResponse struct {
-	SavedRecipe SavedRecipe `json:"saved_recipe"`
+	SavedRecipes []SavedRecipe `json:"saved_recipes"`
 }
 
 // DeleteSavedRecipeResponse represents the response for removing a saved recipe.
@@ -65,7 +64,7 @@ type ListSavedRecipesResponse struct {
 
 // GetPostSaveInfoResponse represents the response for post save tooltip data.
 type GetPostSaveInfoResponse struct {
-	SaveInfo PostSaveInfo `json:"save_info"`
+	PostSaveInfo
 }
 
 // CreateRecipeCategoryRequest represents the request body for creating a recipe category.

--- a/backend/internal/services/saved_recipe_test.go
+++ b/backend/internal/services/saved_recipe_test.go
@@ -164,8 +164,8 @@ func TestGetPostSavesIncludesViewer(t *testing.T) {
 	if !info.ViewerSaved {
 		t.Fatalf("expected viewer_saved true")
 	}
-	if info.ViewerCategory == nil || *info.ViewerCategory != defaultRecipeCategory {
-		t.Fatalf("expected viewer category %q, got %v", defaultRecipeCategory, info.ViewerCategory)
+	if len(info.ViewerCategories) != 1 || info.ViewerCategories[0] != defaultRecipeCategory {
+		t.Fatalf("expected viewer category %q, got %v", defaultRecipeCategory, info.ViewerCategories)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add saved recipe and recipe category handlers with route wiring and responses
- update saved recipe models/service to return viewer categories for tooltip data
- add handler tests for saved recipes and category CRUD

## Testing
- go test ./internal/services -run SavedRecipe -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- go test ./internal/handlers -run SavedRecipe -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)

Closes #671