### PR TITLE
Add YouTube embed support (backend + frontend)

### DIFF
--- a/backend/internal/services/links/embed_registry.go
+++ b/backend/internal/services/links/embed_registry.go
@@ -5,6 +5,7 @@ import "context"
 var embedExtractors = []EmbedExtractor{
 	BandcampExtractor{},
 	NewSoundCloudExtractor(nil),
+	YouTubeExtractor{},
 }
 
 func extractEmbed(

--- a/backend/internal/services/links/youtube.go
+++ b/backend/internal/services/links/youtube.go
@@ -88,7 +88,10 @@ func parseYouTubeVideoID(rawURL string) (string, error) {
 
 func isYouTubeHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
-	return strings.Contains(host, "youtube.com") || strings.HasSuffix(host, "youtu.be")
+	return host == "youtube.com" ||
+		strings.HasSuffix(host, ".youtube.com") ||
+		host == "youtu.be" ||
+		strings.HasSuffix(host, ".youtu.be")
 }
 
 func firstPathSegment(value string) string {

--- a/backend/internal/services/links/youtube.go
+++ b/backend/internal/services/links/youtube.go
@@ -1,0 +1,101 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const youtubeEmbedBaseURL = "https://www.youtube-nocookie.com/embed/"
+
+type YouTubeExtractor struct{}
+
+func (YouTubeExtractor) CanExtract(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return isYouTubeHost(u.Hostname())
+}
+
+func (YouTubeExtractor) Extract(_ context.Context, rawURL string) (*EmbedData, error) {
+	videoID, err := parseYouTubeVideoID(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EmbedData{
+		Type:     "iframe",
+		Provider: "youtube",
+		EmbedURL: fmt.Sprintf("%s%s", youtubeEmbedBaseURL, videoID),
+	}, nil
+}
+
+func parseYouTubeVideoID(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse youtube url: %w", err)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if !isYouTubeHost(host) {
+		return "", errors.New("not a youtube url")
+	}
+
+	pathValue := strings.Trim(u.Path, "/")
+	switch {
+	case strings.HasSuffix(host, "youtu.be"):
+		id := firstPathSegment(pathValue)
+		if id == "" {
+			return "", errors.New("missing youtube video id")
+		}
+		return id, nil
+	case strings.Contains(host, "youtube.com"):
+		if strings.HasPrefix(pathValue, "watch") {
+			id := strings.TrimSpace(u.Query().Get("v"))
+			if id == "" {
+				return "", errors.New("missing youtube video id")
+			}
+			return id, nil
+		}
+		if strings.HasPrefix(pathValue, "embed/") {
+			id := firstPathSegment(strings.TrimPrefix(pathValue, "embed/"))
+			if id == "" {
+				return "", errors.New("missing youtube video id")
+			}
+			return id, nil
+		}
+		if strings.HasPrefix(pathValue, "shorts/") {
+			id := firstPathSegment(strings.TrimPrefix(pathValue, "shorts/"))
+			if id == "" {
+				return "", errors.New("missing youtube video id")
+			}
+			return id, nil
+		}
+		if strings.HasPrefix(pathValue, "v/") {
+			id := firstPathSegment(strings.TrimPrefix(pathValue, "v/"))
+			if id == "" {
+				return "", errors.New("missing youtube video id")
+			}
+			return id, nil
+		}
+	}
+
+	return "", errors.New("missing youtube video id")
+}
+
+func isYouTubeHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return strings.Contains(host, "youtube.com") || strings.HasSuffix(host, "youtu.be")
+}
+
+func firstPathSegment(value string) string {
+	value = strings.Trim(value, "/")
+	if value == "" {
+		return ""
+	}
+	parts := strings.Split(value, "/")
+	return parts[0]
+}

--- a/backend/internal/services/links/youtube_test.go
+++ b/backend/internal/services/links/youtube_test.go
@@ -1,0 +1,83 @@
+package links
+
+import (
+	"context"
+	"testing"
+)
+
+func TestYouTubeExtractorCanExtract(t *testing.T) {
+	extractor := YouTubeExtractor{}
+
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true},
+		{"https://youtu.be/dQw4w9WgXcQ", true},
+		{"https://www.youtube.com/embed/dQw4w9WgXcQ", true},
+		{"https://example.com/watch?v=dQw4w9WgXcQ", false},
+	}
+
+	for _, test := range cases {
+		if got := extractor.CanExtract(test.url); got != test.want {
+			t.Errorf("CanExtract(%q) = %v, want %v", test.url, got, test.want)
+		}
+	}
+}
+
+func TestYouTubeExtractorExtract(t *testing.T) {
+	extractor := YouTubeExtractor{}
+
+	cases := []struct {
+		url         string
+		expectID    string
+		expectError bool
+	}{
+		{
+			url:      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			expectID: "dQw4w9WgXcQ",
+		},
+		{
+			url:      "https://youtu.be/dQw4w9WgXcQ",
+			expectID: "dQw4w9WgXcQ",
+		},
+		{
+			url:      "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s",
+			expectID: "dQw4w9WgXcQ",
+		},
+		{
+			url:      "https://www.youtube.com/embed/dQw4w9WgXcQ?start=10",
+			expectID: "dQw4w9WgXcQ",
+		},
+		{
+			url:         "https://www.youtube.com/watch?v=",
+			expectError: true,
+		},
+	}
+
+	for _, test := range cases {
+		embed, err := extractor.Extract(context.Background(), test.url)
+		if test.expectError {
+			if err == nil {
+				t.Fatalf("expected error for %q", test.url)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Extract(%q) error: %v", test.url, err)
+		}
+		if embed == nil {
+			t.Fatalf("expected embed for %q", test.url)
+		}
+		expectedURL := youtubeEmbedBaseURL + test.expectID
+		if embed.EmbedURL != expectedURL {
+			t.Fatalf("EmbedURL = %q, want %q", embed.EmbedURL, expectedURL)
+		}
+		if embed.Provider != "youtube" {
+			t.Fatalf("Provider = %q, want youtube", embed.Provider)
+		}
+		if embed.Type != "iframe" {
+			t.Fatalf("Type = %q, want iframe", embed.Type)
+		}
+	}
+}

--- a/backend/internal/services/links/youtube_test.go
+++ b/backend/internal/services/links/youtube_test.go
@@ -15,6 +15,8 @@ func TestYouTubeExtractorCanExtract(t *testing.T) {
 		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true},
 		{"https://youtu.be/dQw4w9WgXcQ", true},
 		{"https://www.youtube.com/embed/dQw4w9WgXcQ", true},
+		{"https://notyoutube.com/watch?v=dQw4w9WgXcQ", false},
+		{"https://youtube.com.evil.com/watch?v=dQw4w9WgXcQ", false},
 		{"https://example.com/watch?v=dQw4w9WgXcQ", false},
 	}
 

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -24,6 +24,7 @@
   import BandcampEmbed from '../lib/components/embeds/BandcampEmbed.svelte';
   import SoundCloudEmbed from '../lib/components/embeds/SoundCloudEmbed.svelte';
   import SpotifyEmbed from '../lib/components/embeds/SpotifyEmbed.svelte';
