### PR TITLE
Allow removing attached link metadata when editing a post

### DIFF
--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -125,6 +125,8 @@ type UpdatePostRequest struct {
 	Content string              `json:"content"`
 	Links   *[]LinkRequest      `json:"links,omitempty"`
 	Images  *[]PostImageRequest `json:"images,omitempty"`
+	// RemoveLinkMetadata removes the primary link preview from the post.
+	RemoveLinkMetadata bool `json:"remove_link_metadata,omitempty"`
 	// MentionUsernames contains explicitly selected mentions from the client.
 	MentionUsernames []string `json:"mention_usernames,omitempty"`
 }

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -376,6 +376,48 @@ describe('PostCard', () => {
         { url: 'https://example.com/article' },
         { url: 'https://example.com/extra' },
       ],
+      removeLinkMetadata: false,
+      mentionUsernames: [],
+    });
+  });
+
+  it('removes link preview when editing', async () => {
+    authStore.setUser({
+      id: 'user-1',
+      username: 'Sander',
+      email: 'sander@example.com',
+      isAdmin: false,
+      totpEnabled: false,
+    });
+
+    const postWithLink: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://example.com',
+          metadata: {
+            url: 'https://example.com',
+            title: 'Example',
+            description: 'Desc',
+          },
+        },
+      ],
+    };
+
+    apiUpdatePost.mockResolvedValue({
+      post: { ...postWithLink, links: [] },
+    });
+
+    render(PostCard, { post: postWithLink });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await fireEvent.click(screen.getByLabelText('Remove link'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(apiUpdatePost).toHaveBeenCalledWith('post-1', {
+      content: 'Hello world',
+      links: undefined,
+      removeLinkMetadata: true,
       mentionUsernames: [],
     });
   });
@@ -422,6 +464,7 @@ describe('PostCard', () => {
         { url: 'https://example.com/article' },
         { url: 'https://cdn.example.com/uploads/new.png' },
       ],
+      removeLinkMetadata: false,
       mentionUsernames: [],
     });
   });
@@ -451,6 +494,7 @@ describe('PostCard', () => {
     expect(apiUpdatePost).toHaveBeenCalledWith('post-1', {
       content: 'Hello world',
       links: undefined,
+      removeLinkMetadata: false,
       mentionUsernames: [],
     });
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -559,12 +559,14 @@ class ApiClient {
     data: {
       content: string;
       links?: { url: string; highlights?: { timestamp: number; label?: string }[] }[] | null;
+      removeLinkMetadata?: boolean;
       mentionUsernames?: string[];
     }
   ): Promise<{ post: Post }> {
     const response = await this.patch<{ post: ApiPost }>(`/posts/${postId}`, {
       content: data.content,
       links: data.links ?? undefined,
+      remove_link_metadata: data.removeLinkMetadata ?? undefined,
       mention_usernames: data.mentionUsernames ?? [],
     });
     return { post: mapApiPost(response.post) };


### PR DESCRIPTION
## Summary
- add edit-mode link preview removal with optional re-add flow
- send removal flag to backend and delete link metadata with audit logging
- cover backend and frontend removal scenarios with tests

## Testing
- task backend:test
- task frontend:test

Closes #749