### PR TITLE
Fix recipe stats not updating after save until page reload

### DIFF
--- a/frontend/src/components/recipes/RecipeSaveButton.svelte
+++ b/frontend/src/components/recipes/RecipeSaveButton.svelte
@@ -205,9 +205,12 @@
       recipeStore.applyUnsave(postId, category);
     }
 
-    const delta = toAdd.length - toRemove.length;
-    if (delta !== 0) {
-      postStore.updateRecipeSaveCount(postId, delta);
+    const wasSaved = previous.size > 0;
+    const willBeSaved = next.size > 0;
+    if (!wasSaved && willBeSaved) {
+      postStore.updateRecipeSaveCount(postId, 1);
+    } else if (wasSaved && !willBeSaved) {
+      postStore.updateRecipeSaveCount(postId, -1);
     }
   }
 
@@ -223,9 +226,12 @@
       recipeStore.applySavedRecipes([buildOptimisticRecipe(category)]);
     }
 
-    const delta = removed.length - added.length;
-    if (delta !== 0) {
-      postStore.updateRecipeSaveCount(postId, delta);
+    const wasSaved = previous.size > 0;
+    const willBeSaved = next.size > 0;
+    if (!wasSaved && willBeSaved) {
+      postStore.updateRecipeSaveCount(postId, -1);
+    } else if (wasSaved && !willBeSaved) {
+      postStore.updateRecipeSaveCount(postId, 1);
     }
   }
 

--- a/frontend/src/components/recipes/RecipeSaveButton.svelte
+++ b/frontend/src/components/recipes/RecipeSaveButton.svelte
@@ -9,6 +9,7 @@
     type SavedRecipe as StoreSavedRecipe,
     type RecipeCategory as StoreRecipeCategory,
   } from '../../stores/recipeStore';
+  import { postStore } from '../../stores/postStore';
   import { currentUser } from '../../stores/authStore';
 
   export let postId: string;
@@ -203,6 +204,11 @@
     for (const category of toRemove) {
       recipeStore.applyUnsave(postId, category);
     }
+
+    const delta = toAdd.length - toRemove.length;
+    if (delta !== 0) {
+      postStore.updateRecipeSaveCount(postId, delta);
+    }
   }
 
   function revertOptimisticChange(previous: Set<string>, next: Set<string>) {
@@ -215,6 +221,11 @@
 
     for (const category of removed) {
       recipeStore.applySavedRecipes([buildOptimisticRecipe(category)]);
+    }
+
+    const delta = removed.length - added.length;
+    if (delta !== 0) {
+      postStore.updateRecipeSaveCount(postId, delta);
     }
   }
 

--- a/frontend/src/stores/__tests__/recipeStore.test.ts
+++ b/frontend/src/stores/__tests__/recipeStore.test.ts
@@ -170,6 +170,54 @@ describe('recipeStore', () => {
     expect(post?.recipeStats?.saveCount).toBe(1);
   });
 
