### PR TITLE
Add Bandcamp embed support (backend + frontend)

### DIFF
--- a/backend/internal/services/links/bandcamp.go
+++ b/backend/internal/services/links/bandcamp.go
@@ -1,0 +1,162 @@
+package links
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	bandcampAlbumHeight = 470
+	bandcampTrackHeight = 120
+)
+
+type BandcampExtractor struct{}
+
+func (e BandcampExtractor) CanExtract(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return strings.HasSuffix(host, "bandcamp.com")
+}
+
+func (e BandcampExtractor) Extract(ctx context.Context, rawURL string) (*EmbedData, error) {
+	body, metaTags, err := defaultFetcher.fetchHTML(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return e.ExtractFromHTML(ctx, rawURL, body, metaTags)
+}
+
+func (e BandcampExtractor) ExtractFromHTML(
+	_ context.Context,
+	rawURL string,
+	_ []byte,
+	metaTags map[string]string,
+) (*EmbedData, error) {
+	content, err := parseBandcampContent(rawURL, metaTags)
+	if err != nil {
+		return nil, err
+	}
+	embedURL, height := buildBandcampEmbedURL(content)
+	return &EmbedData{
+		Type:     "iframe",
+		Provider: "bandcamp",
+		EmbedURL: embedURL,
+		Height:   height,
+	}, nil
+}
+
+type bandcampContent struct {
+	Type string
+	ID   string
+}
+
+func parseBandcampContent(rawURL string, metaTags map[string]string) (bandcampContent, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return bandcampContent{}, fmt.Errorf("parse url: %w", err)
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if !strings.HasSuffix(host, "bandcamp.com") {
+		return bandcampContent{}, errors.New("not a bandcamp url")
+	}
+
+	itemType := bandcampTypeFromPath(parsed.Path)
+	metaType, metaID := parseBandcampMeta(metaTags)
+	if metaType != "" {
+		itemType = metaType
+	}
+	if metaID == "" {
+		return bandcampContent{}, errors.New("missing bandcamp item id")
+	}
+	if itemType == "" {
+		return bandcampContent{}, errors.New("missing bandcamp item type")
+	}
+
+	return bandcampContent{
+		Type: itemType,
+		ID:   metaID,
+	}, nil
+}
+
+func bandcampTypeFromPath(path string) string {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.Contains(lower, "/album/"):
+		return "album"
+	case strings.Contains(lower, "/track/"):
+		return "track"
+	default:
+		return ""
+	}
+}
+
+func parseBandcampMeta(metaTags map[string]string) (string, string) {
+	raw := strings.TrimSpace(metaTags["bc-page-properties"])
+	if raw == "" {
+		return "", ""
+	}
+	raw = html.UnescapeString(raw)
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", ""
+	}
+	itemType := normalizeBandcampItemType(payload["item_type"])
+	itemID := normalizeBandcampItemID(payload["item_id"])
+	return itemType, itemID
+}
+
+func normalizeBandcampItemType(value interface{}) string {
+	raw, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "a", "album":
+		return "album"
+	case "t", "track":
+		return "track"
+	default:
+		return ""
+	}
+}
+
+func normalizeBandcampItemID(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		if typed == 0 {
+			return ""
+		}
+		return strconv.FormatInt(int64(typed), 10)
+	default:
+		return ""
+	}
+}
+
+func buildBandcampEmbedURL(content bandcampContent) (string, int) {
+	tracklist := "true"
+	height := bandcampAlbumHeight
+	if content.Type == "track" {
+		tracklist = "false"
+		height = bandcampTrackHeight
+	}
+	embedURL := fmt.Sprintf(
+		"https://bandcamp.com/EmbeddedPlayer/%s=%s/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=%s/artwork=small/transparent=true/",
+		content.Type,
+		content.ID,
+		tracklist,
+	)
+	return embedURL, height
+}

