### PR TITLE
Support hh:mm:ss timestamp format for music links (allow times over 1 hour)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -459,7 +459,7 @@ Auth: Required
 Body: {
   sectionId: "uuid",
   content: "text",
-  links: [{ url: "https://..." }]  // optional
+  links: [{ url: "https://...", highlights: [{ timestamp: 90, label: "Intro" }] }]  // optional, timestamp in seconds
 }
 Response: { post: { id, userId, sectionId, content, links, createdAt } }
 ```

--- a/frontend/src/components/posts/HighlightDisplay.svelte
+++ b/frontend/src/components/posts/HighlightDisplay.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
   import type { Highlight } from '../../stores/postStore';
+  import { formatHighlightTimestamp } from '../../lib/highlights';
 
   export let highlights: Highlight[] = [];
-
-  const formatTimestamp = (seconds: number) => {
-    const safeSeconds = Math.max(0, Math.floor(seconds));
-    const minutes = Math.floor(safeSeconds / 60);
-    const remainder = safeSeconds % 60;
-    return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
-  };
 </script>
 
 {#if highlights?.length}
   <div class="flex flex-wrap gap-2" aria-label="Highlights">
     {#each highlights as highlight (highlight.timestamp + '-' + (highlight.label ?? ''))}
       <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
-        <span class="font-medium text-gray-800">{formatTimestamp(highlight.timestamp)}</span>
+        <span class="font-medium text-gray-800">{formatHighlightTimestamp(highlight.timestamp)}</span>
         {#if highlight.label}
           <span class="ml-1 text-gray-600">{highlight.label}</span>
         {/if}

--- a/frontend/src/components/posts/HighlightEditor.svelte
+++ b/frontend/src/components/posts/HighlightEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Highlight } from '../../stores/postStore';
+  import { formatHighlightTimestamp, parseHighlightTimestamp } from '../../lib/highlights';
 
   const maxHighlights = 20;
 
@@ -9,21 +10,6 @@
   let timestampInput = '';
   let labelInput = '';
   let error: string | null = null;
-
-  const formatTimestamp = (seconds: number) => {
-    const safeSeconds = Math.max(0, Math.floor(seconds));
-    const minutes = Math.floor(safeSeconds / 60);
-    const remainder = safeSeconds % 60;
-    return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
-  };
-
-  const parseTimestamp = (value: string) => {
-    const match = value.trim().match(/^(\d{1,3}):([0-5]\d)$/);
-    if (!match) return null;
-    const minutes = Number(match[1]);
-    const seconds = Number(match[2]);
-    return minutes * 60 + seconds;
-  };
 
   const isAtMax = () => highlights.length >= maxHighlights;
 
@@ -36,9 +22,9 @@
       return;
     }
 
-    const parsedSeconds = parseTimestamp(timestampInput);
+    const parsedSeconds = parseHighlightTimestamp(timestampInput);
     if (parsedSeconds === null) {
-      error = 'Enter a timestamp in mm:ss format.';
+      error = 'Enter a timestamp in mm:ss or hh:mm:ss format.';
       return;
     }
 
@@ -62,12 +48,12 @@
 <div class="space-y-3">
   <div class="grid gap-3 md:grid-cols-2">
     <div class="space-y-1">
-      <label class="text-xs font-medium text-gray-600" for="highlight-timestamp">Timestamp (mm:ss)</label>
+      <label class="text-xs font-medium text-gray-600" for="highlight-timestamp">Timestamp (mm:ss or hh:mm:ss)</label>
       <input
         id="highlight-timestamp"
         type="text"
         inputmode="numeric"
-        placeholder="03:15"
+        placeholder="03:15 or 1:03:15"
         class="w-full rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
         bind:value={timestampInput}
         disabled={disabled}
@@ -112,7 +98,7 @@
         <li class="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm">
           <div class="flex items-center gap-2">
             <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
-              {formatTimestamp(highlight.timestamp)}
+              {formatHighlightTimestamp(highlight.timestamp)}
             </span>
             {#if highlight.label}
               <span class="text-gray-700">{highlight.label}</span>
@@ -123,7 +109,7 @@
             class="text-xs text-gray-400 hover:text-gray-600"
             on:click={() => removeHighlight(index)}
             disabled={disabled}
-            aria-label={`Remove highlight ${formatTimestamp(highlight.timestamp)}`}
+            aria-label={`Remove highlight ${formatHighlightTimestamp(highlight.timestamp)}`}
           >
             Remove
           </button>

--- a/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
@@ -26,6 +26,14 @@ describe('HighlightDisplay', () => {
     expect(queryByText('Intro')).not.toBeInTheDocument();
   });
 
+  it('renders hour timestamps when needed', () => {
+    const { getByText } = render(HighlightDisplay, {
+      highlights: [{ timestamp: 3930 }],
+    });
+
+    expect(getByText('1:05:30')).toBeInTheDocument();
+  });
+
   it('renders nothing when highlights are empty', () => {
     const { queryByLabelText } = render(HighlightDisplay, {
       highlights: [],

--- a/frontend/src/components/posts/__tests__/HighlightEditor.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightEditor.test.ts
@@ -13,7 +13,7 @@ describe('HighlightEditor', () => {
       highlights: [],
     });
 
-    const timestampInput = getByLabelText('Timestamp (mm:ss)');
+    const timestampInput = getByLabelText('Timestamp (mm:ss or hh:mm:ss)');
     const labelInput = getByLabelText('Label (optional)');
 
     await fireEvent.input(timestampInput, { target: { value: '01:30' } });
@@ -22,6 +22,18 @@ describe('HighlightEditor', () => {
 
     expect(getByText('01:30')).toBeInTheDocument();
     expect(getByText('Intro')).toBeInTheDocument();
+  });
+
+  it('adds a highlight from hh:mm:ss input', async () => {
+    const { getByLabelText, getByText } = render(HighlightEditor, {
+      highlights: [],
+    });
+
+    const timestampInput = getByLabelText('Timestamp (mm:ss or hh:mm:ss)');
+    await fireEvent.input(timestampInput, { target: { value: '1:30:45' } });
+    await fireEvent.click(getByText('Add highlight'));
+
+    expect(getByText('1:30:45')).toBeInTheDocument();
   });
 
   it('removes a highlight', async () => {

--- a/frontend/src/components/posts/__tests__/PostForm.test.ts
+++ b/frontend/src/components/posts/__tests__/PostForm.test.ts
@@ -263,12 +263,12 @@ describe('PostForm', () => {
     await fireEvent.keyDown(linkInput, { key: 'Enter' });
     await tick();
 
-    expect(screen.queryByLabelText('Timestamp (mm:ss)')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Timestamp (mm:ss or hh:mm:ss)')).not.toBeInTheDocument();
 
     setActiveSection();
     await tick();
 
-    expect(screen.getByLabelText('Timestamp (mm:ss)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Timestamp (mm:ss or hh:mm:ss)')).toBeInTheDocument();
   });
 
   it('includes highlights in link payload when added', async () => {
@@ -293,7 +293,7 @@ describe('PostForm', () => {
     await fireEvent.keyDown(linkInput, { key: 'Enter' });
     await tick();
 
-    const timestampInput = screen.getByLabelText('Timestamp (mm:ss)');
+    const timestampInput = screen.getByLabelText('Timestamp (mm:ss or hh:mm:ss)');
     const labelInput = screen.getByLabelText('Label (optional)');
     await fireEvent.input(timestampInput, { target: { value: '01:30' } });
     await fireEvent.input(labelInput, { target: { value: 'Intro' } });
@@ -335,7 +335,7 @@ describe('PostForm', () => {
     await fireEvent.keyDown(linkInput, { key: 'Enter' });
     await tick();
 
-    const timestampInput = screen.getByLabelText('Timestamp (mm:ss)');
+    const timestampInput = screen.getByLabelText('Timestamp (mm:ss or hh:mm:ss)');
     await fireEvent.input(timestampInput, { target: { value: '00:30' } });
     await fireEvent.click(screen.getByRole('button', { name: 'Add highlight' }));
 

--- a/frontend/src/lib/highlights.ts
+++ b/frontend/src/lib/highlights.ts
@@ -1,0 +1,32 @@
+export const formatHighlightTimestamp = (seconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const remainder = safeSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
+  }
+  return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
+};
+
+export const parseHighlightTimestamp = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const hourMatch = trimmed.match(/^(\d+):([0-5]\d):([0-5]\d)$/);
+  if (hourMatch) {
+    const hours = Number(hourMatch[1]);
+    const minutes = Number(hourMatch[2]);
+    const seconds = Number(hourMatch[3]);
+    return hours * 3600 + minutes * 60 + seconds;
+  }
+
+  const minuteMatch = trimmed.match(/^(\d+):([0-5]\d)$/);
+  if (minuteMatch) {
+    const minutes = Number(minuteMatch[1]);
+    const seconds = Number(minuteMatch[2]);
+    return minutes * 60 + seconds;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- add shared highlight timestamp parse/format helpers to support mm:ss and hh:mm:ss
- update highlight editor/display and related tests to show hours when needed
- document highlight timestamp payload format in DESIGN.md

## Testing
- task backend:test
- task frontend:test

Closes #750