### PR TITLE
Integrate RecipeStatsBar into PostCard

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -20,6 +20,7 @@
   import { recordComponentRender } from '../lib/observability/performance';
   import { lockBodyScroll, unlockBodyScroll } from '../lib/scrollLock';
   import RecipeCard from './recipes/RecipeCard.svelte';
+  import RecipeStatsBar from './recipes/RecipeStatsBar.svelte';
 
   export let post: Post;
   export let highlightCommentId: string | null = null;
@@ -40,6 +41,7 @@
   $: userReactions = new Set(post.viewerReactions ?? []);
   $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
   $: sectionInfo = $sections.find((s) => s.id === post.sectionId) ?? null;
+  $: recipeStats = post.recipeStats ?? post.recipe_stats ?? null;
   let copiedLink = false;
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
   let isEditing = false;
@@ -1299,6 +1301,18 @@
           postId={post.id}
         />
       </div>
+
+      {#if sectionInfo?.type === 'recipe'}
+        <div class="mt-3">
+          <RecipeStatsBar
+            postId={post.id}
+            saveCount={recipeStats?.saveCount ?? 0}
+            cookCount={recipeStats?.cookCount ?? 0}
+            averageRating={recipeStats?.averageRating ?? null}
+            showEmpty
+          />
+        </div>
+      {/if}
 
       <div class="mt-4 border-t border-gray-200 pt-4">
         <CommentThread

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -1,4 +1,4 @@
-import type { Post, Link, LinkMetadata, PostImage, Highlight } from './postStore';
+import type { Post, Link, LinkMetadata, PostImage, Highlight, RecipeStats } from './postStore';
 
 export interface ApiUser {
   id: string;
@@ -33,8 +33,21 @@ export interface ApiPost {
   comment_count?: number;
   reaction_counts?: Record<string, number>;
   viewer_reactions?: string[];
+  recipe_stats?: ApiRecipeStats | null;
+  recipeStats?: ApiRecipeStats | null;
   created_at: string;
   updated_at?: string;
+}
+
+export interface ApiRecipeStats {
+  save_count?: number | null;
+  cook_count?: number | null;
+  avg_rating?: number | null;
+  average_rating?: number | null;
+  saveCount?: number | null;
+  cookCount?: number | null;
+  avgRating?: number | null;
+  averageRating?: number | null;
 }
 
 function normalizeString(value: unknown): string | undefined {
@@ -58,6 +71,28 @@ function normalizeNumber(value: unknown): number | undefined {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
+}
+
+function normalizeRecipeStats(rawStats: unknown): RecipeStats | undefined {
+  if (!rawStats || typeof rawStats !== 'object') {
+    return undefined;
+  }
+  const record = rawStats as Record<string, unknown>;
+  const saveCount = normalizeNumber(record.save_count ?? record.saveCount) ?? 0;
+  const cookCount = normalizeNumber(record.cook_count ?? record.cookCount) ?? 0;
+  const averageRating =
+    normalizeNumber(
+      record.avg_rating ??
+        record.avgRating ??
+        record.average_rating ??
+        record.averageRating
+    ) ?? null;
+
+  return {
+    saveCount,
+    cookCount,
+    averageRating,
+  };
 }
 
 function normalizeHighlights(rawHighlights: unknown): Highlight[] | undefined {
@@ -193,6 +228,7 @@ export function mapApiPost(apiPost: ApiPost): Post {
     commentCount: apiPost.comment_count,
     reactionCounts: apiPost.reaction_counts ?? undefined,
     viewerReactions: apiPost.viewer_reactions,
+    recipeStats: normalizeRecipeStats(apiPost.recipe_stats ?? apiPost.recipeStats),
     createdAt: apiPost.created_at,
     updatedAt: apiPost.updated_at,
   };

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -56,6 +56,12 @@ export interface PostImage {
   createdAt?: string;
 }
 
+export interface RecipeStats {
+  saveCount: number;
+  cookCount: number;
+  averageRating: number | null;
+}
+
 export interface Post {
   id: string;
   userId: string;
@@ -71,6 +77,8 @@ export interface Post {
   reactionCounts?: Record<string, number>;
   viewerReactions?: string[];
   commentCount?: number;
+  recipeStats?: RecipeStats;
+  recipe_stats?: RecipeStats;
   createdAt: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- render RecipeStatsBar under reactions for recipe section posts
- map recipe stats from API payloads into Post shape
- extend Post types to carry optional recipe stats

## Testing
- npm run check

Closes #684