### PR TITLE
Add track/set length filter to music section

### DIFF
--- a/frontend/src/components/MusicLinksContainer.svelte
+++ b/frontend/src/components/MusicLinksContainer.svelte
@@ -6,6 +6,7 @@
     isLoadingSectionLinks,
     hasMoreSectionLinks,
     sectionLinksStore,
+    musicLengthFilter,
   } from '../stores';
   import { loadSectionLinks, loadMoreSectionLinks } from '../stores/sectionLinksFeedStore';
   import type { SectionLink } from '../stores/sectionLinksStore';
@@ -17,6 +18,7 @@
 
   $: isMusicSection = $activeSection?.type === 'music';
   $: linkCount = $sectionLinks.length;
+  $: lengthFilter = $musicLengthFilter;
 
   $: if (isMusicSection && $activeSection?.id && $activeSection.id !== lastSectionId) {
     lastSectionId = $activeSection.id;
@@ -35,6 +37,16 @@
 
   function toggleExpanded() {
     isExpanded = !isExpanded;
+  }
+
+  const lengthFilters = [
+    { value: 'all', label: 'All' },
+    { value: 'tracks', label: 'Tracks' },
+    { value: 'sets', label: 'Sets/Mixes' },
+  ] as const;
+
+  function setLengthFilter(value: (typeof lengthFilters)[number]['value']) {
+    musicLengthFilter.set(value);
   }
 
   function getThumbnailUrl(link: SectionLink): string | null {
@@ -72,13 +84,13 @@
 
 {#if isMusicSection}
   <div class="bg-white rounded-lg shadow-sm border border-gray-200">
-    <button
-      type="button"
-      class="w-full flex items-center justify-between px-4 py-3"
-      on:click={toggleExpanded}
-      aria-expanded={isExpanded}
-    >
-      <div class="flex items-center gap-2">
+    <div class="flex items-center justify-between px-4 py-3 gap-3">
+      <button
+        type="button"
+        class="flex items-center gap-2"
+        on:click={toggleExpanded}
+        aria-expanded={isExpanded}
+      >
         <svg
           class={`h-4 w-4 text-gray-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
           viewBox="0 0 20 20"
@@ -97,8 +109,25 @@
         >
           {linkCount}
         </span>
+      </button>
+
+      <div class="flex items-center gap-1 rounded-full bg-gray-100 p-1">
+        {#each lengthFilters as filter}
+          <button
+            type="button"
+            class={`px-2.5 py-1 text-xs font-semibold rounded-full transition ${
+              lengthFilter === filter.value
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+            aria-pressed={lengthFilter === filter.value}
+            on:click={() => setLengthFilter(filter.value)}
+          >
+            {filter.label}
+          </button>
+        {/each}
       </div>
-    </button>
+    </div>
 
     {#if isExpanded}
       <div class="border-t border-gray-200 px-4 pb-4 pt-3 space-y-3">

--- a/frontend/src/components/SectionFeed.svelte
+++ b/frontend/src/components/SectionFeed.svelte
@@ -3,12 +3,14 @@
   import {
     activeSection,
     posts,
+    filteredPosts,
     isLoadingPosts,
     postsError,
     postsPaginationError,
     hasMorePosts,
     postStore,
     threadRouteStore,
+    musicLengthFilter,
   } from '../stores';
   import { loadFeed, loadMorePosts } from '../stores/feedStore';
   import { loadThreadTargetPost } from '../stores/threadRouteStore';
@@ -23,6 +25,11 @@
   $: if ($activeSection?.id) {
     loadFeed($activeSection.id);
   }
+
+  $: displayPosts = $filteredPosts;
+  $: hasFilteredResults = displayPosts.length > 0;
+  $: filterLabel =
+    $musicLengthFilter === 'tracks' ? 'tracks' : $musicLengthFilter === 'sets' ? 'sets/mixes' : '';
 
   async function handleLoadMore() {
     if (isLoadingMore || !$hasMorePosts) return;
@@ -164,15 +171,23 @@
       <p class="text-gray-500">No posts yet. Be the first to share something!</p>
     </div>
   {:else}
-    {#each $posts as post (post.id)}
-      {@const isTarget = $threadRouteStore.postId === post.id}
-      <div
-        id={`post-${post.id}`}
-        class={`scroll-mt-24 ${isTarget ? 'ring-2 ring-blue-200 rounded-lg' : ''}`}
-      >
-        <PostCard {post} />
+    {#if !hasFilteredResults}
+      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
+        <p class="text-gray-500">
+          No {filterLabel} posts yet. Try switching the length filter.
+        </p>
       </div>
-    {/each}
+    {:else}
+      {#each displayPosts as post (post.id)}
+        {@const isTarget = $threadRouteStore.postId === post.id}
+        <div
+          id={`post-${post.id}`}
+          class={`scroll-mt-24 ${isTarget ? 'ring-2 ring-blue-200 rounded-lg' : ''}`}
+        >
+          <PostCard {post} />
+        </div>
+      {/each}
+    {/if}
 
     <div bind:this={sentinel} class="h-4"></div>
 

--- a/frontend/src/components/__tests__/MusicLinksContainer.test.ts
+++ b/frontend/src/components/__tests__/MusicLinksContainer.test.ts
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
 import { sectionStore } from '../../stores/sectionStore';
 import { sectionLinksStore, type SectionLink } from '../../stores/sectionLinksStore';
+import { musicLengthFilter } from '../../stores/musicFilterStore';
 
 const loadSectionLinks = vi.hoisted(() => vi.fn());
 const loadMoreSectionLinks = vi.hoisted(() => vi.fn());
@@ -40,6 +42,8 @@ function setActiveSection(type: 'music' | 'general') {
 beforeEach(() => {
   loadSectionLinks.mockReset();
   loadMoreSectionLinks.mockReset();
+  window.sessionStorage?.clear();
+  musicLengthFilter.set('all');
   sectionLinksStore.reset();
   sectionStore.setActiveSection(null);
 });
@@ -91,5 +95,16 @@ describe('MusicLinksContainer', () => {
     await fireEvent.click(button);
 
     expect(loadMoreSectionLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the length filter selection', async () => {
+    setActiveSection('music');
+    render(MusicLinksContainer);
+
+    const tracksButton = screen.getByRole('button', { name: 'Tracks' });
+    await fireEvent.click(tracksButton);
+
+    expect(get(musicLengthFilter)).toBe('tracks');
+    expect(tracksButton).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/frontend/src/stores/__tests__/musicFilterStore.test.ts
+++ b/frontend/src/stores/__tests__/musicFilterStore.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  extractDurationSeconds,
+  matchesMusicLengthFilter,
+  musicLengthFilter,
+  filteredPosts,
+  TRACK_MAX_DURATION_SECONDS,
+} from '../musicFilterStore';
+import { postStore } from '../postStore';
+import { sectionStore } from '../sectionStore';
+
+const basePost = {
+  id: 'post-1',
+  userId: 'user-1',
+  sectionId: 'section-1',
+  content: 'hello',
+  createdAt: '2026-01-29T00:00:00Z',
+};
+
+beforeEach(() => {
+  window.sessionStorage?.clear();
+  musicLengthFilter.set('all');
+  postStore.reset();
+  sectionStore.setActiveSection(null);
+});
+
+describe('musicFilterStore', () => {
+  it('extracts valid duration seconds', () => {
+    expect(extractDurationSeconds({ duration: 0, url: 'a' })).toBeNull();
+    expect(extractDurationSeconds({ duration: -10, url: 'a' })).toBeNull();
+    expect(extractDurationSeconds({ duration: Number.NaN, url: 'a' })).toBeNull();
+    expect(extractDurationSeconds({ duration: 120, url: 'a' })).toBe(120);
+  });
+
+  it('matches length filters', () => {
+    const threshold = TRACK_MAX_DURATION_SECONDS;
+    expect(matchesMusicLengthFilter(null, 'tracks')).toBe(false);
+    expect(matchesMusicLengthFilter(null, 'sets')).toBe(false);
+    expect(matchesMusicLengthFilter(threshold - 1, 'tracks')).toBe(true);
+    expect(matchesMusicLengthFilter(threshold - 1, 'sets')).toBe(false);
+    expect(matchesMusicLengthFilter(threshold, 'tracks')).toBe(false);
+    expect(matchesMusicLengthFilter(threshold, 'sets')).toBe(true);
+  });
+
+  it('filters posts by duration when in music section', () => {
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
+
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          id: 'track-1',
+          links: [{ url: 'https://example.com/track', metadata: { url: 'https://example.com/track', duration: 120 } }],
+        },
+        {
+          ...basePost,
+          id: 'set-1',
+          links: [{ url: 'https://example.com/set', metadata: { url: 'https://example.com/set', duration: TRACK_MAX_DURATION_SECONDS } }],
+        },
+        {
+          ...basePost,
+          id: 'unknown-1',
+          links: [{ url: 'https://example.com/unknown', metadata: { url: 'https://example.com/unknown' } }],
+        },
+      ],
+      null,
+      false
+    );
+
+    musicLengthFilter.set('tracks');
+    expect(get(filteredPosts).map((post) => post.id)).toEqual(['track-1']);
+
+    musicLengthFilter.set('sets');
+    expect(get(filteredPosts).map((post) => post.id)).toEqual(['set-1']);
+  });
+
+  it('does not filter posts outside the music section', () => {
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'General',
+      type: 'general',
+      icon: '💬',
+      slug: 'general',
+    });
+
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          id: 'post-1',
+          links: [{ url: 'https://example.com/track', metadata: { url: 'https://example.com/track', duration: 120 } }],
+        },
+        {
+          ...basePost,
+          id: 'post-2',
+          links: [{ url: 'https://example.com/set', metadata: { url: 'https://example.com/set', duration: TRACK_MAX_DURATION_SECONDS } }],
+        },
+      ],
+      null,
+      false
+    );
+
+    musicLengthFilter.set('tracks');
+    expect(get(filteredPosts).map((post) => post.id)).toEqual(['post-1', 'post-2']);
+  });
+});

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -7,6 +7,7 @@ export * from './commentStore';
 export * from './commentFeedStore';
 export * from './sectionLinksStore';
 export * from './sectionLinksFeedStore';
+export * from './musicFilterStore';
 export * from './websocketStore';
 export * from './searchStore';
 export * from './pwaStore';

--- a/frontend/src/stores/musicFilterStore.ts
+++ b/frontend/src/stores/musicFilterStore.ts
@@ -1,0 +1,81 @@
+import { writable, derived } from 'svelte/store';
+import { activeSection } from './sectionStore';
+import { posts, type Link, type LinkMetadata } from './postStore';
+
+export type MusicLengthFilter = 'all' | 'tracks' | 'sets';
+
+const STORAGE_KEY = 'music-length-filter';
+export const TRACK_MAX_DURATION_SECONDS = 15 * 60;
+
+function isValidFilter(value: string | null): value is MusicLengthFilter {
+  return value === 'all' || value === 'tracks' || value === 'sets';
+}
+
+function getInitialFilter(): MusicLengthFilter {
+  if (typeof window === 'undefined') {
+    return 'all';
+  }
+
+  const stored = window.sessionStorage?.getItem(STORAGE_KEY) ?? null;
+  return isValidFilter(stored) ? stored : 'all';
+}
+
+export function extractDurationSeconds(metadata?: LinkMetadata | null): number | null {
+  const duration = metadata?.duration;
+  if (typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0) {
+    return null;
+  }
+  return duration;
+}
+
+export function matchesMusicLengthFilter(
+  durationSeconds: number | null,
+  filter: MusicLengthFilter
+): boolean {
+  if (filter === 'all') {
+    return true;
+  }
+  if (durationSeconds === null) {
+    return false;
+  }
+  if (filter === 'tracks') {
+    return durationSeconds < TRACK_MAX_DURATION_SECONDS;
+  }
+  return durationSeconds >= TRACK_MAX_DURATION_SECONDS;
+}
+
+function getDurationFromLinks(links?: Link[]): number | null {
+  if (!links || links.length === 0) {
+    return null;
+  }
+
+  for (const link of links) {
+    const duration = extractDurationSeconds(link.metadata);
+    if (duration !== null) {
+      return duration;
+    }
+  }
+
+  return null;
+}
+
+export const musicLengthFilter = writable<MusicLengthFilter>(getInitialFilter());
+
+if (typeof window !== 'undefined') {
+  musicLengthFilter.subscribe((value) => {
+    window.sessionStorage?.setItem(STORAGE_KEY, value);
+  });
+}
+
+export const filteredPosts = derived(
+  [posts, activeSection, musicLengthFilter],
+  ([$posts, $activeSection, $musicLengthFilter]) => {
+    if ($activeSection?.type !== 'music' || $musicLengthFilter === 'all') {
+      return $posts;
+    }
+
+    return $posts.filter((post) =>
+      matchesMusicLengthFilter(getDurationFromLinks(post.links), $musicLengthFilter)
+    );
+  }
+);


### PR DESCRIPTION
## Summary
- add a music length filter store with session persistence
- apply length filtering to music feeds and add empty-state messaging
- add filter controls to the music links header and update tests

## Testing
- task frontend:check
- task frontend:test

Closes #754