+  import YouTubeEmbed from '../lib/components/embeds/YouTubeEmbed.svelte';
 
   export let post: Post;
   export let highlightCommentId: string | null = null;
@@ -1213,6 +1214,13 @@
             fallbackImage={metadata.image}
             fallbackTitle={metadata.title}
           />
+        {:else if primaryLink && metadata?.embed?.provider === 'youtube' && metadata.embed.embedUrl}
+          <div class="mt-3">
+            <YouTubeEmbed
+              embedUrl={metadata.embed.embedUrl}
+              title={metadata.title || 'YouTube video'}
+            />
+          </div>
         {:else if primaryLink && metadata && !primaryLinkIsImage}
           {#if spotifyEmbedUrl}
             <div class="mt-3">
@@ -1280,6 +1288,22 @@
           />
         {:else if spotifyEmbedUrl}
           <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
+        {:else if metadata.embed?.provider === 'youtube' && metadata.embed.embedUrl}
+          <div class="mt-3">
+            <YouTubeEmbed
+              embedUrl={metadata.embed.embedUrl}
+              title={metadata.title || 'YouTube video'}
+            />
+          </div>
+        {:else if spotifyEmbedUrl}
+          <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
+        {:else if metadata.embed?.provider === 'youtube' && metadata.embed.embedUrl}
+          <div class="mt-3">
+            <YouTubeEmbed
+              embedUrl={metadata.embed.embedUrl}
+              title={metadata.title || 'YouTube video'}
+            />
+          </div>
         {:else}
           <a
             href={primaryLink.url}

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -1295,17 +1295,6 @@
               title={metadata.title || 'YouTube video'}
             />
           </div>
-        {:else if spotifyEmbedUrl}
-          <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
-        {:else if metadata.embed?.provider === 'youtube' && metadata.embed.embedUrl}
-          <div class="mt-3">
-            <YouTubeEmbed
-              embedUrl={metadata.embed.embedUrl}
-              title={metadata.title || 'YouTube video'}
-            />
-          </div>
-        {:else if spotifyEmbedUrl}
-          <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
         {:else}
           <a
             href={primaryLink.url}

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -1304,6 +1304,8 @@
               title={metadata.title || 'YouTube video'}
             />
           </div>
+        {:else if spotifyEmbedUrl}
+          <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
         {:else}
           <a
             href={primaryLink.url}

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -291,10 +291,10 @@ describe('PostCard', () => {
     authStore.setUser({ id: 'user-1', username: 'Sander', email: 'sander@test.com' });
     render(PostCard, { post: postWithLink });
 
-    const editButton = screen.getByRole('button', { name: 'Edit post' });
+    const editButton = screen.getByRole('button', { name: 'Edit' });
     await fireEvent.click(editButton);
 
-    expect(screen.getByRole('textbox', { name: 'Edit post' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Edit post content' })).toBeInTheDocument();
   });
 
   it('submits edit form', async () => {
@@ -306,13 +306,13 @@ describe('PostCard', () => {
     authStore.setUser({ id: 'user-1', username: 'Sander', email: 'sander@test.com' });
     render(PostCard, { post: postWithLink });
 
-    const editButton = screen.getByRole('button', { name: 'Edit post' });
+    const editButton = screen.getByRole('button', { name: 'Edit' });
     await fireEvent.click(editButton);
 
-    const textarea = screen.getByRole('textbox', { name: 'Edit post' });
+    const textarea = screen.getByRole('textbox', { name: 'Edit post content' });
     await fireEvent.input(textarea, { target: { value: 'Updated content' } });
 
-    const saveButton = screen.getByRole('button', { name: 'Save post edits' });
+    const saveButton = screen.getByRole('button', { name: 'Save' });
     await fireEvent.click(saveButton);
 
     await tick();

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -15,6 +15,7 @@
   import { logError } from '../../lib/observability/logger';
   import { recordComponentRender } from '../../lib/observability/performance';
   import SpotifyEmbed from '../../lib/components/embeds/SpotifyEmbed.svelte';
+  import YouTubeEmbed from '../../lib/components/embeds/YouTubeEmbed.svelte';
 
   export let postId: string;
   export let commentCount = 0;
@@ -524,7 +525,12 @@
               {#if editingCommentId !== comment.id && comment.links?.length}
                 {#each comment.links as link (link.url)}
                   <div class="mt-2">
-                    {#if link.metadata}
+                    {#if link.metadata?.embed?.provider === 'youtube' && link.metadata.embed.embedUrl}
+                      <YouTubeEmbed
+                        embedUrl={link.metadata.embed.embedUrl}
+                        title={link.metadata.title || 'YouTube video'}
+                      />
+                    {:else if link.metadata}
                       {@const embedUrl =
                         link.metadata.embed?.embedUrl ??
                         (isSpotifyEmbedUrl(link.metadata.embedUrl) ? link.metadata.embedUrl : undefined)}

--- a/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
+++ b/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let embedUrl: string;
+  export let title: string = 'YouTube video';
+</script>
+
+<div class="relative w-full overflow-hidden rounded-lg bg-black" style="padding-top: 56.25%;">
+  <iframe
+    class="absolute inset-0 h-full w-full"
+    src={embedUrl}
+    title={title}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    referrerpolicy="strict-origin-when-cross-origin"
+    data-testid="youtube-embed-frame"
+  ></iframe>
+</div>

--- a/frontend/src/lib/components/embeds/__tests__/YouTubeEmbed.test.ts
+++ b/frontend/src/lib/components/embeds/__tests__/YouTubeEmbed.test.ts
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+
+import YouTubeEmbed from '../YouTubeEmbed.svelte';
+
+describe('YouTubeEmbed', () => {
+  it('renders a responsive iframe with the embed URL', () => {
+    const embedUrl = 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ';
+    render(YouTubeEmbed, { embedUrl, title: 'Video' });
+
+    const iframe = screen.getByTestId('youtube-embed-frame');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute('src', embedUrl);
+    expect(iframe).toHaveAttribute('allowfullscreen');
+  });
+});

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -48,6 +48,36 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.duration).toBe(120);
   });
 
+  it('maps embed metadata', () => {
+    const post = mapApiPost({
+      id: 'post-embed',
+      user_id: 'user-embed',
+      section_id: 'section-embed',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-embed',
+          url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+          metadata: {
+            embed: {
+              type: 'iframe',
+              provider: 'youtube',
+              embed_url: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+              width: 560,
+              height: 315,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(post.links?.[0].metadata?.embed?.provider).toBe('youtube');
+    expect(post.links?.[0].metadata?.embed?.embedUrl).toBe(
+      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'
+    );
+  });
+
   it('handles missing user and links gracefully', () => {
     const post = mapApiPost({
       id: 'post-2',

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -81,6 +81,29 @@ function normalizeNumber(value: unknown): number | undefined {
   return undefined;
 }
 
+function normalizeEmbed(rawEmbed: unknown): LinkEmbed | undefined {
+  if (!rawEmbed || typeof rawEmbed !== 'object' || Array.isArray(rawEmbed)) {
+    return undefined;
+  }
+  const record = rawEmbed as Record<string, unknown>;
+  const embedUrl =
+    normalizeString(record.embedUrl) ?? normalizeString(record.embed_url);
+  const provider = normalizeString(record.provider);
+  if (!embedUrl || !provider) {
+    return undefined;
+  }
+  const type = normalizeString(record.type);
+  const width = normalizeNumber(record.width);
+  const height = normalizeNumber(record.height);
+  return {
+    embedUrl,
+    provider,
+    type,
+    width,
+    height,
+  };
+}
+
 function normalizeRecipeStats(rawStats: unknown): RecipeStats | undefined {
   if (!rawStats || typeof rawStats !== 'object') {
     return undefined;

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -81,29 +81,6 @@ function normalizeNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function normalizeEmbed(rawEmbed: unknown): LinkEmbed | undefined {
-  if (!rawEmbed || typeof rawEmbed !== 'object' || Array.isArray(rawEmbed)) {
-    return undefined;
-  }
-  const record = rawEmbed as Record<string, unknown>;
-  const embedUrl =
-    normalizeString(record.embedUrl) ?? normalizeString(record.embed_url);
-  const provider = normalizeString(record.provider);
-  if (!embedUrl || !provider) {
-    return undefined;
-  }
-  const type = normalizeString(record.type);
-  const width = normalizeNumber(record.width);
-  const height = normalizeNumber(record.height);
-  return {
-    embedUrl,
-    provider,
-    type,
-    width,
-    height,
-  };
-}
-
 function normalizeRecipeStats(rawStats: unknown): RecipeStats | undefined {
   if (!rawStats || typeof rawStats !== 'object') {
     return undefined;


### PR DESCRIPTION
## Summary
- add YouTube embed extractor and embed metadata registration
- render YouTube embeds in posts and comments with a new responsive component
- normalize embed metadata in frontend mapping and add tests

## Testing
- go build ./...
- go test ./internal/services/links -v
- go test ./internal/services -run TestCreatePostStoresYouTubeEmbed -v (skipped: CLUBHOUSE_TEST_DATABASE_URL not set)
- npm run check
- npm run test -- -t "YouTubeEmbed|PostCard|mapApiPost"

Closes #729