--- a/backend/internal/services/links/bandcamp_test.go
+++ b/backend/internal/services/links/bandcamp_test.go
@@ -1,0 +1,63 @@
+package links
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBandcampExtractorCanExtract(t *testing.T) {
+	extractor := BandcampExtractor{}
+
+	if !extractor.CanExtract("https://artist.bandcamp.com/album/test-album") {
+		t.Fatalf("expected bandcamp url to be extractable")
+	}
+	if extractor.CanExtract("https://example.com/album/test") {
+		t.Fatalf("expected non-bandcamp url to be ignored")
+	}
+}
+
+func TestBandcampExtractorExtractFromHTMLAlbum(t *testing.T) {
+	extractor := BandcampExtractor{}
+	metaTags := map[string]string{
+		"bc-page-properties": `{"item_type":"a","item_id":12345}`,
+	}
+
+	embed, err := extractor.ExtractFromHTML(
+		context.Background(),
+		"https://artist.bandcamp.com/album/test-album",
+		nil,
+		metaTags,
+	)
+	if err != nil {
+		t.Fatalf("expected embed, got error: %v", err)
+	}
+	if embed.Provider != "bandcamp" {
+		t.Fatalf("provider = %v, want bandcamp", embed.Provider)
+	}
+	if embed.Height != bandcampAlbumHeight {
+		t.Fatalf("height = %v, want %d", embed.Height, bandcampAlbumHeight)
+	}
+	if embed.EmbedURL == "" || embed.Type != "iframe" {
+		t.Fatalf("expected iframe embed url to be set")
+	}
+}
+
+func TestBandcampExtractorExtractFromHTMLEscapedTrack(t *testing.T) {
+	extractor := BandcampExtractor{}
+	metaTags := map[string]string{
+		"bc-page-properties": "{&quot;item_type&quot;:&quot;t&quot;,&quot;item_id&quot;:67890}",
+	}
+
+	embed, err := extractor.ExtractFromHTML(
+		context.Background(),
+		"https://artist.bandcamp.com/track/test-track",
+		nil,
+		metaTags,
+	)
+	if err != nil {
+		t.Fatalf("expected embed, got error: %v", err)
+	}
+	if embed.Height != bandcampTrackHeight {
+		t.Fatalf("height = %v, want %d", embed.Height, bandcampTrackHeight)
+	}
+}

--- a/backend/internal/services/links/embed.go
+++ b/backend/internal/services/links/embed.go
@@ -25,3 +25,9 @@ type EmbedExtractor interface {
 	CanExtract(url string) bool
 	Extract(ctx context.Context, url string) (*EmbedData, error)
 }
+
+// HTMLEmbedExtractor can parse embeds using already-fetched HTML.
+type HTMLEmbedExtractor interface {
+	EmbedExtractor
+	ExtractFromHTML(ctx context.Context, url string, body []byte, metaTags map[string]string) (*EmbedData, error)
+}

--- a/backend/internal/services/links/embed_registry.go
+++ b/backend/internal/services/links/embed_registry.go
@@ -1,0 +1,34 @@
+package links
+
+import "context"
+
+var embedExtractors = []EmbedExtractor{
+	BandcampExtractor{},
+}
+
+func extractEmbed(
+	ctx context.Context,
+	rawURL string,
+	body []byte,
+	metaTags map[string]string,
+) *EmbedData {
+	for _, extractor := range embedExtractors {
+		if !extractor.CanExtract(rawURL) {
+			continue
+		}
+
+		if htmlExtractor, ok := extractor.(HTMLEmbedExtractor); ok {
+			embed, err := htmlExtractor.ExtractFromHTML(ctx, rawURL, body, metaTags)
+			if err == nil && embed != nil {
+				return embed
+			}
+		}
+
+		embed, err := extractor.Extract(ctx, rawURL)
+		if err == nil && embed != nil {
+			return embed
+		}
+	}
+
+	return nil
+}

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -21,6 +21,7 @@
   import { lockBodyScroll, unlockBodyScroll } from '../lib/scrollLock';
   import RecipeCard from './recipes/RecipeCard.svelte';
   import RecipeStatsBar from './recipes/RecipeStatsBar.svelte';
+  import BandcampEmbed from '../lib/components/embeds/BandcampEmbed.svelte';
 
   export let post: Post;
   export let highlightCommentId: string | null = null;
@@ -396,6 +397,12 @@
   $: primaryLink = post.links?.[0];
   $: primaryLinkIsImage = primaryLink ? Boolean(getImageLinkUrl(primaryLink)) : false;
   $: metadata = primaryLink?.metadata;
+  $: bandcampEmbed =
+    metadata?.embed &&
+    (metadata.embed.provider ?? '').toLowerCase() === 'bandcamp' &&
+    metadata.embed.embedUrl
+      ? metadata.embed
+      : undefined;
   $: primaryImageUrl = imageItems.length > 0 ? imageItems[0].url : undefined;
   $: isInternalUploadLink =
     !hasPostImages && imageItems.length > 0 && imageItems[0].link
@@ -1170,7 +1177,9 @@
             <span class="underline">{activeImageLink.url}</span>
           </a>
         {/if}
