### PR TITLE
Security: Add CSP headers and embed URL validation

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -445,6 +445,7 @@ func main() {
 	// Apply middleware
 	handler := middleware.ChainMiddleware(mux,
 		middleware.RequestID,
+		middleware.CSPMiddleware,
 		middleware.Observability,
 	)
 

--- a/backend/internal/middleware/csp.go
+++ b/backend/internal/middleware/csp.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CSPMiddleware adds a Content-Security-Policy header to reduce iframe injection risks.
+// This policy is aligned with the embed domain whitelist in the links service.
+func CSPMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		csp := []string{
+			"default-src 'self'",
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+			"style-src 'self' 'unsafe-inline'",
+			"img-src 'self' data: https:",
+			"frame-src 'self' https://www.youtube-nocookie.com https://open.spotify.com https://w.soundcloud.com https://bandcamp.com",
+			"connect-src 'self'",
+			"font-src 'self'",
+			"object-src 'none'",
+			"base-uri 'self'",
+			"form-action 'self'",
+			"frame-ancestors 'none'",
+		}
+
+		w.Header().Set("Content-Security-Policy", strings.Join(csp, "; "))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/middleware/csp_test.go
+++ b/backend/internal/middleware/csp_test.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCSPMiddlewareSetsHeader(t *testing.T) {
+	handler := CSPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	header := rec.Header().Get("Content-Security-Policy")
+	if header == "" {
+		t.Fatal("expected Content-Security-Policy header to be set")
+	}
+	if !strings.Contains(header, "frame-src") {
+		t.Fatalf("expected frame-src directive, got %q", header)
+	}
+	if !strings.Contains(header, "https://www.youtube-nocookie.com") {
+		t.Fatalf("expected youtube-nocookie in CSP, got %q", header)
+	}
+}

--- a/backend/internal/services/links/bandcamp.go
+++ b/backend/internal/services/links/bandcamp.go
@@ -46,6 +46,9 @@ func (e BandcampExtractor) ExtractFromHTML(
 		return nil, err
 	}
 	embedURL, height := buildBandcampEmbedURL(content)
+	if err := validateEmbedURL(embedURL); err != nil {
+		return nil, err
+	}
 	return &EmbedData{
 		Type:     "iframe",
 		Provider: "bandcamp",

--- a/backend/internal/services/links/embed_validation.go
+++ b/backend/internal/services/links/embed_validation.go
@@ -1,0 +1,43 @@
+package links
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// allowedEmbedDomains defines the only iframe domains we accept for embeds.
+// This blocks malicious iframe injection and keeps CSP + embed validation aligned.
+var allowedEmbedDomains = map[string]struct{}{
+	"www.youtube-nocookie.com": {},
+	"open.spotify.com":         {},
+	"w.soundcloud.com":         {},
+	"bandcamp.com":             {},
+}
+
+func validateEmbedURL(embedURL string) error {
+	if strings.TrimSpace(embedURL) == "" {
+		return errors.New("embed url is required")
+	}
+
+	parsed, err := url.Parse(embedURL)
+	if err != nil {
+		return fmt.Errorf("parse embed url: %w", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return errors.New("embed url must use https")
+	}
+
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if host == "" {
+		return errors.New("embed url missing host")
+	}
+
+	if _, ok := allowedEmbedDomains[host]; !ok {
+		return fmt.Errorf("embed domain not allowed: %s", host)
+	}
+
+	return nil
+}

--- a/backend/internal/services/links/embed_validation_test.go
+++ b/backend/internal/services/links/embed_validation_test.go
@@ -1,0 +1,40 @@
+package links
+
+import "testing"
+
+func TestValidateEmbedURLAllowsWhitelistedHTTPS(t *testing.T) {
+	cases := []string{
+		"https://www.youtube-nocookie.com/embed/abc123",
+		"https://open.spotify.com/embed/track/xyz",
+		"https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/123",
+		"https://bandcamp.com/EmbeddedPlayer/album=123/size=large/",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			if err := validateEmbedURL(tc); err != nil {
+				t.Fatalf("expected url %q to be valid, got %v", tc, err)
+			}
+		})
+	}
+}
+
+func TestValidateEmbedURLRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "empty", url: ""},
+		{name: "invalid", url: "://bad-url"},
+		{name: "http", url: "http://open.spotify.com/embed/track/xyz"},
+		{name: "non-whitelist", url: "https://evil.example.com/embed/track/xyz"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateEmbedURL(tc.url); err == nil {
+				t.Fatalf("expected url %q to be rejected", tc.url)
+			}
+		})
+	}
+}

