### PR TITLE
Add SoundCloud embed support (backend + frontend)

### DIFF
--- a/backend/internal/services/links/embed_registry.go
+++ b/backend/internal/services/links/embed_registry.go
@@ -4,6 +4,7 @@ import "context"
 
 var embedExtractors = []EmbedExtractor{
 	BandcampExtractor{},
+	NewSoundCloudExtractor(nil),
 }
 
 func extractEmbed(

--- a/backend/internal/services/links/soundcloud.go
+++ b/backend/internal/services/links/soundcloud.go
@@ -49,7 +49,7 @@ func (e *SoundCloudExtractor) CanExtract(rawURL string) bool {
 		return false
 	}
 	host := strings.ToLower(parsed.Hostname())
-	return strings.Contains(host, "soundcloud.com")
+	return host == "soundcloud.com" || strings.HasSuffix(host, ".soundcloud.com")
 }
 
 func (e *SoundCloudExtractor) Extract(ctx context.Context, rawURL string) (*EmbedData, error) {

--- a/backend/internal/services/links/soundcloud.go
+++ b/backend/internal/services/links/soundcloud.go
@@ -1,0 +1,143 @@
+package links
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"golang.org/x/net/html"
+)
+
+const (
+	soundCloudOEmbedURL = "https://soundcloud.com/oembed"
+	soundCloudTimeout   = 5 * time.Second
+)
+
+type SoundCloudExtractor struct {
+	client    *http.Client
+	oEmbedURL string
+}
+
+type soundCloudOEmbedResponse struct {
+	Type         string `json:"type"`
+	Version      string `json:"version"`
+	Title        string `json:"title"`
+	AuthorName   string `json:"author_name"`
+	HTML         string `json:"html"`
+	Width        int    `json:"width"`
+	Height       int    `json:"height"`
+	ThumbnailURL string `json:"thumbnail_url"`
+}
+
+func NewSoundCloudExtractor(client *http.Client) *SoundCloudExtractor {
+	return &SoundCloudExtractor{
+		client:    client,
+		oEmbedURL: soundCloudOEmbedURL,
+	}
+}
+
+func (e *SoundCloudExtractor) CanExtract(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Hostname() == "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return strings.Contains(host, "soundcloud.com")
+}
+
+func (e *SoundCloudExtractor) Extract(ctx context.Context, rawURL string) (*EmbedData, error) {
+	if ctx == nil {
+		return nil, errors.New("context is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, soundCloudTimeout)
+	defer cancel()
+
+	oembedURL := fmt.Sprintf("%s?format=json&url=%s", e.oEmbedURL, url.QueryEscape(rawURL))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, oembedURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build oembed request: %w", err)
+	}
+	req.Header.Set("User-Agent", "ClubhouseSoundCloudEmbed/1.0")
+
+	client := e.client
+	if client == nil {
+		client = &http.Client{Timeout: soundCloudTimeout}
+	}
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		observability.LogWarn(ctx, "soundcloud oembed request failed", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return nil, fmt.Errorf("soundcloud oembed request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		observability.LogWarn(ctx, "soundcloud oembed request returned non-200", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "status", resp.Status)
+		return nil, fmt.Errorf("soundcloud oembed status: %s", resp.Status)
+	}
+
+	var payload soundCloudOEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		observability.LogWarn(ctx, "soundcloud oembed decode failed", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return nil, fmt.Errorf("decode soundcloud oembed: %w", err)
+	}
+
+	embedURL := extractIFrameSrc(payload.HTML)
+	if embedURL == "" {
+		observability.LogWarn(ctx, "soundcloud oembed missing iframe src", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10))
+		return nil, errors.New("soundcloud oembed missing iframe src")
+	}
+
+	observability.LogDebug(ctx, "soundcloud oembed fetched", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "status", strconv.Itoa(resp.StatusCode))
+
+	return &EmbedData{
+		Type:     "oembed",
+		Provider: "soundcloud",
+		EmbedURL: embedURL,
+		Width:    payload.Width,
+		Height:   payload.Height,
+	}, nil
+}
+
+func extractIFrameSrc(htmlSnippet string) string {
+	if strings.TrimSpace(htmlSnippet) == "" {
+		return ""
+	}
+
+	parsed, err := html.Parse(strings.NewReader(htmlSnippet))
+	if err != nil {
+		return ""
+	}
+
+	var src string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n == nil || src != "" {
+			return
+		}
+		if n.Type == html.ElementNode && strings.EqualFold(n.Data, "iframe") {
+			for _, attr := range n.Attr {
+				if strings.EqualFold(attr.Key, "src") {
+					src = strings.TrimSpace(attr.Val)
+					return
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(parsed)
+
+	return src
+}

--- a/backend/internal/services/links/soundcloud_integration_test.go
+++ b/backend/internal/services/links/soundcloud_integration_test.go
@@ -1,0 +1,26 @@
+package links
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSoundCloudExtractorIntegration(t *testing.T) {
+	if os.Getenv("SOUNDCLOUD_OEMBED_INTEGRATION") == "" {
+		t.Skip("set SOUNDCLOUD_OEMBED_INTEGRATION=1 to run")
+	}
+
+	extractor := NewSoundCloudExtractor(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	embed, err := extractor.Extract(ctx, "https://soundcloud.com/hamdiofficialmusic/counting")
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if embed == nil || embed.EmbedURL == "" {
+		t.Fatal("expected embed URL")
+	}
+}

--- a/backend/internal/services/links/soundcloud_test.go
+++ b/backend/internal/services/links/soundcloud_test.go
@@ -1,0 +1,112 @@
+package links
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSoundCloudExtractorCanExtract(t *testing.T) {
+	extractor := NewSoundCloudExtractor(nil)
+
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "track", url: "https://soundcloud.com/artist/track", want: true},
+		{name: "playlist", url: "https://soundcloud.com/artist/sets/playlist", want: true},
+		{name: "subdomain", url: "https://m.soundcloud.com/artist/track", want: true},
+		{name: "youtube", url: "https://youtube.com/watch?v=abc", want: false},
+		{name: "invalid", url: "://bad-url", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractor.CanExtract(tc.url); got != tc.want {
+				t.Fatalf("CanExtract(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSoundCloudExtractorExtract(t *testing.T) {
+	const targetURL = "https://soundcloud.com/artist/track"
+	const embedSrc = "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Get("format") != "json" {
+			t.Fatalf("format = %q, want json", query.Get("format"))
+		}
+		if query.Get("url") != targetURL {
+			t.Fatalf("url = %q, want %q", query.Get("url"), targetURL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"type": "rich",
+			"version": "1.0",
+			"title": "Test Track",
+			"author_name": "Artist",
+			"html": "<iframe src=\"`+embedSrc+`\"></iframe>",
+			"width": 100,
+			"height": 166,
+			"thumbnail_url": "https://example.com/image.png"
+		}`)
+	}))
+	defer server.Close()
+
+	extractor := NewSoundCloudExtractor(&http.Client{Timeout: time.Second})
+	extractor.oEmbedURL = server.URL
+
+	embed, err := extractor.Extract(context.Background(), targetURL)
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if embed == nil {
+		t.Fatal("expected embed data")
+	}
+	if embed.Provider != "soundcloud" {
+		t.Fatalf("provider = %q, want soundcloud", embed.Provider)
+	}
+	if embed.EmbedURL != embedSrc {
+		t.Fatalf("embed_url = %q, want %q", embed.EmbedURL, embedSrc)
+	}
+	if embed.Height != 166 {
+		t.Fatalf("height = %d, want 166", embed.Height)
+	}
+}
+
+func TestSoundCloudExtractorExtractHandlesStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	extractor := NewSoundCloudExtractor(&http.Client{Timeout: time.Second})
+	extractor.oEmbedURL = server.URL
+
+	_, err := extractor.Extract(context.Background(), "https://soundcloud.com/artist/track")
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+}
+
+func TestSoundCloudExtractorExtractMissingIframe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"html":"<div>No iframe</div>"}`)
+	}))
+	defer server.Close()
+
+	extractor := NewSoundCloudExtractor(&http.Client{Timeout: time.Second})
+	extractor.oEmbedURL = server.URL
+
+	_, err := extractor.Extract(context.Background(), "https://soundcloud.com/artist/track")
+	if err == nil {
+		t.Fatal("expected error when iframe src missing")
+	}
+}

--- a/backend/internal/services/links/soundcloud_test.go
+++ b/backend/internal/services/links/soundcloud_test.go
@@ -20,6 +20,7 @@ func TestSoundCloudExtractorCanExtract(t *testing.T) {
 		{name: "track", url: "https://soundcloud.com/artist/track", want: true},
 		{name: "playlist", url: "https://soundcloud.com/artist/sets/playlist", want: true},
 		{name: "subdomain", url: "https://m.soundcloud.com/artist/track", want: true},
+		{name: "malicious suffix", url: "https://soundcloud.com.evil.com/artist/track", want: false},
 		{name: "youtube", url: "https://youtube.com/watch?v=abc", want: false},
 		{name: "invalid", url: "://bad-url", want: false},
 	}

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -22,6 +22,7 @@
   import RecipeCard from './recipes/RecipeCard.svelte';
   import RecipeStatsBar from './recipes/RecipeStatsBar.svelte';
   import BandcampEmbed from '../lib/components/embeds/BandcampEmbed.svelte';
+  import SoundCloudEmbed from '../lib/components/embeds/SoundCloudEmbed.svelte';
 
   export let post: Post;
   export let highlightCommentId: string | null = null;
@@ -37,6 +38,10 @@
     title: string;
     altText?: string;
     link?: Link;
+  };
+  type SoundCloudEmbedData = {
+    embedUrl: string;
+    height?: number;
   };
 
   $: userReactions = new Set(post.viewerReactions ?? []);
@@ -402,6 +407,10 @@
     (metadata.embed.provider ?? '').toLowerCase() === 'bandcamp' &&
     metadata.embed.embedUrl
       ? metadata.embed
+      : undefined;
+  $: soundCloudEmbed =
+    metadata?.embed?.provider === 'soundcloud' && metadata.embed.embedUrl
+      ? ({ ...metadata.embed, embedUrl: metadata.embed.embedUrl } as SoundCloudEmbedData)
       : undefined;
   $: primaryImageUrl = imageItems.length > 0 ? imageItems[0].url : undefined;
   $: isInternalUploadLink =
@@ -1177,7 +1186,13 @@
             <span class="underline">{activeImageLink.url}</span>
           </a>
         {/if}
-        {#if primaryLink && bandcampEmbed}
+        {#if primaryLink && soundCloudEmbed}
+          <SoundCloudEmbed
+            embedUrl={soundCloudEmbed.embedUrl}
+            height={soundCloudEmbed.height}
+            title={metadata?.title}
+          />
+        {:else if primaryLink && bandcampEmbed}
           <BandcampEmbed embed={bandcampEmbed} linkUrl={primaryLink.url} title={metadata?.title} />
         {:else if primaryLink && metadata?.recipe}
           <RecipeCard
@@ -1230,7 +1245,13 @@
           </a>
         {/if}
       {:else if !isEditing && primaryLink && metadata}
-        {#if bandcampEmbed}
+        {#if soundCloudEmbed}
+          <SoundCloudEmbed
+            embedUrl={soundCloudEmbed.embedUrl}
+            height={soundCloudEmbed.height}
+            title={metadata?.title}
+          />
+        {:else if bandcampEmbed}
           <BandcampEmbed embed={bandcampEmbed} linkUrl={primaryLink.url} title={metadata?.title} />
         {:else if metadata.recipe}
           <RecipeCard

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -79,6 +79,35 @@ describe('PostCard', () => {
     expect(screen.getByText('Example')).toBeInTheDocument();
   });
 
+  it('renders soundcloud embed when embed metadata present', () => {
+    const postWithEmbed: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://soundcloud.com/artist/track',
+          metadata: {
+            url: 'https://soundcloud.com/artist/track',
+            provider: 'soundcloud',
+            title: 'Track Title',
+            embed: {
+              provider: 'soundcloud',
+              embedUrl: 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1',
+              height: 166,
+            },
+          },
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithEmbed });
+    const iframe = screen.getByTestId('soundcloud-embed');
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1'
+    );
+    expect(iframe).toHaveAttribute('height', '166');
+  });
+
   it('renders recipe card when recipe metadata present', () => {
     const postWithRecipe: Post = {
       ...basePost,

--- a/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
+++ b/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let embedUrl: string;
+  export let height: number | undefined = undefined;
+  export let title: string | undefined = undefined;
+
+  const fallbackHeight = 166;
+
+  $: resolvedHeight = height && height > 0 ? height : fallbackHeight;
+  $: iframeTitle = title ? `SoundCloud player: ${title}` : 'SoundCloud player';
+</script>
+
+<div class="mt-3 rounded-lg border border-gray-200 overflow-hidden bg-white">
+  <iframe
+    src={embedUrl}
+    title={iframeTitle}
+    height={resolvedHeight}
+    class="w-full"
+    loading="lazy"
+    allow="autoplay"
+    style="border: 0;"
+    data-testid="soundcloud-embed"
+  ></iframe>
+</div>

--- a/frontend/src/lib/components/embeds/__tests__/SoundCloudEmbed.test.ts
+++ b/frontend/src/lib/components/embeds/__tests__/SoundCloudEmbed.test.ts
@@ -1,0 +1,34 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, it, expect } from 'vitest';
+import SoundCloudEmbed from '../SoundCloudEmbed.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SoundCloudEmbed', () => {
+  it('renders SoundCloud iframe with provided height', () => {
+    render(SoundCloudEmbed, {
+      embedUrl: 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1',
+      height: 240,
+      title: 'Test Track',
+    });
+
+    const iframe = screen.getByTestId('soundcloud-embed');
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1'
+    );
+    expect(iframe).toHaveAttribute('height', '240');
+    expect(iframe).toHaveAttribute('title', 'SoundCloud player: Test Track');
+  });
+
+  it('falls back to default SoundCloud height', () => {
+    render(SoundCloudEmbed, {
+      embedUrl: 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2',
+    });
+
+    const iframe = screen.getByTestId('soundcloud-embed');
+    expect(iframe).toHaveAttribute('height', '166');
+  });
+});

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -189,4 +189,35 @@ describe('mapApiPost', () => {
       'https://bandcamp.com/EmbeddedPlayer/album=123'
     );
   });
+
+  it('normalizes soundcloud embed metadata', () => {
+    const post = mapApiPost({
+      id: 'post-7',
+      user_id: 'user-7',
+      section_id: 'section-7',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-7',
+          url: 'https://soundcloud.com/artist/track',
+          metadata: {
+            provider: 'soundcloud',
+            embed: {
+              provider: 'soundcloud',
+              embed_url: 'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1',
+              height: 166,
+            },
+          },
+        },
+      ],
+    });
+
+    const metadata = post.links?.[0].metadata;
+    expect(metadata?.embedUrl).toBe(
+      'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1'
+    );
+    expect(metadata?.embed?.provider).toBe('soundcloud');
+    expect(metadata?.embed?.height).toBe(166);
+  });
 });


### PR DESCRIPTION
## Summary
- add SoundCloud oEmbed extractor and embed registry with logging
- attach embed data to link metadata while keeping failures non-fatal
- render SoundCloud embeds in PostCard with mapper updates and tests

## Testing
- go build ./...
- go test ./internal/services/links -v
- cd frontend && npm run check
- cd frontend && npm run test -- -t "embed"
- cd frontend && npm run test -- -t "soundcloud|SoundCloud"
- SoundCloud integration test skipped (SOUNDCLOUD_OEMBED_INTEGRATION not set)

Closes #731