### PR TITLE
Fix SoundCloud oEmbed JSON decode error (version field type mismatch)

### DIFF
--- a/backend/internal/services/links/soundcloud.go
+++ b/backend/internal/services/links/soundcloud.go
@@ -26,14 +26,14 @@ type SoundCloudExtractor struct {
 }
 
 type soundCloudOEmbedResponse struct {
-	Type         string `json:"type"`
-	Version      string `json:"version"`
-	Title        string `json:"title"`
-	AuthorName   string `json:"author_name"`
-	HTML         string `json:"html"`
-	Width        int    `json:"width"`
-	Height       int    `json:"height"`
-	ThumbnailURL string `json:"thumbnail_url"`
+	Type         string          `json:"type"`
+	Version      json.RawMessage `json:"version"`
+	Title        string          `json:"title"`
+	AuthorName   string          `json:"author_name"`
+	HTML         string          `json:"html"`
+	Width        int             `json:"width"`
+	Height       int             `json:"height"`
+	ThumbnailURL string          `json:"thumbnail_url"`
 }
 
 func NewSoundCloudExtractor(client *http.Client) *SoundCloudExtractor {

--- a/backend/internal/services/links/soundcloud_test.go
+++ b/backend/internal/services/links/soundcloud_test.go
@@ -49,7 +49,7 @@ func TestSoundCloudExtractorExtract(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"type": "rich",
-			"version": "1.0",
+			"version": 1.0,
 			"title": "Test Track",
 			"author_name": "Artist",
 			"html": "<iframe src=\"`+embedSrc+`\"></iframe>",


### PR DESCRIPTION
## Summary
- accept numeric SoundCloud oEmbed version values by storing the raw JSON field
- update the SoundCloud extractor test payload to use the numeric version format

## Testing
- `go build ./...`
- `go test ./internal/services/links -v`
- `task backend:test`

Closes #740
