### PR TITLE
Create recipeStore for frontend state management

### DIFF
--- a/frontend/src/stores/__tests__/recipeStore.test.ts
+++ b/frontend/src/stores/__tests__/recipeStore.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+
+const apiSaveRecipe = vi.hoisted(() => vi.fn());
+const apiUnsaveRecipe = vi.hoisted(() => vi.fn());
+const apiLogCook = vi.hoisted(() => vi.fn());
+const apiUpdateCookLog = vi.hoisted(() => vi.fn());
+const apiRemoveCookLog = vi.hoisted(() => vi.fn());
+const apiGetSavedRecipes = vi.hoisted(() => vi.fn());
+const apiGetRecipeCategories = vi.hoisted(() => vi.fn());
+const apiCreateCategory = vi.hoisted(() => vi.fn());
+const apiUpdateCategory = vi.hoisted(() => vi.fn());
+const apiDeleteCategory = vi.hoisted(() => vi.fn());
+const apiGetCookLogs = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    saveRecipe: apiSaveRecipe,
+    unsaveRecipe: apiUnsaveRecipe,
+    logCook: apiLogCook,
+    updateCookLog: apiUpdateCookLog,
+    removeCookLog: apiRemoveCookLog,
+    getMySavedRecipes: apiGetSavedRecipes,
+    getMyRecipeCategories: apiGetRecipeCategories,
+    createRecipeCategory: apiCreateCategory,
+    updateRecipeCategory: apiUpdateCategory,
+    deleteRecipeCategory: apiDeleteCategory,
+    getMyCookLogs: apiGetCookLogs,
+  },
+}));
+
+const {
+  recipeStore,
+  savedRecipesByCategory,
+  sortedCategories,
+  handleRecipeSavedEvent,
+  handleCookLogRemovedEvent,
+} = await import('../recipeStore');
+
+beforeEach(() => {
+  recipeStore.reset();
+  apiSaveRecipe.mockReset();
+  apiUnsaveRecipe.mockReset();
+  apiLogCook.mockReset();
+  apiUpdateCookLog.mockReset();
+  apiRemoveCookLog.mockReset();
+  apiGetSavedRecipes.mockReset();
+  apiGetRecipeCategories.mockReset();
+  apiCreateCategory.mockReset();
+  apiUpdateCategory.mockReset();
+  apiDeleteCategory.mockReset();
+  apiGetCookLogs.mockReset();
+});
+
+describe('recipeStore', () => {
+  it('loadSavedRecipes populates saved recipes map', async () => {
+    apiGetSavedRecipes.mockResolvedValue({
+      categories: [
+        {
+          name: 'Favorites',
+          recipes: [
+            {
+              id: 'save-1',
+              user_id: 'user-1',
+              post_id: 'post-1',
+              category: 'Favorites',
+              created_at: '2024-01-01T00:00:00Z',
+              post: {
+                id: 'post-1',
+                user_id: 'user-1',
+                section_id: 'section-1',
+                content: 'Recipe 1',
+                created_at: '2024-01-01T00:00:00Z',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await recipeStore.loadSavedRecipes();
+    const state = get(recipeStore);
+    const favorites = state.savedRecipes.get('Favorites') ?? [];
+
+    expect(state.isLoadingSaved).toBe(false);
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].post?.id).toBe('post-1');
+  });
+
+  it('saveRecipe merges new saved recipes into map', async () => {
+    apiSaveRecipe.mockResolvedValue({
+      saved_recipes: [
+        {
+          id: 'save-2',
+          user_id: 'user-1',
+          post_id: 'post-2',
+          category: 'Favorites',
+          created_at: '2024-01-02T00:00:00Z',
+        },
+      ],
+    });
+
+    await recipeStore.saveRecipe('post-2', ['Favorites']);
+    const state = get(recipeStore);
+    const favorites = state.savedRecipes.get('Favorites') ?? [];
+
+    expect(favorites).toHaveLength(1);
+    expect(favorites[0].postId).toBe('post-2');
+  });
+
+  it('unsaveRecipe removes saved recipes from category', async () => {
+    apiUnsaveRecipe.mockResolvedValue(undefined);
+
+    recipeStore.applySavedRecipes([
+      {
+        id: 'save-3',
+        userId: 'user-1',
+        postId: 'post-3',
+        category: 'Favorites',
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    await recipeStore.unsaveRecipe('post-3', 'Favorites');
+    const state = get(recipeStore);
+
+    expect(state.savedRecipes.get('Favorites')).toBeUndefined();
+  });
+
+  it('updateCategory renames saved recipe categories', async () => {
+    apiUpdateCategory.mockResolvedValue({
+      category: {
+        id: 'cat-1',
+        user_id: 'user-1',
+        name: 'Top Picks',
+        position: 1,
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    recipeStore.setCategories([
+      { id: 'cat-1', userId: 'user-1', name: 'Favorites', position: 1, createdAt: 'now' },
+    ]);
+    recipeStore.applySavedRecipes([
+      {
+        id: 'save-4',
+        userId: 'user-1',
+        postId: 'post-4',
+        category: 'Favorites',
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    await recipeStore.updateCategory('cat-1', 'Top Picks');
+    const state = get(recipeStore);
+
+    expect(state.savedRecipes.get('Favorites')).toBeUndefined();
+    const renamed = state.savedRecipes.get('Top Picks') ?? [];
+    expect(renamed).toHaveLength(1);
+    expect(renamed[0].category).toBe('Top Picks');
+  });
+
+  it('deleteCategory moves recipes to Uncategorized', async () => {
+    apiDeleteCategory.mockResolvedValue(undefined);
+
+    recipeStore.setCategories([
+      { id: 'cat-2', userId: 'user-1', name: 'Weeknight', position: 2, createdAt: 'now' },
+    ]);
+    recipeStore.applySavedRecipes([
+      {
+        id: 'save-5',
+        userId: 'user-1',
+        postId: 'post-5',
+        category: 'Weeknight',
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    await recipeStore.deleteCategory('cat-2');
+    const state = get(recipeStore);
+    const uncategorized = state.savedRecipes.get('Uncategorized') ?? [];
+
+    expect(state.categories).toHaveLength(0);
+    expect(uncategorized).toHaveLength(1);
+    expect(uncategorized[0].category).toBe('Uncategorized');
+  });
+
+  it('loadCookLogs populates cook logs', async () => {
+    apiGetCookLogs.mockResolvedValue({
+      cook_logs: [
+        {
+          id: 'log-1',
+          user_id: 'user-1',
+          post_id: 'post-1',
+          rating: 4,
+          notes: 'Nice',
+          created_at: '2024-01-03T00:00:00Z',
+          post: {
+            id: 'post-1',
+            user_id: 'user-1',
+            section_id: 'section-1',
+            content: 'Recipe',
+            created_at: '2024-01-01T00:00:00Z',
+          },
+        },
+      ],
+    });
+
+    await recipeStore.loadCookLogs();
+    const state = get(recipeStore);
+
+    expect(state.cookLogs).toHaveLength(1);
+    expect(state.cookLogs[0].post?.id).toBe('post-1');
+  });
+
+  it('derived stores expose sorted categories and map', () => {
+    recipeStore.setCategories([
+      { id: 'cat-1', userId: 'user-1', name: 'Zed', position: 2, createdAt: 'now' },
+      { id: 'cat-2', userId: 'user-1', name: 'Alpha', position: 1, createdAt: 'now' },
+    ]);
+
+    const sorted = get(sortedCategories);
+    const map = get(savedRecipesByCategory);
+
+    expect(sorted[0].name).toBe('Alpha');
+    expect(map).toBeInstanceOf(Map);
+  });
+
+  it('realtime handlers apply events', () => {
+    handleRecipeSavedEvent({
+      saved_recipe: {
+        id: 'save-10',
+        user_id: 'user-1',
+        post_id: 'post-10',
+        category: 'Favorites',
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    handleCookLogRemovedEvent({ post_id: 'post-10' });
+
+    const state = get(recipeStore);
+    const favorites = state.savedRecipes.get('Favorites') ?? [];
+    expect(favorites).toHaveLength(1);
+  });
+});

--- a/frontend/src/stores/recipeStore.ts
+++ b/frontend/src/stores/recipeStore.ts
@@ -1,0 +1,568 @@
+import { derived, get, writable } from 'svelte/store';
+import {
+  api,
+  type SavedRecipe as ApiSavedRecipe,
+  type SavedRecipeCategory as ApiSavedRecipeCategory,
+  type RecipeCategory as ApiRecipeCategory,
+  type CookLog as ApiCookLog,
+  type CookLogWithPost as ApiCookLogWithPost,
+} from '../services/api';
+import { mapApiPost, type ApiPost } from './postMapper';
+import type { Post } from './postStore';
+
+const DEFAULT_RECIPE_CATEGORY = 'Uncategorized';
+
+export interface SavedRecipe {
+  id: string;
+  userId: string;
+  postId: string;
+  category: string;
+  createdAt: string;
+  deletedAt?: string | null;
+  post?: Post;
+}
+
+export interface RecipeCategory {
+  id: string;
+  userId: string;
+  name: string;
+  position: number;
+  createdAt: string;
+}
+
+export interface CookLog {
+  id: string;
+  userId: string;
+  postId: string;
+  rating: number;
+  notes?: string | null;
+  createdAt: string;
+  updatedAt?: string | null;
+  deletedAt?: string | null;
+  post?: Post;
+}
+
+export interface RecipeState {
+  savedRecipes: Map<string, SavedRecipe[]>;
+  categories: RecipeCategory[];
+  cookLogs: CookLog[];
+  isLoadingSaved: boolean;
+  isLoadingCategories: boolean;
+  isLoadingCookLogs: boolean;
+  error: string | null;
+}
+
+function mapApiRecipeCategory(category: ApiRecipeCategory): RecipeCategory {
+  return {
+    id: category.id,
+    userId: category.user_id,
+    name: category.name,
+    position: category.position,
+    createdAt: category.created_at,
+  };
+}
+
+function mapApiSavedRecipe(recipe: ApiSavedRecipe): SavedRecipe {
+  return {
+    id: recipe.id,
+    userId: recipe.user_id,
+    postId: recipe.post_id,
+    category: recipe.category,
+    createdAt: recipe.created_at,
+    deletedAt: recipe.deleted_at ?? undefined,
+    post: recipe.post ? mapApiPost(recipe.post) : undefined,
+  };
+}
+
+function mapApiCookLog(log: ApiCookLog | ApiCookLogWithPost): CookLog {
+  const post = 'post' in log && log.post ? mapApiPost(log.post as ApiPost) : undefined;
+  return {
+    id: log.id,
+    userId: log.user_id,
+    postId: log.post_id,
+    rating: log.rating,
+    notes: log.notes ?? undefined,
+    createdAt: log.created_at,
+    updatedAt: log.updated_at ?? undefined,
+    deletedAt: log.deleted_at ?? undefined,
+    post,
+  };
+}
+
+function buildSavedRecipesMap(categories: ApiSavedRecipeCategory[]): Map<string, SavedRecipe[]> {
+  const entries = new Map<string, SavedRecipe[]>();
+  for (const category of categories) {
+    const recipes = (category.recipes ?? []).map(mapApiSavedRecipe);
+    entries.set(category.name, recipes);
+  }
+  return entries;
+}
+
+function addSavedRecipeToMap(
+  map: Map<string, SavedRecipe[]>,
+  savedRecipe: SavedRecipe
+): Map<string, SavedRecipe[]> {
+  const next = new Map(map);
+  const existing = next.get(savedRecipe.category) ?? [];
+  const filtered = existing.filter((item) => item.id !== savedRecipe.id && item.postId !== savedRecipe.postId);
+  next.set(savedRecipe.category, [...filtered, savedRecipe]);
+  return next;
+}
+
+function removeSavedRecipeFromMap(
+  map: Map<string, SavedRecipe[]>,
+  postId: string,
+  category?: string
+): Map<string, SavedRecipe[]> {
+  const next = new Map(map);
+  if (category) {
+    const existing = next.get(category) ?? [];
+    const filtered = existing.filter((item) => item.postId !== postId);
+    if (filtered.length > 0) {
+      next.set(category, filtered);
+    } else {
+      next.delete(category);
+    }
+    return next;
+  }
+
+  for (const [key, recipes] of next.entries()) {
+    const filtered = recipes.filter((item) => item.postId !== postId);
+    if (filtered.length > 0) {
+      next.set(key, filtered);
+    } else {
+      next.delete(key);
+    }
+  }
+
+  return next;
+}
+
+function moveCategoryRecipes(
+  map: Map<string, SavedRecipe[]>,
+  fromCategory: string,
+  toCategory: string
+): Map<string, SavedRecipe[]> {
+  if (fromCategory === toCategory) {
+    return map;
+  }
+
+  const next = new Map(map);
+  const existing = next.get(fromCategory) ?? [];
+  next.delete(fromCategory);
+  if (existing.length === 0) {
+    return next;
+  }
+
+  const updated = existing.map((recipe) => ({ ...recipe, category: toCategory }));
+  const target = next.get(toCategory) ?? [];
+  next.set(toCategory, [...target, ...updated]);
+  return next;
+}
+
+function upsertCookLog(logs: CookLog[], nextLog: CookLog): CookLog[] {
+  const index = logs.findIndex((entry) => entry.postId === nextLog.postId);
+  if (index === -1) {
+    return [nextLog, ...logs];
+  }
+  const existing = logs[index];
+  const merged: CookLog = {
+    ...existing,
+    ...nextLog,
+    post: nextLog.post ?? existing.post,
+  };
+  const updated = [...logs];
+  updated[index] = merged;
+  return updated;
+}
+
+function extractSavedRecipes(payload: unknown): ApiSavedRecipe[] {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  const record = payload as Record<string, unknown>;
+  if (Array.isArray(record.saved_recipes)) {
+    return record.saved_recipes as ApiSavedRecipe[];
+  }
+  if (Array.isArray(record.savedRecipes)) {
+    return record.savedRecipes as ApiSavedRecipe[];
+  }
+  if (record.saved_recipe) {
+    return [record.saved_recipe as ApiSavedRecipe];
+  }
+  if (record.savedRecipe) {
+    return [record.savedRecipe as ApiSavedRecipe];
+  }
+  return [];
+}
+
+function extractCookLog(payload: unknown): ApiCookLog | ApiCookLogWithPost | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.cook_log) {
+    return record.cook_log as ApiCookLog;
+  }
+  if (record.cookLog) {
+    return record.cookLog as ApiCookLog;
+  }
+  if (record.log && typeof record.log === 'object') {
+    return record.log as ApiCookLog;
+  }
+  return null;
+}
+
+function extractPostId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const postId = record.post_id ?? record.postId;
+  return typeof postId === 'string' && postId.length > 0 ? postId : null;
+}
+
+function extractCategoryName(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const category = record.category ?? record.categoryName ?? record.category_name;
+  return typeof category === 'string' && category.length > 0 ? category : null;
+}
+
+function extractRecipeCategory(payload: unknown): ApiRecipeCategory | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (record.category && typeof record.category === 'object') {
+    return record.category as ApiRecipeCategory;
+  }
+  if (record.recipe_category && typeof record.recipe_category === 'object') {
+    return record.recipe_category as ApiRecipeCategory;
+  }
+  if (record.recipeCategory && typeof record.recipeCategory === 'object') {
+    return record.recipeCategory as ApiRecipeCategory;
+  }
+  return null;
+}
+
+const initialState: RecipeState = {
+  savedRecipes: new Map(),
+  categories: [],
+  cookLogs: [],
+  isLoadingSaved: false,
+  isLoadingCategories: false,
+  isLoadingCookLogs: false,
+  error: null,
+};
+
+function createRecipeStore() {
+  const { subscribe, update, set } = writable<RecipeState>({ ...initialState });
+
+  return {
+    subscribe,
+    setSavedRecipes: (savedRecipes: Map<string, SavedRecipe[]>) =>
+      update((state) => ({
+        ...state,
+        savedRecipes,
+        isLoadingSaved: false,
+        error: null,
+      })),
+    setCategories: (categories: RecipeCategory[]) =>
+      update((state) => ({
+        ...state,
+        categories,
+        isLoadingCategories: false,
+        error: null,
+      })),
+    setCookLogs: (cookLogs: CookLog[]) =>
+      update((state) => ({
+        ...state,
+        cookLogs,
+        isLoadingCookLogs: false,
+        error: null,
+      })),
+    setLoadingSaved: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoadingSaved: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setLoadingCategories: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoadingCategories: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setLoadingCookLogs: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoadingCookLogs: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setError: (error: string | null) =>
+      update((state) => ({
+        ...state,
+        error,
+        isLoadingSaved: false,
+        isLoadingCategories: false,
+        isLoadingCookLogs: false,
+      })),
+    reset: () => set({ ...initialState, savedRecipes: new Map() }),
+    applySavedRecipes: (savedRecipes: SavedRecipe[]) =>
+      update((state) => {
+        let nextMap = state.savedRecipes;
+        for (const recipe of savedRecipes) {
+          nextMap = addSavedRecipeToMap(nextMap, recipe);
+        }
+        return {
+          ...state,
+          savedRecipes: nextMap,
+          error: null,
+        };
+      }),
+    applyUnsave: (postId: string, category?: string) =>
+      update((state) => ({
+        ...state,
+        savedRecipes: removeSavedRecipeFromMap(state.savedRecipes, postId, category),
+        error: null,
+      })),
+    applyCookLog: (cookLog: CookLog) =>
+      update((state) => ({
+        ...state,
+        cookLogs: upsertCookLog(state.cookLogs, cookLog),
+        error: null,
+      })),
+    applyCookLogRemoval: (postId: string) =>
+      update((state) => ({
+        ...state,
+        cookLogs: state.cookLogs.filter((log) => log.postId !== postId),
+        error: null,
+      })),
+    applyCategory: (category: RecipeCategory) =>
+      update((state) => {
+        const existingIndex = state.categories.findIndex((item) => item.id === category.id);
+        const nextCategories = [...state.categories];
+        if (existingIndex === -1) {
+          nextCategories.push(category);
+        } else {
+          nextCategories[existingIndex] = { ...nextCategories[existingIndex], ...category };
+        }
+        return {
+          ...state,
+          categories: nextCategories,
+          error: null,
+        };
+      }),
+    applyCategoryDeletion: (categoryId: string, categoryName?: string) =>
+      update((state) => {
+        const existing = state.categories.find((item) => item.id === categoryId);
+        const nameToDelete = categoryName ?? existing?.name ?? '';
+        const nextCategories = state.categories.filter((item) => item.id !== categoryId);
+        let nextMap = state.savedRecipes;
+        if (nameToDelete) {
+          nextMap = moveCategoryRecipes(nextMap, nameToDelete, DEFAULT_RECIPE_CATEGORY);
+        }
+        return {
+          ...state,
+          categories: nextCategories,
+          savedRecipes: nextMap,
+          error: null,
+        };
+      }),
+    saveRecipe: async (postId: string, categories: string[]): Promise<void> => {
+      try {
+        const response = await api.saveRecipe(postId, categories);
+        const savedRecipes = (response.saved_recipes ?? []).map(mapApiSavedRecipe);
+        recipeStore.applySavedRecipes(savedRecipes);
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to save recipe');
+      }
+    },
+    unsaveRecipe: async (postId: string, category?: string): Promise<void> => {
+      try {
+        await api.unsaveRecipe(postId, category);
+        recipeStore.applyUnsave(postId, category);
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to unsave recipe');
+      }
+    },
+    logCook: async (postId: string, rating: number, notes?: string): Promise<void> => {
+      try {
+        const response = await api.logCook(postId, rating, notes);
+        recipeStore.applyCookLog(mapApiCookLog(response.cook_log));
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to log cook');
+      }
+    },
+    updateCookLog: async (postId: string, rating: number, notes?: string): Promise<void> => {
+      try {
+        const response = await api.updateCookLog(postId, rating, notes);
+        recipeStore.applyCookLog(mapApiCookLog(response.cook_log));
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to update cook log');
+      }
+    },
+    removeCookLog: async (postId: string): Promise<void> => {
+      try {
+        await api.removeCookLog(postId);
+        recipeStore.applyCookLogRemoval(postId);
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to remove cook log');
+      }
+    },
+    createCategory: async (name: string): Promise<void> => {
+      try {
+        const response = await api.createRecipeCategory(name);
+        recipeStore.applyCategory(mapApiRecipeCategory(response.category));
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to create category');
+      }
+    },
+    updateCategory: async (id: string, name?: string, position?: number): Promise<void> => {
+      const state = get(recipeStore);
+      const existing = state.categories.find((category) => category.id === id);
+      try {
+        const response = await api.updateRecipeCategory(id, { name, position });
+        const updated = mapApiRecipeCategory(response.category);
+        recipeStore.applyCategory(updated);
+        if (existing && existing.name !== updated.name) {
+          recipeStore.updateSavedRecipeCategory(existing.name, updated.name);
+        }
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to update category');
+      }
+    },
+    deleteCategory: async (id: string): Promise<void> => {
+      const state = get(recipeStore);
+      const existing = state.categories.find((category) => category.id === id);
+      try {
+        await api.deleteRecipeCategory(id);
+        recipeStore.applyCategoryDeletion(id, existing?.name);
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to delete category');
+      }
+    },
+    updateSavedRecipeCategory: (fromCategory: string, toCategory: string) =>
+      update((state) => ({
+        ...state,
+        savedRecipes: moveCategoryRecipes(state.savedRecipes, fromCategory, toCategory),
+      })),
+    loadSavedRecipes: async (): Promise<void> => {
+      recipeStore.setLoadingSaved(true);
+      try {
+        const response = await api.getMySavedRecipes();
+        const savedRecipes = buildSavedRecipesMap(response.categories ?? []);
+        recipeStore.setSavedRecipes(savedRecipes);
+      } catch (error) {
+        recipeStore.setError(
+          error instanceof Error ? error.message : 'Failed to load saved recipes'
+        );
+      }
+    },
+    loadCategories: async (): Promise<void> => {
+      recipeStore.setLoadingCategories(true);
+      try {
+        const response = await api.getMyRecipeCategories();
+        const categories = (response.categories ?? []).map(mapApiRecipeCategory);
+        recipeStore.setCategories(categories);
+      } catch (error) {
+        recipeStore.setError(
+          error instanceof Error ? error.message : 'Failed to load recipe categories'
+        );
+      }
+    },
+    loadCookLogs: async (): Promise<void> => {
+      recipeStore.setLoadingCookLogs(true);
+      try {
+        const response = await api.getMyCookLogs();
+        const cookLogs = (response.cook_logs ?? []).map(mapApiCookLog);
+        recipeStore.setCookLogs(cookLogs);
+      } catch (error) {
+        recipeStore.setError(error instanceof Error ? error.message : 'Failed to load cook logs');
+      }
+    },
+  };
+}
+
+export const recipeStore = createRecipeStore();
+
+export const savedRecipesByCategory = derived(recipeStore, ($store) => $store.savedRecipes);
+
+export const sortedCategories = derived(recipeStore, ($store) =>
+  [...$store.categories].sort((a, b) => {
+    if (a.position !== b.position) {
+      return a.position - b.position;
+    }
+    return a.name.localeCompare(b.name);
+  })
+);
+
+export function handleRecipeSavedEvent(payload: unknown): void {
+  const recipes = extractSavedRecipes(payload).map(mapApiSavedRecipe);
+  if (recipes.length === 0) {
+    return;
+  }
+  recipeStore.applySavedRecipes(recipes);
+}
+
+export function handleRecipeUnsavedEvent(payload: unknown): void {
+  const postId = extractPostId(payload);
+  if (!postId) {
+    return;
+  }
+  const category = extractCategoryName(payload) ?? undefined;
+  recipeStore.applyUnsave(postId, category);
+}
+
+export function handleCookLogCreatedEvent(payload: unknown): void {
+  const log = extractCookLog(payload);
+  if (!log) {
+    return;
+  }
+  recipeStore.applyCookLog(mapApiCookLog(log));
+}
+
+export function handleCookLogUpdatedEvent(payload: unknown): void {
+  const log = extractCookLog(payload);
+  if (!log) {
+    return;
+  }
+  recipeStore.applyCookLog(mapApiCookLog(log));
+}
+
+export function handleCookLogRemovedEvent(payload: unknown): void {
+  const postId = extractPostId(payload);
+  if (!postId) {
+    return;
+  }
+  recipeStore.applyCookLogRemoval(postId);
+}
+
+export function handleRecipeCategoryCreatedEvent(payload: unknown): void {
+  const category = extractRecipeCategory(payload);
+  if (!category) {
+    return;
+  }
+  recipeStore.applyCategory(mapApiRecipeCategory(category));
+}
+
+export function handleRecipeCategoryUpdatedEvent(payload: unknown): void {
+  const category = extractRecipeCategory(payload);
+  if (!category) {
+    return;
+  }
+  recipeStore.applyCategory(mapApiRecipeCategory(category));
+}
+
+export function handleRecipeCategoryDeletedEvent(payload: unknown): void {
+  const category = extractRecipeCategory(payload);
+  const categoryId = category?.id ?? (payload as Record<string, unknown> | null)?.id;
+  if (typeof categoryId !== 'string') {
+    return;
+  }
+  const categoryName = category?.name ?? extractCategoryName(payload) ?? undefined;
+  recipeStore.applyCategoryDeletion(categoryId, categoryName);
+}

--- a/frontend/src/stores/websocketStore.ts
+++ b/frontend/src/stores/websocketStore.ts
@@ -4,6 +4,16 @@ import { isAuthenticated, currentUser } from './authStore';
 import { postStore, type Post } from './postStore';
 import { commentStore, type Comment } from './commentStore';
 import { handleRealtimeNotification } from './notificationStore';
+import {
+  handleCookLogCreatedEvent,
+  handleCookLogRemovedEvent,
+  handleCookLogUpdatedEvent,
+  handleRecipeCategoryCreatedEvent,
+  handleRecipeCategoryDeletedEvent,
+  handleRecipeCategoryUpdatedEvent,
+  handleRecipeSavedEvent,
+  handleRecipeUnsavedEvent,
+} from './recipeStore';
 import { api } from '../services/api';
 import { mapApiComment } from './commentMapper';
 import { mapApiPost, type ApiPost } from './postMapper';
@@ -274,6 +284,38 @@ function connect() {
       }
       case 'notification': {
         handleRealtimeNotification(parsed.data);
+        break;
+      }
+      case 'recipe_saved': {
+        handleRecipeSavedEvent(parsed.data);
+        break;
+      }
+      case 'recipe_unsaved': {
+        handleRecipeUnsavedEvent(parsed.data);
+        break;
+      }
+      case 'cook_log_created': {
+        handleCookLogCreatedEvent(parsed.data);
+        break;
+      }
+      case 'cook_log_updated': {
+        handleCookLogUpdatedEvent(parsed.data);
+        break;
+      }
+      case 'cook_log_removed': {
+        handleCookLogRemovedEvent(parsed.data);
+        break;
+      }
+      case 'recipe_category_created': {
+        handleRecipeCategoryCreatedEvent(parsed.data);
+        break;
+      }
+      case 'recipe_category_updated': {
+        handleRecipeCategoryUpdatedEvent(parsed.data);
+        break;
+      }
+      case 'recipe_category_deleted': {
+        handleRecipeCategoryDeletedEvent(parsed.data);
         break;
       }
       default:


### PR DESCRIPTION
## Summary
- add recipe store with saved recipes, categories, and cook logs state/actions
- hook recipe realtime events into websocket handler
- add unit tests for recipe store and websocket recipe events

## Testing
- npm run test -- src/stores/__tests__/recipeStore.test.ts src/stores/__tests__/websocketStore.test.ts
- npm run check

Closes #676