-        {#if primaryLink && metadata?.recipe}
+        {#if primaryLink && bandcampEmbed}
+          <BandcampEmbed embed={bandcampEmbed} linkUrl={primaryLink.url} title={metadata?.title} />
+        {:else if primaryLink && metadata?.recipe}
           <RecipeCard
             recipe={metadata.recipe}
             sourceUrl={primaryLink.url}
@@ -1221,7 +1230,9 @@
           </a>
         {/if}
       {:else if !isEditing && primaryLink && metadata}
-        {#if metadata.recipe}
+        {#if bandcampEmbed}
+          <BandcampEmbed embed={bandcampEmbed} linkUrl={primaryLink.url} title={metadata?.title} />
+        {:else if metadata.recipe}
           <RecipeCard
             recipe={metadata.recipe}
             sourceUrl={primaryLink.url}

--- a/frontend/src/lib/components/embeds/BandcampEmbed.svelte
+++ b/frontend/src/lib/components/embeds/BandcampEmbed.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { EmbedData } from '../../../stores/postStore';
+
+  export let embed: EmbedData;
+  export let linkUrl: string;
+  export let title: string | undefined = undefined;
+
+  $: playerHeight = embed.height ?? 120;
+  $: playerTitle = title ? `${title} on Bandcamp` : 'Bandcamp player';
+</script>
+
+<div class="mt-3 space-y-2">
+  <iframe
+    src={embed.embedUrl}
+    title={playerTitle}
+    class="w-full rounded-lg border border-gray-200"
+    style={`height: ${playerHeight}px;`}
+    loading="lazy"
+    allow="encrypted-media"
+    sandbox="allow-same-origin allow-scripts allow-popups"
+  ></iframe>
+  <a
+    href={linkUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm break-all"
+  >
+    <span>🔗</span>
+    <span class="underline">{linkUrl}</span>
+  </a>
+</div>

--- a/frontend/src/lib/components/embeds/__tests__/BandcampEmbed.test.ts
+++ b/frontend/src/lib/components/embeds/__tests__/BandcampEmbed.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+
+const { default: BandcampEmbed } = await import('../BandcampEmbed.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BandcampEmbed', () => {
+  it('renders iframe with expected height and link', () => {
+    render(BandcampEmbed, {
+      embed: {
+        embedUrl: 'https://bandcamp.com/EmbeddedPlayer/album=123',
+        height: 470,
+      },
+      linkUrl: 'https://artist.bandcamp.com/album/test',
+      title: 'Test Album',
+    });
+
+    const iframe = screen.getByTitle('Test Album on Bandcamp');
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://bandcamp.com/EmbeddedPlayer/album=123'
+    );
+    expect(iframe).toHaveStyle('height: 470px;');
+    expect(screen.getByText('https://artist.bandcamp.com/album/test')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -157,4 +157,36 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.embedUrl).toBe('https://example.com/embed');
     expect(post.links?.[0].metadata?.duration).toBe(180);
   });
+
+  it('normalizes embed objects', () => {
+    const post = mapApiPost({
+      id: 'post-7',
+      user_id: 'user-7',
+      section_id: 'section-7',
+      content: 'hello',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-7',
+          url: 'https://artist.bandcamp.com/album/test',
+          metadata: {
+            embed: {
+              type: 'iframe',
+              provider: 'bandcamp',
+              embed_url: 'https://bandcamp.com/EmbeddedPlayer/album=123',
+              height: 470,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(post.links?.[0].metadata?.embed?.embedUrl).toBe(
+      'https://bandcamp.com/EmbeddedPlayer/album=123'
+    );
+    expect(post.links?.[0].metadata?.embed?.height).toBe(470);
+    expect(post.links?.[0].metadata?.embedUrl).toBe(
+      'https://bandcamp.com/EmbeddedPlayer/album=123'
+    );
+  });
 });

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -21,8 +21,17 @@ export interface LinkMetadata {
   author?: string;
   duration?: number;
   embedUrl?: string;
+  embed?: EmbedData;
   type?: string;
   recipe?: RecipeMetadata;
+}
+
+export interface EmbedData {
+  type?: string;
+  provider?: string;
+  embedUrl: string;
+  width?: number;
+  height?: number;
 }
 
 export interface RecipeNutritionInfo {


### PR DESCRIPTION
## Summary
- add Bandcamp embed extraction and registry in link metadata fetcher
- surface embed metadata and render Bandcamp player in posts
- add backend + frontend tests for Bandcamp embeds

Closes #732