### PR TITLE
Add button to trigger recipe parser when adding link to recipe post

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -348,6 +348,7 @@ func main() {
 
 	// Link preview route (protected with CSRF - POST only, prevents SSRF)
 	mux.Handle("/api/v1/links/preview", requireAuthCSRF(http.HandlerFunc(linkHandler.PreviewLink)))
+	mux.Handle("/api/v1/links/parse-recipe", requireAuthCSRF(http.HandlerFunc(linkHandler.ParseRecipe)))
 	mux.Handle("/api/v1/metrics/vitals", requireAuth(http.HandlerFunc(frontendMetricsHandler.RecordFrontendMetrics)))
 
 	// Notification routes (protected)

--- a/backend/internal/handlers/links.go
+++ b/backend/internal/handlers/links.go
@@ -93,3 +93,80 @@ func (h *LinkHandler) PreviewLink(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 }
+
+// ParseRecipe handles POST /api/v1/links/parse-recipe.
+func (h *LinkHandler) ParseRecipe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	if !services.GetConfigService().IsLinkMetadataEnabled() {
+		writeError(r.Context(), w, http.StatusForbidden, "LINK_METADATA_DISABLED", "Link previews are disabled")
+		return
+	}
+
+	var req models.LinkPreviewRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	trimmedURL := strings.TrimSpace(req.URL)
+	if trimmedURL == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, "URL_REQUIRED", "URL is required")
+		return
+	}
+
+	if len(trimmedURL) > 2048 {
+		writeError(r.Context(), w, http.StatusBadRequest, "URL_TOO_LONG", "Link URL must be less than 2048 characters")
+		return
+	}
+
+	observability.RecordLinkMetadataFetchAttempt(r.Context(), 1)
+	start := time.Now()
+	embed, _ := linkmeta.ExtractEmbed(r.Context(), trimmedURL)
+	metadata, err := linkmeta.FetchMetadata(r.Context(), trimmedURL)
+	observability.RecordLinkMetadataFetchDuration(r.Context(), time.Since(start))
+	domain := linkmeta.ExtractDomain(trimmedURL)
+	if err != nil {
+		errorType := linkmeta.ClassifyFetchError(err)
+		observability.RecordLinkMetadataFetchFailure(r.Context(), 1, domain, errorType)
+		observability.LogWarn(r.Context(), "recipe metadata fetch failed", "link_url", trimmedURL, "link_domain", domain, "error_type", errorType, "error", err.Error())
+		writeError(r.Context(), w, http.StatusBadGateway, "RECIPE_PARSE_FAILED", "Failed to parse recipe")
+		return
+	}
+
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	metadata = linkmeta.ApplyEmbedMetadata(metadata, embed)
+	if _, ok := metadata["url"]; !ok {
+		metadata["url"] = trimmedURL
+	}
+
+	recipe, ok := metadata["recipe"]
+	if !ok || recipe == nil {
+		observability.RecordLinkMetadataFetchFailure(r.Context(), 1, domain, "recipe_not_found")
+		observability.LogWarn(r.Context(), "recipe metadata not found", "link_url", trimmedURL, "link_domain", domain)
+		writeError(r.Context(), w, http.StatusUnprocessableEntity, "RECIPE_NOT_FOUND", "No recipe data found")
+		return
+	}
+
+	observability.RecordLinkMetadataFetchSuccess(r.Context(), 1)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(models.LinkPreviewResponse{Metadata: metadata}); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode recipe parse response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}

--- a/frontend/src/components/posts/LinkPreview.svelte
+++ b/frontend/src/components/posts/LinkPreview.svelte
@@ -5,58 +5,66 @@
   export let onRemove: (() => void) | undefined = undefined;
 </script>
 
-<div class="flex items-start gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg">
-  {#if metadata.image}
-    <img
-      src={metadata.image}
-      alt={metadata.title || 'Link preview'}
-      class="w-16 h-16 object-cover rounded flex-shrink-0"
-    />
-  {:else}
-    <div class="w-16 h-16 bg-gray-200 rounded flex-shrink-0 flex items-center justify-center">
-      <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-        />
-      </svg>
-    </div>
-  {/if}
+<div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+  <div class="flex items-start gap-3">
+    {#if metadata.image}
+      <img
+        src={metadata.image}
+        alt={metadata.title || 'Link preview'}
+        class="w-16 h-16 object-cover rounded flex-shrink-0"
+      />
+    {:else}
+      <div class="w-16 h-16 bg-gray-200 rounded flex-shrink-0 flex items-center justify-center">
+        <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+          />
+        </svg>
+      </div>
+    {/if}
 
-  <div class="flex-1 min-w-0">
-    {#if metadata.provider}
-      <span class="text-xs text-gray-500 uppercase tracking-wide">
-        {metadata.provider}
-      </span>
+    <div class="flex-1 min-w-0">
+      {#if metadata.provider}
+        <span class="text-xs text-gray-500 uppercase tracking-wide">
+          {metadata.provider}
+        </span>
+      {/if}
+      {#if metadata.title}
+        <h4 class="text-sm font-medium text-gray-900 truncate">
+          {metadata.title}
+        </h4>
+      {/if}
+      {#if metadata.description}
+        <p class="text-xs text-gray-600 line-clamp-2">{metadata.description}</p>
+      {/if}
+      <p class="text-xs text-gray-400 truncate mt-1">{metadata.url}</p>
+    </div>
+
+    {#if onRemove}
+      <button
+        type="button"
+        on:click={onRemove}
+        class="p-1 text-gray-400 hover:text-gray-600"
+        aria-label="Remove link"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
     {/if}
-    {#if metadata.title}
-      <h4 class="text-sm font-medium text-gray-900 truncate">
-        {metadata.title}
-      </h4>
-    {/if}
-    {#if metadata.description}
-      <p class="text-xs text-gray-600 line-clamp-2">{metadata.description}</p>
-    {/if}
-    <p class="text-xs text-gray-400 truncate mt-1">{metadata.url}</p>
   </div>
 
-  {#if onRemove}
-    <button
-      type="button"
-      on:click={onRemove}
-      class="p-1 text-gray-400 hover:text-gray-600"
-      aria-label="Remove link"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M6 18L18 6M6 6l12 12"
-        />
-      </svg>
-    </button>
+  {#if $$slots.footer}
+    <div class="mt-3">
+      <slot name="footer" />
+    </div>
   {/if}
 </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -576,6 +576,10 @@ class ApiClient {
     return this.post('/links/preview', { url });
   }
 
+  async parseRecipe(url: string): Promise<{ metadata: LinkMetadata }> {
+    return this.post('/links/parse-recipe', { url });
+  }
+
   async createComment(data: CreateCommentRequest): Promise<{ comment: ApiComment }> {
     return this.post('/comments', {
       post_id: data.postId,


### PR DESCRIPTION
## Summary
- add recipe parse endpoint and wiring for link parsing
- surface Parse Recipe / Re-parse button in recipe post form and render RecipeCard
- extend tests for link parsing flow and recipe parsing UI

## Testing
- `go build ./...`
- `go test ./internal/handlers -run Link -v`
- `task frontend:check`
- `task frontend:test`

Closes #751