### PR TITLE
Add timestamp click-to-seek functionality for music embeds

### DIFF
--- a/frontend/src/components/posts/HighlightDisplay.svelte
+++ b/frontend/src/components/posts/HighlightDisplay.svelte
@@ -1,19 +1,86 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import type { Highlight } from '../../stores/postStore';
   import { formatHighlightTimestamp } from '../../lib/highlights';
 
   export let highlights: Highlight[] = [];
+  export let onSeek: ((timestamp: number) => Promise<boolean> | boolean) | undefined = undefined;
+  export let unsupportedMessage: string = 'Seeking not supported for this embed.';
+
+  let activeTimestamp: number | null = null;
+  let feedbackMessage: string | null = null;
+  let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const resetFeedback = () => {
+    if (feedbackTimeout) {
+      clearTimeout(feedbackTimeout);
+      feedbackTimeout = null;
+    }
+  };
+
+  const setFeedback = (message: string) => {
+    resetFeedback();
+    feedbackMessage = message;
+    feedbackTimeout = setTimeout(() => {
+      feedbackMessage = null;
+      activeTimestamp = null;
+      feedbackTimeout = null;
+    }, 2000);
+  };
+
+  const handleSeek = async (timestamp: number) => {
+    if (!onSeek) return;
+
+    try {
+      const result = await onSeek(timestamp);
+      if (result) {
+        activeTimestamp = timestamp;
+        setFeedback(`Jumped to ${formatHighlightTimestamp(timestamp)}.`);
+        return;
+      }
+      setFeedback(unsupportedMessage);
+    } catch {
+      setFeedback('Unable to seek right now.');
+    }
+  };
+
+  onDestroy(() => {
+    resetFeedback();
+  });
 </script>
 
 {#if highlights?.length}
   <div class="flex flex-wrap gap-2" aria-label="Highlights">
     {#each highlights as highlight (highlight.timestamp + '-' + (highlight.label ?? ''))}
-      <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
-        <span class="font-medium text-gray-800">{formatHighlightTimestamp(highlight.timestamp)}</span>
-        {#if highlight.label}
-          <span class="ml-1 text-gray-600">{highlight.label}</span>
-        {/if}
-      </span>
+      {#if onSeek}
+        <button
+          type="button"
+          class={`inline-flex items-center rounded-full px-2 py-1 text-xs transition-colors ${
+            activeTimestamp === highlight.timestamp
+              ? 'bg-blue-100 text-blue-800'
+              : 'bg-gray-100 text-gray-700 hover:bg-blue-50 hover:text-blue-800'
+          }`}
+          on:click={() => handleSeek(highlight.timestamp)}
+          aria-pressed={activeTimestamp === highlight.timestamp ? 'true' : 'false'}
+        >
+          <span class="font-medium">{formatHighlightTimestamp(highlight.timestamp)}</span>
+          {#if highlight.label}
+            <span class="ml-1 text-gray-600">{highlight.label}</span>
+          {/if}
+        </button>
+      {:else}
+        <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
+          <span class="font-medium text-gray-800">{formatHighlightTimestamp(highlight.timestamp)}</span>
+          {#if highlight.label}
+            <span class="ml-1 text-gray-600">{highlight.label}</span>
+          {/if}
+        </span>
+      {/if}
     {/each}
   </div>
+  {#if feedbackMessage}
+    <p class="mt-2 text-xs text-gray-500" role="status" aria-live="polite">
+      {feedbackMessage}
+    </p>
+  {/if}
 {/if}

--- a/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
 
 const { default: HighlightDisplay } = await import('../HighlightDisplay.svelte');
 
@@ -40,5 +40,27 @@ describe('HighlightDisplay', () => {
     });
 
     expect(queryByLabelText('Highlights')).not.toBeInTheDocument();
+  });
+
+  it('renders clickable highlights when seek handler is provided', () => {
+    const onSeek = vi.fn().mockResolvedValue(true);
+    const { getByRole } = render(HighlightDisplay, {
+      highlights: [{ timestamp: 5, label: 'Intro' }],
+      onSeek,
+    });
+
+    expect(getByRole('button', { name: '00:05 Intro' })).toBeInTheDocument();
+  });
+
+  it('shows feedback when seeking is unsupported', async () => {
+    const onSeek = vi.fn().mockResolvedValue(false);
+    const { getByRole, getByText } = render(HighlightDisplay, {
+      highlights: [{ timestamp: 30 }],
+      onSeek,
+      unsupportedMessage: 'Seeking not supported',
+    });
+
+    await fireEvent.click(getByRole('button', { name: '00:30' }));
+    expect(getByText('Seeking not supported')).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
+++ b/frontend/src/lib/components/embeds/SoundCloudEmbed.svelte
@@ -1,12 +1,55 @@
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import type { EmbedController } from '../../embeds/controller';
+  import { loadSoundCloudApi } from '../../embeds/soundcloudApi';
+
   export let embedUrl: string;
   export let height: number | undefined = undefined;
   export let title: string | undefined = undefined;
+  export let onReady: ((controller: EmbedController) => void) | undefined = undefined;
 
   const fallbackHeight = 166;
+  const readyEvent = 'ready';
+
+  let iframeElement: HTMLIFrameElement | null = null;
+  let widget: {
+    seekTo: (milliseconds: number) => void;
+    play: () => void;
+    bind: (event: string, handler: () => void) => void;
+    unbind: (event: string) => void;
+  } | null = null;
 
   $: resolvedHeight = height && height > 0 ? height : fallbackHeight;
   $: iframeTitle = title ? `SoundCloud player: ${title}` : 'SoundCloud player';
+
+  onMount(async () => {
+    if (typeof window === 'undefined' || !iframeElement) return;
+
+    try {
+      const SC = await loadSoundCloudApi();
+      widget = SC.Widget(iframeElement);
+      widget.bind(readyEvent, () => {
+        if (!onReady) return;
+        onReady({
+          provider: 'soundcloud',
+          supportsSeeking: true,
+          seekTo: async (seconds: number) => {
+            if (!widget) return;
+            widget.seekTo(seconds * 1000);
+            widget.play();
+          },
+        });
+      });
+    } catch {
+      // Ignore failed initialization; controller won't be provided.
+    }
+  });
+
+  onDestroy(() => {
+    if (widget?.unbind) {
+      widget.unbind(readyEvent);
+    }
+  });
 </script>
 
 <div class="mt-3 rounded-lg border border-gray-200 overflow-hidden bg-white">
@@ -20,5 +63,6 @@
     allow="autoplay"
     style="border: 0;"
     data-testid="soundcloud-embed"
+    bind:this={iframeElement}
   ></iframe>
 </div>

--- a/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
+++ b/frontend/src/lib/components/embeds/YouTubeEmbed.svelte
@@ -1,17 +1,74 @@
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import type { EmbedController } from '../../embeds/controller';
+  import { loadYouTubeApi, type YouTubePlayer } from '../../embeds/youtubeApi';
+
   export let embedUrl: string;
   export let title: string = 'YouTube video';
+  export let onReady: ((controller: EmbedController) => void) | undefined = undefined;
+
+  let iframeElement: HTMLIFrameElement | null = null;
+  let player: YouTubePlayer | null = null;
+
+  const buildApiEmbedUrl = (value: string, origin?: string): string => {
+    try {
+      const url = new URL(value);
+      url.searchParams.set('enablejsapi', '1');
+      if (origin) {
+        url.searchParams.set('origin', origin);
+      }
+      return url.toString();
+    } catch {
+      return value;
+    }
+  };
+
+  $: apiEmbedUrl =
+    typeof window === 'undefined' ? embedUrl : buildApiEmbedUrl(embedUrl, window.location.origin);
+
+  onMount(async () => {
+    if (typeof window === 'undefined' || !iframeElement) return;
+
+    try {
+      const ytApi = await loadYouTubeApi();
+      player = new ytApi.Player(iframeElement, {
+        events: {
+          onReady: () => {
+            if (!onReady) return;
+            onReady({
+              provider: 'youtube',
+              supportsSeeking: true,
+              seekTo: async (seconds: number) => {
+                if (!player) return;
+                player.seekTo(seconds, true);
+                player.playVideo();
+              },
+            });
+          },
+        },
+      });
+    } catch {
+      // Ignore failed initialization; controller won't be provided.
+    }
+  });
+
+  onDestroy(() => {
+    if (player && typeof player.destroy === 'function') {
+      player.destroy();
+    }
+  });
 </script>
 
 <div class="relative w-full overflow-hidden rounded-lg bg-black" style="padding-top: 56.25%;">
   <iframe
     class="absolute inset-0 h-full w-full"
-    src={embedUrl}
+    src={apiEmbedUrl}
     title={title}
     sandbox="allow-scripts allow-same-origin allow-presentation"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen
     referrerpolicy="strict-origin-when-cross-origin"
     data-testid="youtube-embed-frame"
+    bind:this={iframeElement}
   ></iframe>
 </div>

--- a/frontend/src/lib/components/embeds/__tests__/YouTubeEmbed.test.ts
+++ b/frontend/src/lib/components/embeds/__tests__/YouTubeEmbed.test.ts
@@ -10,7 +10,9 @@ describe('YouTubeEmbed', () => {
 
     const iframe = screen.getByTestId('youtube-embed-frame');
     expect(iframe).toBeInTheDocument();
-    expect(iframe).toHaveAttribute('src', embedUrl);
+    const src = iframe.getAttribute('src') ?? '';
+    expect(src).toContain(embedUrl);
+    expect(src).toContain('enablejsapi=1');
     expect(iframe).toHaveAttribute('allowfullscreen');
   });
 });

--- a/frontend/src/lib/embeds/controller.ts
+++ b/frontend/src/lib/embeds/controller.ts
@@ -1,0 +1,7 @@
+export type EmbedProvider = 'youtube' | 'soundcloud' | 'spotify' | 'bandcamp' | 'unknown';
+
+export type EmbedController = {
+  provider: EmbedProvider;
+  supportsSeeking: boolean;
+  seekTo: (seconds: number) => Promise<void>;
+};

--- a/frontend/src/lib/embeds/soundcloudApi.ts
+++ b/frontend/src/lib/embeds/soundcloudApi.ts
@@ -1,0 +1,40 @@
+let apiPromise: Promise<NonNullable<Window['SC']>> | null = null;
+
+const SOUNDCLOUD_WIDGET_API_SRC = 'https://w.soundcloud.com/player/api.js';
+
+export const loadSoundCloudApi = (): Promise<NonNullable<Window['SC']>> => {
+  if (apiPromise) return apiPromise;
+
+  apiPromise = new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') {
+      reject(new Error('SoundCloud API can only be loaded in the browser.'));
+      return;
+    }
+
+    if (window.SC?.Widget) {
+      resolve(window.SC);
+      return;
+    }
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[data-soundcloud-widget-api="true"]`
+    );
+
+    if (existingScript) {
+      existingScript.addEventListener('load', () => resolve(window.SC as NonNullable<Window['SC']>));
+      existingScript.addEventListener('error', () => reject(new Error('Failed to load SoundCloud API.')));
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = SOUNDCLOUD_WIDGET_API_SRC;
+    script.async = true;
+    script.defer = true;
+    script.dataset.soundcloudWidgetApi = 'true';
+    script.onload = () => resolve(window.SC as NonNullable<Window['SC']>);
+    script.onerror = () => reject(new Error('Failed to load SoundCloud API.'));
+    document.head.appendChild(script);
+  });
+
+  return apiPromise;
+};

--- a/frontend/src/lib/embeds/youtubeApi.ts
+++ b/frontend/src/lib/embeds/youtubeApi.ts
@@ -1,0 +1,57 @@
+export type YouTubePlayer = {
+  seekTo: (seconds: number, allowSeekAhead: boolean) => void;
+  playVideo: () => void;
+  destroy: () => void;
+};
+
+export type YouTubeApi = {
+  Player: new (element: HTMLElement, options: { events?: { onReady?: () => void } }) => YouTubePlayer;
+};
+
+let apiPromise: Promise<YouTubeApi> | null = null;
+
+const YOUTUBE_IFRAME_API_SRC = 'https://www.youtube.com/iframe_api';
+
+export const loadYouTubeApi = (): Promise<YouTubeApi> => {
+  if (apiPromise) return apiPromise;
+
+  apiPromise = new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') {
+      reject(new Error('YouTube API can only be loaded in the browser.'));
+      return;
+    }
+
+    if (window.YT?.Player) {
+      resolve(window.YT as YouTubeApi);
+      return;
+    }
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      `script[data-youtube-iframe-api="true"]`
+    );
+
+    const previousHandler = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      if (typeof previousHandler === 'function') {
+        previousHandler();
+      }
+      if (window.YT?.Player) {
+        resolve(window.YT as YouTubeApi);
+      } else {
+        reject(new Error('YouTube API failed to initialize.'));
+      }
+    };
+
+    if (!existingScript) {
+      const script = document.createElement('script');
+      script.src = YOUTUBE_IFRAME_API_SRC;
+      script.async = true;
+      script.defer = true;
+      script.dataset.youtubeIframeApi = 'true';
+      script.onerror = () => reject(new Error('Failed to load YouTube API.'));
+      document.head.appendChild(script);
+    }
+  });
+
+  return apiPromise;
+};

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -10,3 +10,27 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+type SoundCloudWidget = {
+  seekTo: (milliseconds: number) => void;
+  play: () => void;
+  bind: (event: string, handler: () => void) => void;
+  unbind: (event: string) => void;
+};
+
+declare namespace YT {
+  class Player {
+    constructor(element: HTMLElement, options: { events?: { onReady?: () => void } });
+    seekTo(seconds: number, allowSeekAhead: boolean): void;
+    playVideo(): void;
+    destroy(): void;
+  }
+}
+
+interface Window {
+  YT?: typeof YT;
+  onYouTubeIframeAPIReady?: () => void;
+  SC?: {
+    Widget: (element: HTMLIFrameElement) => SoundCloudWidget;
+  };
+}


### PR DESCRIPTION
## Summary
- add embed controller abstraction with YouTube/SoundCloud API loading
- wire highlight clicks to seek with feedback and unsupported messaging
- add tests and typings for embed controllers

Closes #752