--- a/backend/internal/services/links/soundcloud.go
+++ b/backend/internal/services/links/soundcloud.go
@@ -97,6 +97,10 @@ func (e *SoundCloudExtractor) Extract(ctx context.Context, rawURL string) (*Embe
 		observability.LogWarn(ctx, "soundcloud oembed missing iframe src", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10))
 		return nil, errors.New("soundcloud oembed missing iframe src")
 	}
+	if err := validateEmbedURL(embedURL); err != nil {
+		observability.LogWarn(ctx, "soundcloud oembed invalid iframe src", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return nil, err
+	}
 
 	observability.LogDebug(ctx, "soundcloud oembed fetched", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "status", strconv.Itoa(resp.StatusCode))
 

--- a/backend/internal/services/links/spotify.go
+++ b/backend/internal/services/links/spotify.go
@@ -41,6 +41,9 @@ func (SpotifyExtractor) Extract(ctx context.Context, rawURL string) (*EmbedData,
 	}
 
 	embedURL := fmt.Sprintf("https://open.spotify.com/embed/%s/%s", content.Type, content.ID)
+	if err := validateEmbedURL(embedURL); err != nil {
+		return nil, err
+	}
 	return &EmbedData{
 		Type:     "iframe",
 		Provider: "spotify",

--- a/backend/internal/services/links/youtube.go
+++ b/backend/internal/services/links/youtube.go
@@ -26,10 +26,15 @@ func (YouTubeExtractor) Extract(_ context.Context, rawURL string) (*EmbedData, e
 		return nil, err
 	}
 
+	embedURL := fmt.Sprintf("%s%s", youtubeEmbedBaseURL, videoID)
+	if err := validateEmbedURL(embedURL); err != nil {
+		return nil, err
+	}
+
 	return &EmbedData{
 		Type:     "iframe",
 		Provider: "youtube",
-		EmbedURL: fmt.Sprintf("%s%s", youtubeEmbedBaseURL, videoID),
+		EmbedURL: embedURL,
 	}, nil
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="description" content="A self-hosted social platform for communities" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src 'self' https://www.youtube-nocookie.com https://open.spotify.com https://w.soundcloud.com https://bandcamp.com; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+    />
 
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#4f46e5" />

--- a/frontend/src/lib/components/embeds/BandcampEmbed.svelte
+++ b/frontend/src/lib/components/embeds/BandcampEmbed.svelte
@@ -17,7 +17,7 @@
     style={`height: ${playerHeight}px;`}
     loading="lazy"
     allow="encrypted-media"
-    sandbox="allow-same-origin allow-scripts allow-popups"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
   ></iframe>
   <a
     href={linkUrl}

--- a/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
+++ b/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
@@ -16,6 +16,7 @@
     height={resolvedHeight}
     class="w-full"
     loading="lazy"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allow="autoplay"
     style="border: 0;"
     data-testid="soundcloud-embed"

--- a/frontend/src/lib/components/embeds/SpotifyEmbed.svelte
+++ b/frontend/src/lib/components/embeds/SpotifyEmbed.svelte
@@ -40,6 +40,7 @@
     style={`height: ${computedHeight}px;`}
     frameborder="0"
     loading="lazy"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
   ></iframe>
 </div>

--- a/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
+++ b/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
@@ -8,6 +8,7 @@
     class="absolute inset-0 h-full w-full"
     src={embedUrl}
     title={title}
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen
     referrerpolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- add CSP middleware and CSP meta fallback aligned with embed domains
- validate iframe embed URLs against HTTPS + whitelist and wire into extractors
- enforce iframe sandbox attributes across embed components
- add tests for CSP header and URL validation

## Testing
- `cd backend && go test ./internal/services/links -v`
- `cd backend && go test ./internal/middleware -v`
- `cd frontend && npm run check`

Closes #733