+  it('save count does not change when toggling categories while still saved', async () => {
+    apiSaveRecipe.mockResolvedValue({
+      saved_recipes: [
+        {
+          id: 'save-4',
+          user_id: 'user-1',
+          post_id: 'post-4',
+          category: 'Weeknight',
+          created_at: '2024-01-02T00:00:00Z',
+        },
+      ],
+    });
+    apiUnsaveRecipe.mockResolvedValue(undefined);
+
+    recipeStore.applySavedRecipes([
+      {
+        id: 'save-4a',
+        userId: 'user-1',
+        postId: 'post-4',
+        category: 'Favorites',
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    postStore.setPosts(
+      [
+        {
+          id: 'post-4',
+          userId: 'user-1',
+          sectionId: 'section-1',
+          content: 'Recipe 4',
+          createdAt: '2024-01-01T00:00:00Z',
+          recipeStats: { saveCount: 5, cookCount: 0, averageRating: null },
+        },
+      ],
+      null,
+      false
+    );
+
+    await recipeStore.saveRecipe('post-4', ['Weeknight']);
+    let post = get(postStore).posts.find((item) => item.id === 'post-4');
+    expect(post?.recipeStats?.saveCount).toBe(5);
+
+    await recipeStore.unsaveRecipe('post-4', 'Favorites');
+    post = get(postStore).posts.find((item) => item.id === 'post-4');
+    expect(post?.recipeStats?.saveCount).toBe(5);
+  });
+
   it('updateCategory renames saved recipe categories', async () => {
     apiUpdateCategory.mockResolvedValue({
       category: {

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -224,6 +224,48 @@ function createPostStore() {
           };
         }),
       })),
+    updateRecipeSaveCount: (postId: string, delta: number) =>
+      update((state) => ({
+        ...state,
+        posts: state.posts.map((post) => {
+          if (post.id !== postId) {
+            return post;
+          }
+          const currentStats = post.recipeStats ?? post.recipe_stats ?? {
+            saveCount: 0,
+            cookCount: 0,
+            averageRating: null,
+          };
+          const nextSaveCount = Math.max(0, currentStats.saveCount + delta);
+          const nextStats = { ...currentStats, saveCount: nextSaveCount };
+          return {
+            ...post,
+            recipeStats: nextStats,
+            recipe_stats: nextStats,
+          };
+        }),
+      })),
+    setRecipeSaveCount: (postId: string, saveCount: number) =>
+      update((state) => ({
+        ...state,
+        posts: state.posts.map((post) => {
+          if (post.id !== postId) {
+            return post;
+          }
+          const currentStats = post.recipeStats ?? post.recipe_stats ?? {
+            saveCount: 0,
+            cookCount: 0,
+            averageRating: null,
+          };
+          const nextSaveCount = Math.max(0, Number.isFinite(saveCount) ? saveCount : 0);
+          const nextStats = { ...currentStats, saveCount: nextSaveCount };
+          return {
+            ...post,
+            recipeStats: nextStats,
+            recipe_stats: nextStats,
+          };
+        }),
+      })),
     toggleReaction: (postId: string, emoji: string) =>
       update((state) => ({
         ...state,

--- a/frontend/src/stores/recipeStore.ts
+++ b/frontend/src/stores/recipeStore.ts
@@ -8,7 +8,7 @@ import {
   type CookLogWithPost as ApiCookLogWithPost,
 } from '../services/api';
 import { mapApiPost, type ApiPost } from './postMapper';
-import type { Post } from './postStore';
+import { postStore, type Post } from './postStore';
 
 const DEFAULT_RECIPE_CATEGORY = 'Uncategorized';
 
@@ -107,6 +107,19 @@ function addSavedRecipeToMap(
   const filtered = existing.filter((item) => item.id !== savedRecipe.id && item.postId !== savedRecipe.postId);
   next.set(savedRecipe.category, [...filtered, savedRecipe]);
   return next;
+}
+
+function getSavedCategoriesForPost(
+  map: Map<string, SavedRecipe[]>,
+  postId: string
+): Set<string> {
+  const categories = new Set<string>();
+  for (const [category, recipes] of map.entries()) {
+    if (recipes.some((recipe) => recipe.postId === postId)) {
+      categories.add(category);
+    }
+  }
+  return categories;
 }
 
 function removeSavedRecipeFromMap(
@@ -257,6 +270,15 @@ function extractCategoryId(payload: unknown): string | null {
   return typeof categoryId === 'string' && categoryId.length > 0 ? categoryId : null;
 }
 
+async function refreshPostSaveCount(postId: string): Promise<void> {
+  try {
+    const response = await api.getPostSaves(postId);
+    postStore.setRecipeSaveCount(postId, response.save_count);
+  } catch {
+    // Ignore transient failures; the next event or refresh will reconcile.
+  }
+}
+
 const initialState: RecipeState = {
   savedRecipes: new Map(),
   categories: [],
@@ -383,17 +405,31 @@ function createRecipeStore() {
       }),
     saveRecipe: async (postId: string, categories: string[]): Promise<void> => {
       try {
+        const existing = getSavedCategoriesForPost(get(recipeStore).savedRecipes, postId);
+        const normalized = categories
+          .map((category) => category.trim())
+          .filter((category) => category.length > 0);
+        const unique = Array.from(new Set(normalized));
+        const delta = unique.filter((category) => !existing.has(category)).length;
         const response = await api.saveRecipe(postId, categories);
         const savedRecipes = (response.saved_recipes ?? []).map(mapApiSavedRecipe);
         recipeStore.applySavedRecipes(savedRecipes);
+        if (delta > 0) {
+          postStore.updateRecipeSaveCount(postId, delta);
+        }
       } catch (error) {
         recipeStore.setError(error instanceof Error ? error.message : 'Failed to save recipe');
       }
     },
     unsaveRecipe: async (postId: string, category?: string): Promise<void> => {
       try {
+        const existing = getSavedCategoriesForPost(get(recipeStore).savedRecipes, postId);
+        const delta = category === undefined ? existing.size : existing.has(category) ? 1 : 0;
         await api.unsaveRecipe(postId, category);
         recipeStore.applyUnsave(postId, category);
+        if (delta > 0) {
+          postStore.updateRecipeSaveCount(postId, -delta);
+        }
       } catch (error) {
         recipeStore.setError(error instanceof Error ? error.message : 'Failed to unsave recipe');
       }
@@ -509,21 +545,25 @@ export const sortedCategories = derived(recipeStore, ($store) =>
   })
 );
 
-export function handleRecipeSavedEvent(payload: unknown): void {
+export async function handleRecipeSavedEvent(payload: unknown): Promise<void> {
   const recipes = extractSavedRecipes(payload).map(mapApiSavedRecipe);
-  if (recipes.length === 0) {
-    return;
+  if (recipes.length > 0) {
+    recipeStore.applySavedRecipes(recipes);
   }
-  recipeStore.applySavedRecipes(recipes);
+  const postId = extractPostId(payload);
+  if (postId) {
+    await refreshPostSaveCount(postId);
+  }
 }
 
-export function handleRecipeUnsavedEvent(payload: unknown): void {
+export async function handleRecipeUnsavedEvent(payload: unknown): Promise<void> {
   const postId = extractPostId(payload);
   if (!postId) {
     return;
   }
   const category = extractCategoryName(payload) ?? undefined;
   recipeStore.applyUnsave(postId, category);
+  await refreshPostSaveCount(postId);
 }
 
 export function handleCookLogCreatedEvent(payload: unknown): void {


### PR DESCRIPTION
## Summary
- update recipe save counts immediately via post store updates
- refresh save counts on recipe save/unsave websocket events
- adjust recipe store tests to cover realtime stat updates

Closes #744
