### PR TITLE
Add Spotify embed support (backend + frontend)

### DIFF
--- a/backend/internal/services/link_metadata_test.go
+++ b/backend/internal/services/link_metadata_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sanderginn/clubhouse/internal/models"
+	linkmeta "github.com/sanderginn/clubhouse/internal/services/links"
+)
+
+func TestFetchLinkMetadataIncludesSpotifyEmbed(t *testing.T) {
+	config := GetConfigService()
+	current := config.GetConfig().LinkMetadataEnabled
+	enabled := true
+	if _, err := config.UpdateConfig(context.Background(), &enabled, nil, nil); err != nil {
+		t.Fatalf("failed to enable link metadata: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := config.UpdateConfig(context.Background(), &current, nil, nil); err != nil {
+			t.Fatalf("failed to restore link metadata: %v", err)
+		}
+	})
+
+	linkmeta.SetFetchMetadataFuncForTests(func(ctx context.Context, rawURL string) (map[string]interface{}, error) {
+		return map[string]interface{}{"title": "Spotify"}, nil
+	})
+	t.Cleanup(func() {
+		linkmeta.SetFetchMetadataFuncForTests(nil)
+	})
+
+	links := []models.LinkRequest{{URL: "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp"}}
+	metadata := fetchLinkMetadata(context.Background(), links)
+	if len(metadata) != 1 {
+		t.Fatalf("expected 1 metadata entry, got %d", len(metadata))
+	}
+	if len(metadata[0]) == 0 {
+		t.Fatalf("expected metadata to be populated")
+	}
+
+	embed, ok := metadata[0]["embed"].(*linkmeta.EmbedData)
+	if !ok || embed == nil {
+		t.Fatalf("expected embed metadata to be present")
+	}
+	if embed.Provider != "spotify" {
+		t.Fatalf("embed provider = %s", embed.Provider)
+	}
+	if embed.EmbedURL != "https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp" {
+		t.Fatalf("embed url = %s", embed.EmbedURL)
+	}
+}

--- a/backend/internal/services/links/embed_extractors.go
+++ b/backend/internal/services/links/embed_extractors.go
@@ -1,0 +1,37 @@
+package links
+
+import "context"
+
+var defaultEmbedExtractors = []EmbedExtractor{
+	SpotifyExtractor{},
+}
+
+// ExtractEmbed returns the first matching embed payload for a URL.
+func ExtractEmbed(ctx context.Context, rawURL string) (*EmbedData, error) {
+	for _, extractor := range defaultEmbedExtractors {
+		if extractor.CanExtract(rawURL) {
+			return extractor.Extract(ctx, rawURL)
+		}
+	}
+	return nil, nil
+}
+
+// ApplyEmbedMetadata merges embed details into the metadata map.
+func ApplyEmbedMetadata(metadata map[string]interface{}, embed *EmbedData) map[string]interface{} {
+	if embed == nil {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	metadata["embed"] = embed
+	metadata["embed_url"] = embed.EmbedURL
+	metadata["embed_provider"] = embed.Provider
+	if embed.Height > 0 {
+		metadata["embed_height"] = embed.Height
+	}
+	if embed.Width > 0 {
+		metadata["embed_width"] = embed.Width
+	}
+	return metadata
+}

--- a/backend/internal/services/links/metadata.go
+++ b/backend/internal/services/links/metadata.go
@@ -46,7 +46,20 @@ var defaultFetcher = NewFetcher(nil)
 
 // FetchMetadata fetches metadata for a URL using the default fetcher.
 func FetchMetadata(ctx context.Context, rawURL string) (map[string]interface{}, error) {
+	return fetchMetadataFunc(ctx, rawURL)
+}
+
+var fetchMetadataFunc = func(ctx context.Context, rawURL string) (map[string]interface{}, error) {
 	return defaultFetcher.Fetch(ctx, rawURL)
+}
+
+// SetFetchMetadataFuncForTests overrides the default fetcher. Use only in tests.
+func SetFetchMetadataFuncForTests(fn func(context.Context, string) (map[string]interface{}, error)) {
+	if fn == nil {
+		fetchMetadataFunc = defaultFetcher.Fetch
+		return
+	}
+	fetchMetadataFunc = fn
 }
 
 // Fetch retrieves metadata for the provided URL.

--- a/backend/internal/services/links/spotify.go
+++ b/backend/internal/services/links/spotify.go
@@ -1,0 +1,109 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// SpotifyExtractor extracts embed metadata for Spotify URLs.
+type SpotifyExtractor struct{}
+
+// SpotifyContent represents the parsed Spotify content type and ID.
+type SpotifyContent struct {
+	Type string
+	ID   string
+}
+
+var spotifyContentTypes = map[string]struct{}{
+	"track":    {},
+	"album":    {},
+	"playlist": {},
+	"artist":   {},
+	"show":     {},
+	"episode":  {},
+}
+
+// CanExtract returns true when the URL is a supported Spotify URL.
+func (SpotifyExtractor) CanExtract(rawURL string) bool {
+	_, err := parseSpotifyURL(rawURL)
+	return err == nil
+}
+
+// Extract parses the Spotify URL and returns an iframe embed payload.
+func (SpotifyExtractor) Extract(ctx context.Context, rawURL string) (*EmbedData, error) {
+	_ = ctx
+	content, err := parseSpotifyURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	embedURL := fmt.Sprintf("https://open.spotify.com/embed/%s/%s", content.Type, content.ID)
+	return &EmbedData{
+		Type:     "iframe",
+		Provider: "spotify",
+		EmbedURL: embedURL,
+		Height:   spotifyEmbedHeight(content.Type),
+	}, nil
+}
+
+func parseSpotifyURL(rawURL string) (*SpotifyContent, error) {
+	if strings.TrimSpace(rawURL) == "" {
+		return nil, errors.New("spotify url is required")
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse spotify url: %w", err)
+	}
+
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	if host != "open.spotify.com" {
+		return nil, errors.New("unsupported spotify host")
+	}
+
+	segments := strings.FieldsFunc(strings.Trim(u.Path, "/"), func(r rune) bool {
+		return r == '/'
+	})
+	if len(segments) == 0 {
+		return nil, errors.New("spotify path is missing")
+	}
+
+	index := 0
+	if strings.HasPrefix(segments[index], "intl-") && len(segments) > 1 {
+		index++
+	}
+	if index < len(segments) && segments[index] == "embed" && len(segments) > index+2 {
+		index++
+	}
+
+	if len(segments) <= index+1 {
+		return nil, errors.New("spotify content type or id missing")
+	}
+
+	contentType := strings.ToLower(segments[index])
+	contentID := segments[index+1]
+	if _, ok := spotifyContentTypes[contentType]; !ok {
+		return nil, errors.New("unsupported spotify content type")
+	}
+	if strings.TrimSpace(contentID) == "" {
+		return nil, errors.New("spotify content id missing")
+	}
+
+	return &SpotifyContent{Type: contentType, ID: contentID}, nil
+}
+
+func spotifyEmbedHeight(contentType string) int {
+	switch contentType {
+	case "track":
+		return 152
+	case "show", "episode":
+		return 232
+	case "album", "playlist", "artist":
+		return 380
+	default:
+		return 380
+	}
+}

--- a/backend/internal/services/links/spotify_test.go
+++ b/backend/internal/services/links/spotify_test.go
@@ -1,0 +1,107 @@
+package links
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseSpotifyURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		url        string
+		wantType   string
+		wantID     string
+		shouldFail bool
+	}{
+		{
+			name:     "track",
+			url:      "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+			wantType: "track",
+			wantID:   "3n3Ppam7vgaVa1iaRUc9Lp",
+		},
+		{
+			name:     "album",
+			url:      "https://open.spotify.com/album/6mUdeDZCsExyJLMdAfDuwh",
+			wantType: "album",
+			wantID:   "6mUdeDZCsExyJLMdAfDuwh",
+		},
+		{
+			name:     "playlist",
+			url:      "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+			wantType: "playlist",
+			wantID:   "37i9dQZF1DXcBWIGoYBM5M",
+		},
+		{
+			name:     "artist",
+			url:      "https://open.spotify.com/artist/1dfeR4HaWDbWqFHLkxsg1d",
+			wantType: "artist",
+			wantID:   "1dfeR4HaWDbWqFHLkxsg1d",
+		},
+		{
+			name:     "show",
+			url:      "https://open.spotify.com/show/2rN1dT9uLw8wKjtBF6qWvG",
+			wantType: "show",
+			wantID:   "2rN1dT9uLw8wKjtBF6qWvG",
+		},
+		{
+			name:     "episode",
+			url:      "https://open.spotify.com/episode/4rOoJ6Egrf8K2IrywzwOMk",
+			wantType: "episode",
+			wantID:   "4rOoJ6Egrf8K2IrywzwOMk",
+		},
+		{
+			name:     "embed url",
+			url:      "https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp",
+			wantType: "track",
+			wantID:   "3n3Ppam7vgaVa1iaRUc9Lp",
+		},
+		{
+			name:       "invalid host",
+			url:        "https://example.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+			shouldFail: true,
+		},
+		{
+			name:       "unsupported type",
+			url:        "https://open.spotify.com/user/123",
+			shouldFail: true,
+		},
+	}
+
+	for _, tc := range cases {
+		result, err := parseSpotifyURL(tc.url)
+		if tc.shouldFail {
+			if err == nil {
+				t.Fatalf("%s: expected error", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: parse error: %v", tc.name, err)
+		}
+		if result.Type != tc.wantType {
+			t.Errorf("%s: type = %s, want %s", tc.name, result.Type, tc.wantType)
+		}
+		if result.ID != tc.wantID {
+			t.Errorf("%s: id = %s, want %s", tc.name, result.ID, tc.wantID)
+		}
+	}
+}
+
+func TestSpotifyExtractorExtract(t *testing.T) {
+	extractor := SpotifyExtractor{}
+	url := "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp"
+
+	embed, err := extractor.Extract(context.Background(), url)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	if embed.EmbedURL != "https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp" {
+		t.Fatalf("embed url = %s", embed.EmbedURL)
+	}
+	if embed.Provider != "spotify" {
+		t.Fatalf("provider = %s", embed.Provider)
+	}
+	if embed.Height != 152 {
+		t.Fatalf("height = %d", embed.Height)
+	}
+}

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -165,7 +165,7 @@ describe('PostCard', () => {
           metadata: {
             url: 'https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp',
             embed: {
-              url: 'https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp',
+              embedUrl: 'https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp',
               height: 152,
               provider: 'spotify',
             },

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -156,6 +156,28 @@ describe('PostCard', () => {
     expect(screen.getByText('Intro')).toBeInTheDocument();
   });
 
+  it('renders spotify embed when embed metadata is present', () => {
+    const postWithSpotify: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp',
+          metadata: {
+            url: 'https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp',
+            embed: {
+              url: 'https://open.spotify.com/embed/track/3n3Ppam7vgaVa1iaRUc9Lp',
+              height: 152,
+              provider: 'spotify',
+            },
+          },
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithSpotify });
+    expect(screen.getByTitle('Spotify track')).toBeInTheDocument();
+  });
+
   it('shows a posted in label when section pill label is enabled', () => {
     sectionStore.setSections([
       {

--- a/frontend/src/components/comments/CommentThread.svelte
+++ b/frontend/src/components/comments/CommentThread.svelte
@@ -526,7 +526,7 @@
                   <div class="mt-2">
                     {#if link.metadata}
                       {@const embedUrl =
-                        link.metadata.embed?.url ??
+                        link.metadata.embed?.embedUrl ??
                         (isSpotifyEmbedUrl(link.metadata.embedUrl) ? link.metadata.embedUrl : undefined)}
                       {#if embedUrl && isSpotifyEmbedUrl(embedUrl)}
                         <SpotifyEmbed embedUrl={embedUrl} height={link.metadata.embed?.height} />

--- a/frontend/src/lib/components/embeds/SpotifyEmbed.svelte
+++ b/frontend/src/lib/components/embeds/SpotifyEmbed.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  const DEFAULT_HEIGHTS: Record<string, number> = {
+    track: 152,
+    album: 380,
+    playlist: 380,
+    artist: 380,
+    show: 232,
+    episode: 232,
+  };
+
+  export let embedUrl: string;
+  export let height: number | undefined = undefined;
+  export let title: string | undefined = undefined;
+
+  const resolveTypeFromUrl = (value: string): string | undefined => {
+    try {
+      const parsed = new URL(value);
+      const parts = parsed.pathname.split('/').filter(Boolean);
+      const embedIndex = parts.indexOf('embed');
+      if (embedIndex >= 0 && parts.length > embedIndex + 1) {
+        return parts[embedIndex + 1];
+      }
+      return parts[0];
+    } catch {
+      return undefined;
+    }
+  };
+
+  $: contentType = embedUrl ? resolveTypeFromUrl(embedUrl) : undefined;
+  $: computedHeight =
+    height ?? (contentType ? DEFAULT_HEIGHTS[contentType] : undefined) ?? DEFAULT_HEIGHTS.album;
+  $: iframeTitle = title ?? (contentType ? `Spotify ${contentType}` : 'Spotify player');
+</script>
+
+<div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+  <iframe
+    src={embedUrl}
+    title={iframeTitle}
+    class="w-full"
+    style={`height: ${computedHeight}px;`}
+    frameborder="0"
+    loading="lazy"
+    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+  ></iframe>
+</div>

--- a/frontend/src/lib/components/embeds/__tests__/SpotifyEmbed.test.ts
+++ b/frontend/src/lib/components/embeds/__tests__/SpotifyEmbed.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+const { default: SpotifyEmbed } = await import('../SpotifyEmbed.svelte');
+
+describe('SpotifyEmbed', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('uses provided height when available', () => {
+    const { container } = render(SpotifyEmbed, {
+      embedUrl: 'https://open.spotify.com/embed/track/xyz',
+      height: 232,
+    });
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('style')).toContain('232px');
+  });
+
+  it('infers height from embed url', () => {
+    const { container, getByTitle } = render(SpotifyEmbed, {
+      embedUrl: 'https://open.spotify.com/embed/track/xyz',
+    });
+
+    expect(getByTitle('Spotify track')).toBeInTheDocument();
+    const iframe = container.querySelector('iframe');
+    expect(iframe?.getAttribute('style')).toContain('152px');
+  });
+});

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -28,7 +28,11 @@ describe('mapApiPost', () => {
             image: 'https://example.com/image.png',
             author: 'Author',
             duration: 120,
-            embedUrl: 'https://example.com/embed',
+            embed: {
+              embed_url: 'https://open.spotify.com/embed/track/xyz',
+              provider: 'spotify',
+              height: 152,
+            },
           },
         },
       ],
@@ -37,7 +41,9 @@ describe('mapApiPost', () => {
     expect(post.id).toBe('post-1');
     expect(post.user?.username).toBe('sander');
     expect(post.commentCount).toBe(2);
-    expect(post.links?.[0].metadata?.embedUrl).toBe('https://example.com/embed');
+    expect(post.links?.[0].metadata?.embedUrl).toBe('https://open.spotify.com/embed/track/xyz');
+    expect(post.links?.[0].metadata?.embed?.provider).toBe('spotify');
+    expect(post.links?.[0].metadata?.embed?.height).toBe(152);
     expect(post.links?.[0].metadata?.author).toBe('Author');
     expect(post.links?.[0].metadata?.duration).toBe(120);
   });
@@ -132,6 +138,7 @@ describe('mapApiPost', () => {
       description: 'Example Description',
       image_url: 'https://cdn.example.com/image.png',
       embed_url: 'https://example.com/embed',
+      embed_height: '232',
       duration: '180',
     });
 
@@ -155,6 +162,7 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.description).toBe('Example Description');
     expect(post.links?.[0].metadata?.image).toBe('https://cdn.example.com/image.png');
     expect(post.links?.[0].metadata?.embedUrl).toBe('https://example.com/embed');
+    expect(post.links?.[0].metadata?.embed?.height).toBe(232);
     expect(post.links?.[0].metadata?.duration).toBe(180);
   });
 

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -21,17 +21,17 @@ export interface LinkMetadata {
   author?: string;
   duration?: number;
   embedUrl?: string;
-  embed?: LinkEmbed;
+  embed?: EmbedData;
   type?: string;
   recipe?: RecipeMetadata;
 }
 
-export interface LinkEmbed {
-  url: string;
-  provider?: string;
+export interface EmbedData {
   type?: string;
-  height?: number;
+  provider?: string;
+  embedUrl: string;
   width?: number;
+  height?: number;
 }
 
 export interface RecipeNutritionInfo {
@@ -207,30 +207,85 @@ function createPostStore() {
     updateReactionCount: (postId: string, emoji: string, delta: number) =>
       update((state) => ({
         ...state,
-        posts: state.posts.map((post) =>
-          post.id === postId
-            ? {
-                ...post,
-                reactionCounts: {
-                  ...(post.reactionCounts ?? {}),
-                  [emoji]: Math.max(0, (post.reactionCounts?.[emoji] ?? 0) + delta),
-                },
-              }
-            : post
-        ),
+        posts: state.posts.map((post) => {
+          if (post.id !== postId) {
+            return post;
+          }
+          const counts = { ...(post.reactionCounts ?? {}) };
+          const next = (counts[emoji] ?? 0) + delta;
+          if (next <= 0) {
+            delete counts[emoji];
+          } else {
+            counts[emoji] = next;
+          }
+          return {
+            ...post,
+            reactionCounts: counts,
+          };
+        }),
       })),
     toggleReaction: (postId: string, emoji: string) =>
       update((state) => ({
         ...state,
         posts: state.posts.map((post) => {
-          if (post.id !== postId) return post;
-          const reactions = post.viewerReactions ?? [];
-          const hasReaction = reactions.includes(emoji);
+          if (post.id !== postId) {
+            return post;
+          }
+          const viewerReactions = new Set(post.viewerReactions ?? []);
+          const counts = { ...(post.reactionCounts ?? {}) };
+
+          if (viewerReactions.has(emoji)) {
+            viewerReactions.delete(emoji);
+            const next = (counts[emoji] ?? 0) - 1;
+            if (next <= 0) delete counts[emoji];
+            else counts[emoji] = next;
+          } else {
+            viewerReactions.add(emoji);
+            counts[emoji] = (counts[emoji] ?? 0) + 1;
+          }
+
           return {
             ...post,
-            viewerReactions: hasReaction
-              ? reactions.filter((reaction) => reaction !== emoji)
-              : [...reactions, emoji],
+            reactionCounts: counts,
+            viewerReactions: Array.from(viewerReactions),
+          };
+        }),
+      })),
+    setLoading: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoading,
+        error: isLoading ? null : state.error,
+        paginationError: isLoading ? null : state.paginationError,
+      })),
+    setError: (error: string | null) =>
+      update((state) => ({ ...state, error, isLoading: false, paginationError: null })),
+    setPaginationError: (error: string | null) =>
+      update((state) => ({ ...state, paginationError: error, isLoading: false })),
+    reset: () =>
+      set({
+        posts: [],
+        isLoading: false,
+        error: null,
+        paginationError: null,
+        cursor: null,
+        hasMore: true,
+      }),
+    updateUserProfilePicture: (userId: string, profilePictureUrl?: string) =>
+      update((state) => ({
+        ...state,
+        posts: state.posts.map((post) => {
+          const shouldUpdate =
+            post.user?.id === userId || (!post.user && post.userId === userId);
+          if (!shouldUpdate || !post.user) {
+            return post;
+          }
+          return {
+            ...post,
+            user: {
+              ...post.user,
+              profilePictureUrl,
+            },
           };
         }),
       })),
@@ -239,16 +294,9 @@ function createPostStore() {
 
 export const postStore = createPostStore();
 
-export const sortedPosts = derived(postStore, ($store) =>
-  [...$store.posts].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-);
-
-export const isLoadingPosts = derived(postStore, ($store) => $store.isLoading);
-
-export const postError = derived(postStore, ($store) => $store.error);
-
-export const postPaginationError = derived(postStore, ($store) => $store.paginationError);
-
-export const hasMorePosts = derived(postStore, ($store) => $store.hasMore);
-
-export const postCursor = derived(postStore, ($store) => $store.cursor);
+export const posts = derived(postStore, ($postStore) => $postStore.posts);
+export const isLoadingPosts = derived(postStore, ($postStore) => $postStore.isLoading);
+export const postsError = derived(postStore, ($postStore) => $postStore.error);
+export const postsPaginationError = derived(postStore, ($postStore) => $postStore.paginationError);
+export const hasMorePosts = derived(postStore, ($postStore) => $postStore.hasMore);
+export const postCursor = derived(postStore, ($postStore) => $postStore.cursor);


### PR DESCRIPTION
## Summary
- add Spotify embed extractor and merge embed metadata into link processing
- render Spotify embeds in post/comment link cards with a new Svelte component
- add backend and frontend tests covering Spotify embeds

Closes #730