### PR TITLE
Allow heart reactions on music timestamps

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -147,6 +147,7 @@ func main() {
 	commentHandler := handlers.NewCommentHandler(dbConn, redisConn, pushService)
 	adminHandler := handlers.NewAdminHandler(dbConn, redisConn)
 	reactionHandler := handlers.NewReactionHandler(dbConn, redisConn, pushService)
+	highlightReactionHandler := handlers.NewHighlightReactionHandler(dbConn, redisConn)
 	cookLogHandler := handlers.NewCookLogHandler(dbConn, redisConn)
 	userHandler := handlers.NewUserHandler(dbConn)
 	sectionHandler := handlers.NewSectionHandler(dbConn)
@@ -285,21 +286,23 @@ func main() {
 
 	// Post routes - route to appropriate handler
 	postRouteHandler := newPostRouteHandler(requireAuth, requireAuthCSRF, postRouteDeps{
-		getThread:              commentHandler.GetThread,
-		restorePost:            postHandler.RestorePost,
-		addReactionToPost:      reactionHandler.AddReactionToPost,
-		removeReactionFromPost: reactionHandler.RemoveReactionFromPost,
-		getReactions:           reactionHandler.GetPostReactions,
-		saveRecipe:             savedRecipeHandler.SaveRecipe,
-		unsaveRecipe:           savedRecipeHandler.UnsaveRecipe,
-		getPostSaves:           savedRecipeHandler.GetPostSaves,
-		logCook:                cookLogHandler.LogCook,
-		updateCookLog:          cookLogHandler.UpdateCookLog,
-		removeCookLog:          cookLogHandler.RemoveCookLog,
-		getCookLogs:            cookLogHandler.GetPostCookLogs,
-		getPost:                postHandler.GetPost,
-		updatePost:             postHandler.UpdatePost,
-		deletePost:             postHandler.DeletePost,
+		getThread:               commentHandler.GetThread,
+		restorePost:             postHandler.RestorePost,
+		addHighlightReaction:    highlightReactionHandler.AddHighlightReaction,
+		removeHighlightReaction: highlightReactionHandler.RemoveHighlightReaction,
+		addReactionToPost:       reactionHandler.AddReactionToPost,
+		removeReactionFromPost:  reactionHandler.RemoveReactionFromPost,
+		getReactions:            reactionHandler.GetPostReactions,
+		saveRecipe:              savedRecipeHandler.SaveRecipe,
+		unsaveRecipe:            savedRecipeHandler.UnsaveRecipe,
+		getPostSaves:            savedRecipeHandler.GetPostSaves,
+		logCook:                 cookLogHandler.LogCook,
+		updateCookLog:           cookLogHandler.UpdateCookLog,
+		removeCookLog:           cookLogHandler.RemoveCookLog,
+		getCookLogs:             cookLogHandler.GetPostCookLogs,
+		getPost:                 postHandler.GetPost,
+		updatePost:              postHandler.UpdatePost,
+		deletePost:              postHandler.DeletePost,
 	})
 	mux.Handle("/api/v1/posts/", postRouteHandler)
 

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -10,21 +10,23 @@ import (
 type authMiddleware = middleware.Middleware
 
 type postRouteDeps struct {
-	getThread              http.HandlerFunc
-	restorePost            http.HandlerFunc
-	addReactionToPost      http.HandlerFunc
-	removeReactionFromPost http.HandlerFunc
-	getReactions           http.HandlerFunc
-	saveRecipe             http.HandlerFunc
-	unsaveRecipe           http.HandlerFunc
-	getPostSaves           http.HandlerFunc
-	logCook                http.HandlerFunc
-	updateCookLog          http.HandlerFunc
-	removeCookLog          http.HandlerFunc
-	getCookLogs            http.HandlerFunc
-	getPost                http.HandlerFunc
-	updatePost             http.HandlerFunc
-	deletePost             http.HandlerFunc
+	getThread               http.HandlerFunc
+	restorePost             http.HandlerFunc
+	addHighlightReaction    http.HandlerFunc
+	removeHighlightReaction http.HandlerFunc
+	addReactionToPost       http.HandlerFunc
+	removeReactionFromPost  http.HandlerFunc
+	getReactions            http.HandlerFunc
+	saveRecipe              http.HandlerFunc
+	unsaveRecipe            http.HandlerFunc
+	getPostSaves            http.HandlerFunc
+	logCook                 http.HandlerFunc
+	updateCookLog           http.HandlerFunc
+	removeCookLog           http.HandlerFunc
+	getCookLogs             http.HandlerFunc
+	getPost                 http.HandlerFunc
+	updatePost              http.HandlerFunc
+	deletePost              http.HandlerFunc
 }
 
 func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddleware, deps postRouteDeps) http.Handler {
@@ -37,6 +39,16 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/restore") {
 			// POST /api/v1/posts/{id}/restore
 			requireAuthCSRF(http.HandlerFunc(deps.restorePost)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && isHighlightReactionPath(r.URL.Path) {
+			// POST /api/v1/posts/{id}/highlights/{highlightId}/reactions
+			requireAuthCSRF(http.HandlerFunc(deps.addHighlightReaction)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && isHighlightReactionPath(r.URL.Path) {
+			// DELETE /api/v1/posts/{id}/highlights/{highlightId}/reactions
+			requireAuthCSRF(http.HandlerFunc(deps.removeHighlightReaction)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/reactions") {
@@ -142,6 +154,11 @@ func isPostIDPath(path string) bool {
 		return false
 	}
 	return parts[1] == "api" && parts[2] == "v1" && parts[3] == "posts" && parts[4] != ""
+}
+
+func isHighlightReactionPath(path string) bool {
+	trimmed := strings.TrimSuffix(path, "/")
+	return strings.Contains(trimmed, "/highlights/") && strings.HasSuffix(trimmed, "/reactions")
 }
 
 func isCommentIDPath(path string) bool {

--- a/backend/internal/handlers/highlight_reaction.go
+++ b/backend/internal/handlers/highlight_reaction.go
@@ -1,0 +1,191 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+type HighlightReactionHandler struct {
+	service     *services.HighlightReactionService
+	postService *services.PostService
+	redis       *redis.Client
+}
+
+func NewHighlightReactionHandler(db *sql.DB, redisClient *redis.Client) *HighlightReactionHandler {
+	return &HighlightReactionHandler{
+		service:     services.NewHighlightReactionService(db),
+		postService: services.NewPostService(db),
+		redis:       redisClient,
+	}
+}
+
+// AddHighlightReaction handles POST /api/v1/posts/{postId}/highlights/{highlightId}/reactions
+func (h *HighlightReactionHandler) AddHighlightReaction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, highlightID, err := extractHighlightReactionPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid highlight reaction path")
+		return
+	}
+
+	response, err := h.service.AddReaction(r.Context(), postID, highlightID, userID)
+	if err != nil {
+		switch err.Error() {
+		case "invalid highlight id":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_HIGHLIGHT_ID", err.Error())
+		case "highlight not found":
+			writeError(r.Context(), w, http.StatusNotFound, "HIGHLIGHT_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "HIGHLIGHT_REACTION_FAILED", "Failed to add highlight reaction")
+		}
+		return
+	}
+
+	publishCtx, cancel := publishContext()
+	linkID, _, decodeErr := models.DecodeHighlightID(highlightID)
+	if decodeErr == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(postPrefix, postID), "highlight_reaction_added", highlightReactionEventData{
+			PostID:      postID,
+			LinkID:      linkID,
+			HighlightID: highlightID,
+			UserID:      userID,
+		})
+		if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+			_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "highlight_reaction_added", highlightReactionEventData{
+				PostID:      postID,
+				LinkID:      linkID,
+				HighlightID: highlightID,
+				UserID:      userID,
+			})
+		}
+	}
+	observability.RecordReactionAdded(publishCtx, "❤️")
+	cancel()
+
+	observability.LogInfo(r.Context(), "highlight reaction added",
+		"post_id", postID.String(),
+		"highlight_id", highlightID,
+		"user_id", userID.String(),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode highlight reaction response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// RemoveHighlightReaction handles DELETE /api/v1/posts/{postId}/highlights/{highlightId}/reactions
+func (h *HighlightReactionHandler) RemoveHighlightReaction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, highlightID, err := extractHighlightReactionPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid highlight reaction path")
+		return
+	}
+
+	response, err := h.service.RemoveReaction(r.Context(), postID, highlightID, userID)
+	if err != nil {
+		switch err.Error() {
+		case "invalid highlight id":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_HIGHLIGHT_ID", err.Error())
+			return
+		case "highlight not found":
+			writeError(r.Context(), w, http.StatusNotFound, "HIGHLIGHT_NOT_FOUND", err.Error())
+			return
+		case "reaction not found":
+			w.WriteHeader(http.StatusNoContent)
+			return
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "HIGHLIGHT_REACTION_FAILED", "Failed to remove highlight reaction")
+			return
+		}
+	}
+
+	publishCtx, cancel := publishContext()
+	linkID, _, decodeErr := models.DecodeHighlightID(highlightID)
+	if decodeErr == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(postPrefix, postID), "highlight_reaction_removed", highlightReactionEventData{
+			PostID:      postID,
+			LinkID:      linkID,
+			HighlightID: highlightID,
+			UserID:      userID,
+		})
+		if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+			_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "highlight_reaction_removed", highlightReactionEventData{
+				PostID:      postID,
+				LinkID:      linkID,
+				HighlightID: highlightID,
+				UserID:      userID,
+			})
+		}
+	}
+	observability.RecordReactionRemoved(publishCtx, "❤️")
+	cancel()
+
+	observability.LogInfo(r.Context(), "highlight reaction removed",
+		"post_id", postID.String(),
+		"highlight_id", highlightID,
+		"user_id", userID.String(),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode highlight reaction response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+func extractHighlightReactionPath(path string) (uuid.UUID, string, error) {
+	postID, err := extractPostIDFromPath(path)
+	if err != nil {
+		return uuid.UUID{}, "", err
+	}
+	parts := strings.Split(strings.TrimSuffix(path, "/"), "/")
+	for i, part := range parts {
+		if part == "highlights" && i+1 < len(parts) {
+			return postID, parts[i+1], nil
+		}
+	}
+	return uuid.UUID{}, "", errors.New("highlight ID not found in path")
+}

--- a/backend/internal/handlers/pubsub.go
+++ b/backend/internal/handlers/pubsub.go
@@ -51,6 +51,13 @@ type reactionEventData struct {
 	Emoji     string     `json:"emoji"`
 }
 
+type highlightReactionEventData struct {
+	PostID      uuid.UUID `json:"post_id"`
+	LinkID      uuid.UUID `json:"link_id"`
+	HighlightID string    `json:"highlight_id"`
+	UserID      uuid.UUID `json:"user_id"`
+}
+
 type recipeSavedEventData struct {
 	PostID     uuid.UUID `json:"post_id"`
 	UserID     uuid.UUID `json:"user_id"`

--- a/backend/internal/models/highlight_id.go
+++ b/backend/internal/models/highlight_id.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type highlightIDPayload struct {
+	LinkID    string `json:"link_id"`
+	Timestamp int    `json:"timestamp"`
+	Label     string `json:"label,omitempty"`
+}
+
+// EncodeHighlightID builds a stable, URL-safe identifier for a highlight.
+func EncodeHighlightID(linkID uuid.UUID, highlight Highlight) (string, error) {
+	payload := highlightIDPayload{
+		LinkID:    linkID.String(),
+		Timestamp: highlight.Timestamp,
+		Label:     highlight.Label,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode highlight id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+// DecodeHighlightID parses a highlight identifier into link ID and highlight data.
+func DecodeHighlightID(value string) (uuid.UUID, Highlight, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return uuid.UUID{}, Highlight{}, fmt.Errorf("invalid highlight id")
+	}
+	var payload highlightIDPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return uuid.UUID{}, Highlight{}, fmt.Errorf("invalid highlight id")
+	}
+	linkID, err := uuid.Parse(payload.LinkID)
+	if err != nil {
+		return uuid.UUID{}, Highlight{}, fmt.Errorf("invalid highlight id")
+	}
+	highlight := Highlight{
+		Timestamp: payload.Timestamp,
+		Label:     payload.Label,
+	}
+	return linkID, highlight, nil
+}

--- a/backend/internal/models/highlight_reaction.go
+++ b/backend/internal/models/highlight_reaction.go
@@ -1,0 +1,7 @@
+package models
+
+type HighlightReactionResponse struct {
+	HighlightID   string `json:"highlight_id"`
+	HeartCount    int    `json:"heart_count"`
+	ViewerReacted bool   `json:"viewer_reacted"`
+}

--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -75,8 +75,11 @@ type LinkRequest struct {
 
 // Highlight represents a timestamped highlight for a link.
 type Highlight struct {
-	Timestamp int    `json:"timestamp"`
-	Label     string `json:"label,omitempty"`
+	ID            string `json:"id,omitempty"`
+	Timestamp     int    `json:"timestamp"`
+	Label         string `json:"label,omitempty"`
+	HeartCount    int    `json:"heart_count,omitempty"`
+	ViewerReacted bool   `json:"viewer_reacted,omitempty"`
 }
 
 const (

--- a/backend/internal/services/highlight_reaction.go
+++ b/backend/internal/services/highlight_reaction.go
@@ -1,0 +1,218 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const highlightReactionEmoji = "❤️"
+
+type HighlightReactionService struct {
+	db *sql.DB
+}
+
+func NewHighlightReactionService(db *sql.DB) *HighlightReactionService {
+	return &HighlightReactionService{db: db}
+}
+
+func (s *HighlightReactionService) AddReaction(ctx context.Context, postID uuid.UUID, highlightID string, userID uuid.UUID) (*models.HighlightReactionResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.highlight_reactions").Start(ctx, "HighlightReactionService.AddReaction")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.String("user_id", userID.String()),
+	)
+	defer span.End()
+
+	linkID, highlight, err := s.resolveHighlight(ctx, postID, highlightID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO highlight_reactions (id, user_id, link_id, highlight_id, created_at)
+		VALUES (gen_random_uuid(), $1, $2, $3, now())
+		ON CONFLICT (user_id, highlight_id) DO NOTHING
+	`, userID, linkID, highlightID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to create highlight reaction: %w", err)
+	}
+
+	state, err := s.getReactionState(ctx, highlightID, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.logHighlightReactionAudit(ctx, "add_highlight_reaction", userID, map[string]interface{}{
+		"post_id":      postID.String(),
+		"link_id":      linkID.String(),
+		"highlight_id": highlightID,
+		"timestamp":    highlight.Timestamp,
+		"label":        highlight.Label,
+		"emoji":        highlightReactionEmoji,
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return state, nil
+}
+
+func (s *HighlightReactionService) RemoveReaction(ctx context.Context, postID uuid.UUID, highlightID string, userID uuid.UUID) (*models.HighlightReactionResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.highlight_reactions").Start(ctx, "HighlightReactionService.RemoveReaction")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.String("user_id", userID.String()),
+	)
+	defer span.End()
+
+	linkID, highlight, err := s.resolveHighlight(ctx, postID, highlightID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM highlight_reactions
+		WHERE user_id = $1 AND highlight_id = $2
+	`, userID, highlightID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to remove highlight reaction: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to confirm highlight reaction removal: %w", err)
+	}
+	if rowsAffected == 0 {
+		notFoundErr := errors.New("reaction not found")
+		recordSpanError(span, notFoundErr)
+		return nil, notFoundErr
+	}
+
+	state, err := s.getReactionState(ctx, highlightID, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.logHighlightReactionAudit(ctx, "remove_highlight_reaction", userID, map[string]interface{}{
+		"post_id":      postID.String(),
+		"link_id":      linkID.String(),
+		"highlight_id": highlightID,
+		"timestamp":    highlight.Timestamp,
+		"label":        highlight.Label,
+		"emoji":        highlightReactionEmoji,
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return state, nil
+}
+
+func (s *HighlightReactionService) getReactionState(ctx context.Context, highlightID string, userID uuid.UUID) (*models.HighlightReactionResponse, error) {
+	var count int
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM highlight_reactions
+		WHERE highlight_id = $1
+	`, highlightID).Scan(&count); err != nil {
+		return nil, fmt.Errorf("failed to fetch highlight reaction count: %w", err)
+	}
+
+	viewerReacted := false
+	if userID != uuid.Nil {
+		var exists bool
+		if err := s.db.QueryRowContext(ctx, `
+			SELECT EXISTS(
+				SELECT 1
+				FROM highlight_reactions
+				WHERE highlight_id = $1 AND user_id = $2
+			)
+		`, highlightID, userID).Scan(&exists); err != nil {
+			return nil, fmt.Errorf("failed to fetch viewer highlight reaction: %w", err)
+		}
+		viewerReacted = exists
+	}
+
+	return &models.HighlightReactionResponse{
+		HighlightID:   highlightID,
+		HeartCount:    count,
+		ViewerReacted: viewerReacted,
+	}, nil
+}
+
+func (s *HighlightReactionService) resolveHighlight(ctx context.Context, postID uuid.UUID, highlightID string) (uuid.UUID, models.Highlight, error) {
+	linkID, highlight, err := models.DecodeHighlightID(highlightID)
+	if err != nil {
+		return uuid.UUID{}, models.Highlight{}, errors.New("invalid highlight id")
+	}
+
+	var metadataJSON sql.NullString
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT metadata
+		FROM links
+		WHERE id = $1 AND post_id = $2
+	`, linkID, postID).Scan(&metadataJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.UUID{}, models.Highlight{}, errors.New("highlight not found")
+		}
+		return uuid.UUID{}, models.Highlight{}, fmt.Errorf("failed to fetch highlight: %w", err)
+	}
+	if !metadataJSON.Valid {
+		return uuid.UUID{}, models.Highlight{}, errors.New("highlight not found")
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(metadataJSON.String), &metadata); err != nil {
+		return uuid.UUID{}, models.Highlight{}, fmt.Errorf("failed to parse highlight metadata: %w", err)
+	}
+
+	raw, ok := metadata["highlights"]
+	if !ok {
+		return uuid.UUID{}, models.Highlight{}, errors.New("highlight not found")
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return uuid.UUID{}, models.Highlight{}, fmt.Errorf("failed to parse highlight metadata: %w", err)
+	}
+	var highlights []models.Highlight
+	if err := json.Unmarshal(encoded, &highlights); err != nil {
+		return uuid.UUID{}, models.Highlight{}, fmt.Errorf("failed to parse highlight metadata: %w", err)
+	}
+
+	for _, candidate := range highlights {
+		if candidate.Timestamp == highlight.Timestamp && candidate.Label == highlight.Label {
+			return linkID, candidate, nil
+		}
+	}
+
+	return uuid.UUID{}, models.Highlight{}, errors.New("highlight not found")
+}
+
+func (s *HighlightReactionService) logHighlightReactionAudit(ctx context.Context, action string, userID uuid.UUID, metadata map[string]interface{}) error {
+	auditService := NewAuditService(s.db)
+	if err := auditService.LogAuditWithMetadata(ctx, action, uuid.Nil, userID, metadata); err != nil {
+		observability.LogError(ctx, observability.ErrorLog{
+			Message:    "failed to create highlight reaction audit log",
+			Code:       "HIGHLIGHT_REACTION_AUDIT_FAILED",
+			StatusCode: 500,
+			Err:        err,
+		})
+		return fmt.Errorf("failed to create highlight reaction audit log: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/services/highlight_reaction_test.go
+++ b/backend/internal/services/highlight_reaction_test.go
@@ -40,7 +40,7 @@ func TestAddHighlightReactionCreatesAuditLog(t *testing.T) {
 	}
 
 	service := NewHighlightReactionService(db)
-	response, err := service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	response, created, err := service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
 	if err != nil {
 		t.Fatalf("AddReaction failed: %v", err)
 	}
@@ -49,6 +49,17 @@ func TestAddHighlightReactionCreatesAuditLog(t *testing.T) {
 	}
 	if !response.ViewerReacted {
 		t.Fatalf("expected viewer reacted true")
+	}
+	if !created {
+		t.Fatalf("expected created to be true")
+	}
+
+	_, created, err = service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("AddReaction retry failed: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created false on retry")
 	}
 
 	var auditCount int
@@ -94,7 +105,7 @@ func TestRemoveHighlightReactionCreatesAuditLog(t *testing.T) {
 	}
 
 	service := NewHighlightReactionService(db)
-	_, err = service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	_, _, err = service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
 	if err != nil {
 		t.Fatalf("AddReaction failed: %v", err)
 	}

--- a/backend/internal/services/highlight_reaction_test.go
+++ b/backend/internal/services/highlight_reaction_test.go
@@ -1,0 +1,124 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestAddHighlightReactionCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "highlightreactor", "highlightreactor@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Music", "music")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Highlight post")
+
+	linkID := uuid.New()
+	highlight := models.Highlight{Timestamp: 30, Label: "Drop"}
+	metadata := map[string]interface{}{"highlights": []models.Highlight{highlight}}
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("failed to marshal highlight metadata: %v", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO links (id, post_id, url, metadata, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, linkID, uuid.MustParse(postID), "https://example.com", string(metadataBytes))
+	if err != nil {
+		t.Fatalf("failed to create link: %v", err)
+	}
+
+	highlightID, err := models.EncodeHighlightID(linkID, highlight)
+	if err != nil {
+		t.Fatalf("failed to encode highlight id: %v", err)
+	}
+
+	service := NewHighlightReactionService(db)
+	response, err := service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("AddReaction failed: %v", err)
+	}
+	if response.HeartCount != 1 {
+		t.Fatalf("expected heart count 1, got %d", response.HeartCount)
+	}
+	if !response.ViewerReacted {
+		t.Fatalf("expected viewer reacted true")
+	}
+
+	var auditCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_logs
+		WHERE action = 'add_highlight_reaction' AND target_user_id = $1
+	`, uuid.MustParse(userID)).Scan(&auditCount); err != nil {
+		t.Fatalf("failed to query audit logs: %v", err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("expected 1 audit log, got %d", auditCount)
+	}
+}
+
+func TestRemoveHighlightReactionCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "highlightremove", "highlightremove@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Music", "music")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Highlight post")
+
+	linkID := uuid.New()
+	highlight := models.Highlight{Timestamp: 45, Label: "Verse"}
+	metadata := map[string]interface{}{"highlights": []models.Highlight{highlight}}
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("failed to marshal highlight metadata: %v", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO links (id, post_id, url, metadata, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, linkID, uuid.MustParse(postID), "https://example.com", string(metadataBytes))
+	if err != nil {
+		t.Fatalf("failed to create link: %v", err)
+	}
+
+	highlightID, err := models.EncodeHighlightID(linkID, highlight)
+	if err != nil {
+		t.Fatalf("failed to encode highlight id: %v", err)
+	}
+
+	service := NewHighlightReactionService(db)
+	_, err = service.AddReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("AddReaction failed: %v", err)
+	}
+
+	response, err := service.RemoveReaction(context.Background(), uuid.MustParse(postID), highlightID, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("RemoveReaction failed: %v", err)
+	}
+	if response.HeartCount != 0 {
+		t.Fatalf("expected heart count 0, got %d", response.HeartCount)
+	}
+	if response.ViewerReacted {
+		t.Fatalf("expected viewer reacted false")
+	}
+
+	var auditCount int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_logs
+		WHERE action = 'remove_highlight_reaction' AND target_user_id = $1
+	`, uuid.MustParse(userID)).Scan(&auditCount); err != nil {
+		t.Fatalf("failed to query audit logs: %v", err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("expected 1 audit log, got %d", auditCount)
+	}
+}

--- a/backend/internal/testutil/testutil.go
+++ b/backend/internal/testutil/testutil.go
@@ -96,6 +96,7 @@ func CleanupTables(t *testing.T, db *sql.DB) {
 			mfa_backup_codes,
 			auth_events,
 			audit_logs,
+			highlight_reactions,
 			push_subscriptions,
 			notifications,
 			mentions,

--- a/backend/migrations/031_create_highlight_reactions_table.down.sql
+++ b/backend/migrations/031_create_highlight_reactions_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS highlight_reactions;

--- a/backend/migrations/031_create_highlight_reactions_table.up.sql
+++ b/backend/migrations/031_create_highlight_reactions_table.up.sql
@@ -2,7 +2,7 @@
 CREATE TABLE highlight_reactions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id),
-  link_id UUID NOT NULL REFERENCES links(id),
+  link_id UUID NOT NULL REFERENCES links(id) ON DELETE CASCADE,
   highlight_id TEXT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT now(),
 

--- a/backend/migrations/031_create_highlight_reactions_table.up.sql
+++ b/backend/migrations/031_create_highlight_reactions_table.up.sql
@@ -1,0 +1,14 @@
+-- Create highlight_reactions table
+CREATE TABLE highlight_reactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  link_id UUID NOT NULL REFERENCES links(id),
+  highlight_id TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+
+  CONSTRAINT unique_highlight_reaction UNIQUE(user_id, highlight_id)
+);
+
+CREATE INDEX idx_highlight_reactions_user_id ON highlight_reactions(user_id);
+CREATE INDEX idx_highlight_reactions_link_id ON highlight_reactions(link_id);
+CREATE INDEX idx_highlight_reactions_highlight_id ON highlight_reactions(highlight_id);

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -464,6 +464,33 @@
     }
   }
 
+  async function toggleHighlightReaction(linkId: string, highlight: { id?: string; viewerReacted?: boolean }) {
+    if (!highlight.id) {
+      return;
+    }
+    const hasReacted = Boolean(highlight.viewerReacted);
+    const delta = hasReacted ? -1 : 1;
+    postStore.updateHighlightReaction(post.id, linkId, highlight.id, delta, !hasReacted);
+
+    try {
+      if (hasReacted) {
+        await api.removeHighlightReaction(post.id, highlight.id);
+      } else {
+        await api.addHighlightReaction(post.id, highlight.id);
+      }
+    } catch (e) {
+      logError('Failed to toggle highlight reaction', { postId: post.id, highlightId: highlight.id }, e);
+      postStore.updateHighlightReaction(post.id, linkId, highlight.id, -delta, hasReacted);
+    }
+  }
+
+  function handleHighlightReaction(highlight: { id?: string; viewerReacted?: boolean }) {
+    if (!primaryLink?.id) {
+      return;
+    }
+    void toggleHighlightReaction(primaryLink.id, highlight);
+  }
+
   function getProviderIcon(provider: string | undefined): string {
     switch (provider) {
       case 'spotify':
@@ -1599,6 +1626,7 @@
           <HighlightDisplay
             highlights={primaryLink.highlights}
             onSeek={highlightEmbedProvider ? handleHighlightSeek : undefined}
+            onToggleReaction={primaryLink?.id ? handleHighlightReaction : undefined}
             unsupportedMessage={highlightSeekMessage}
           />
         </div>

--- a/frontend/src/components/posts/HighlightDisplay.svelte
+++ b/frontend/src/components/posts/HighlightDisplay.svelte
@@ -5,16 +5,26 @@
 
   export let highlights: Highlight[] = [];
   export let onSeek: ((timestamp: number) => Promise<boolean> | boolean) | undefined = undefined;
+  export let onToggleReaction: ((highlight: Highlight) => Promise<void> | void) | undefined = undefined;
   export let unsupportedMessage: string = 'Seeking not supported for this embed.';
 
   let activeTimestamp: number | null = null;
   let feedbackMessage: string | null = null;
   let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
+  let reactionPulseId: string | null = null;
+  let reactionPulseTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const resetFeedback = () => {
     if (feedbackTimeout) {
       clearTimeout(feedbackTimeout);
       feedbackTimeout = null;
+    }
+  };
+
+  const resetReactionPulse = () => {
+    if (reactionPulseTimeout) {
+      clearTimeout(reactionPulseTimeout);
+      reactionPulseTimeout = null;
     }
   };
 
@@ -44,38 +54,73 @@
     }
   };
 
+  const handleToggleReaction = (highlight: Highlight) => {
+    if (!onToggleReaction) return;
+    const key = highlight.id ?? `${highlight.timestamp}-${highlight.label ?? ''}`;
+    reactionPulseId = key;
+    resetReactionPulse();
+    reactionPulseTimeout = setTimeout(() => {
+      reactionPulseId = null;
+      reactionPulseTimeout = null;
+    }, 450);
+    onToggleReaction(highlight);
+  };
+
   onDestroy(() => {
     resetFeedback();
+    resetReactionPulse();
   });
 </script>
 
 {#if highlights?.length}
   <div class="flex flex-wrap gap-2" aria-label="Highlights">
-    {#each highlights as highlight (highlight.timestamp + '-' + (highlight.label ?? ''))}
-      {#if onSeek}
-        <button
-          type="button"
-          class={`inline-flex items-center rounded-full px-2 py-1 text-xs transition-colors ${
-            activeTimestamp === highlight.timestamp
-              ? 'bg-blue-100 text-blue-800'
-              : 'bg-gray-100 text-gray-700 hover:bg-blue-50 hover:text-blue-800'
-          }`}
-          on:click={() => handleSeek(highlight.timestamp)}
-          aria-pressed={activeTimestamp === highlight.timestamp ? 'true' : 'false'}
-        >
-          <span class="font-medium">{formatHighlightTimestamp(highlight.timestamp)}</span>
-          {#if highlight.label}
-            <span class="ml-1 text-gray-600">{highlight.label}</span>
-          {/if}
-        </button>
-      {:else}
-        <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
-          <span class="font-medium text-gray-800">{formatHighlightTimestamp(highlight.timestamp)}</span>
-          {#if highlight.label}
-            <span class="ml-1 text-gray-600">{highlight.label}</span>
-          {/if}
-        </span>
-      {/if}
+    {#each highlights as highlight (highlight.id ?? highlight.timestamp + '-' + (highlight.label ?? ''))}
+      <div class="inline-flex items-center gap-1">
+        {#if onSeek}
+          <button
+            type="button"
+            class={`inline-flex items-center rounded-full px-2 py-1 text-xs transition-colors ${
+              activeTimestamp === highlight.timestamp
+                ? 'bg-blue-100 text-blue-800'
+                : 'bg-gray-100 text-gray-700 hover:bg-blue-50 hover:text-blue-800'
+            }`}
+            on:click={() => handleSeek(highlight.timestamp)}
+            aria-pressed={activeTimestamp === highlight.timestamp ? 'true' : 'false'}
+          >
+            <span class="font-medium">{formatHighlightTimestamp(highlight.timestamp)}</span>
+            {#if highlight.label}
+              <span class="ml-1 text-gray-600">{highlight.label}</span>
+            {/if}
+          </button>
+        {:else}
+          <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
+            <span class="font-medium text-gray-800">{formatHighlightTimestamp(highlight.timestamp)}</span>
+            {#if highlight.label}
+              <span class="ml-1 text-gray-600">{highlight.label}</span>
+            {/if}
+          </span>
+        {/if}
+        {#if onToggleReaction}
+          <button
+            type="button"
+            class={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs transition-transform duration-150 ${
+              highlight.viewerReacted ? 'bg-rose-100 text-rose-700' : 'bg-gray-100 text-gray-600'
+            } ${reactionPulseId === (highlight.id ?? `${highlight.timestamp}-${highlight.label ?? ''}`) ? 'scale-110' : ''}`}
+            on:click={() => handleToggleReaction(highlight)}
+            aria-pressed={highlight.viewerReacted ? 'true' : 'false'}
+            aria-label={`Heart highlight ${formatHighlightTimestamp(highlight.timestamp)}${
+              highlight.label ? ` ${highlight.label}` : ''
+            }`}
+          >
+            <span class="text-base leading-none">
+              {highlight.viewerReacted ? '❤️' : '🤍'}
+            </span>
+            {#if (highlight.heartCount ?? 0) > 0}
+              <span class="font-medium">{highlight.heartCount}</span>
+            {/if}
+          </button>
+        {/if}
+      </div>
     {/each}
   </div>
   {#if feedbackMessage}

--- a/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
+++ b/frontend/src/components/posts/__tests__/HighlightDisplay.test.ts
@@ -63,4 +63,18 @@ describe('HighlightDisplay', () => {
     await fireEvent.click(getByRole('button', { name: '00:30' }));
     expect(getByText('Seeking not supported')).toBeInTheDocument();
   });
+
+  it('renders heart reactions and toggles on click', async () => {
+    const onToggleReaction = vi.fn();
+    const { getByRole, queryByText } = render(HighlightDisplay, {
+      highlights: [{ id: 'highlight-1', timestamp: 5, label: 'Intro', heartCount: 2, viewerReacted: true }],
+      onToggleReaction,
+    });
+
+    expect(getByRole('button', { name: 'Heart highlight 00:05 Intro' })).toBeInTheDocument();
+    expect(queryByText('2')).toBeInTheDocument();
+
+    await fireEvent.click(getByRole('button', { name: 'Heart highlight 00:05 Intro' }));
+    expect(onToggleReaction).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -81,6 +81,12 @@ export interface ApiReactionGroup {
   users: ApiReactionUser[];
 }
 
+export interface ApiHighlightReactionResponse {
+  highlight_id: string;
+  heart_count: number;
+  viewer_reacted: boolean;
+}
+
 export interface ApiUserSummary {
   id: string;
   username: string;
@@ -639,6 +645,23 @@ class ApiClient {
 
   async removeCommentReaction(commentId: string, emoji: string): Promise<void> {
     await this.delete(`/comments/${commentId}/reactions/${encodeURIComponent(emoji)}`);
+  }
+
+  async addHighlightReaction(
+    postId: string,
+    highlightId: string
+  ): Promise<ApiHighlightReactionResponse> {
+    return this.post(
+      `/posts/${postId}/highlights/${encodeURIComponent(highlightId)}/reactions`,
+      {}
+    );
+  }
+
+  async removeHighlightReaction(
+    postId: string,
+    highlightId: string
+  ): Promise<ApiHighlightReactionResponse> {
+    return this.delete(`/posts/${postId}/highlights/${encodeURIComponent(highlightId)}/reactions`);
   }
 
   async saveRecipe(postId: string, categories: string[]): Promise<{ saved_recipes: SavedRecipe[] }> {

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -111,6 +111,35 @@ describe('postStore', () => {
     expect(state.posts[0].reactionCounts?.['🔥']).toBeUndefined();
   });
 
+  it('updateHighlightReaction updates counts and viewer state', () => {
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          links: [
+            {
+              id: 'link-1',
+              url: 'https://example.com',
+              highlights: [{ id: 'highlight-1', timestamp: 5, heartCount: 0, viewerReacted: false }],
+            },
+          ],
+        },
+      ],
+      null,
+      true
+    );
+
+    postStore.updateHighlightReaction('post-1', 'link-1', 'highlight-1', 1, true);
+    let state = get(postStore);
+    expect(state.posts[0].links?.[0].highlights?.[0].heartCount).toBe(1);
+    expect(state.posts[0].links?.[0].highlights?.[0].viewerReacted).toBe(true);
+
+    postStore.updateHighlightReaction('post-1', 'link-1', 'highlight-1', -1, false);
+    state = get(postStore);
+    expect(state.posts[0].links?.[0].highlights?.[0].heartCount).toBe(0);
+    expect(state.posts[0].links?.[0].highlights?.[0].viewerReacted).toBe(false);
+  });
+
   it('reset restores defaults', () => {
     postStore.setPosts([basePost], 'cursor-1', false);
     postStore.reset();

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -140,7 +140,15 @@ function normalizeHighlights(rawHighlights: unknown): Highlight[] | undefined {
       if (!item || typeof item !== 'object') {
         return null;
       }
-      const record = item as { timestamp?: unknown; label?: unknown };
+      const record = item as {
+        id?: unknown;
+        timestamp?: unknown;
+        label?: unknown;
+        heart_count?: unknown;
+        heartCount?: unknown;
+        viewer_reacted?: unknown;
+        viewerReacted?: unknown;
+      };
       if (typeof record.timestamp !== 'number' || !Number.isFinite(record.timestamp)) {
         return null;
       }
@@ -148,9 +156,21 @@ function normalizeHighlights(rawHighlights: unknown): Highlight[] | undefined {
         typeof record.label === 'string' && record.label.trim().length > 0
           ? record.label
           : undefined;
+      const id = typeof record.id === 'string' && record.id.trim().length > 0 ? record.id : undefined;
+      const heartCount =
+        normalizeNumber(record.heart_count ?? record.heartCount) ?? undefined;
+      const viewerReacted =
+        typeof record.viewer_reacted === 'boolean'
+          ? record.viewer_reacted
+          : typeof record.viewerReacted === 'boolean'
+            ? record.viewerReacted
+            : undefined;
       return {
         timestamp: record.timestamp,
         ...(label ? { label } : {}),
+        ...(id ? { id } : {}),
+        ...(typeof heartCount === 'number' ? { heartCount } : {}),
+        ...(typeof viewerReacted === 'boolean' ? { viewerReacted } : {}),
       } as Highlight;
     })
     .filter(Boolean) as Highlight[];

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -1,8 +1,11 @@
 import { writable, derived } from 'svelte/store';
 
 export interface Highlight {
+  id?: string;
   timestamp: number;
   label?: string;
+  heartCount?: number;
+  viewerReacted?: boolean;
 }
 
 export interface Link {
@@ -248,6 +251,48 @@ function createPostStore() {
             ...post,
             reactionCounts: counts,
             viewerReactions: Array.from(viewerReactions),
+          };
+        }),
+      })),
+    updateHighlightReaction: (
+      postId: string,
+      linkId: string,
+      highlightId: string,
+      delta: number,
+      viewerReacted?: boolean
+    ) =>
+      update((state) => ({
+        ...state,
+        posts: state.posts.map((post) => {
+          if (post.id !== postId) {
+            return post;
+          }
+          if (!post.links) {
+            return post;
+          }
+          const links = post.links.map((link) => {
+            if (link.id !== linkId || !link.highlights) {
+              return link;
+            }
+            const highlights = link.highlights.map((highlight) => {
+              if (highlight.id !== highlightId) {
+                return highlight;
+              }
+              const nextCount = Math.max(0, (highlight.heartCount ?? 0) + delta);
+              return {
+                ...highlight,
+                heartCount: nextCount,
+                viewerReacted: viewerReacted ?? highlight.viewerReacted,
+              };
+            });
+            return {
+              ...link,
+              highlights,
+            };
+          });
+          return {
+            ...post,
+            links,
           };
         }),
       })),

--- a/frontend/src/stores/websocketStore.ts
+++ b/frontend/src/stores/websocketStore.ts
@@ -52,6 +52,13 @@ interface WsReactionEvent {
   emoji: string;
 }
 
+interface WsHighlightReactionEvent {
+  post_id: string;
+  link_id: string;
+  highlight_id: string;
+  user_id: string;
+}
+
 interface WsSubscriptionPayload {
   sectionIds: string[];
 }
@@ -280,6 +287,40 @@ function connect() {
         if (payload.post_id) {
           postStore.updateReactionCount(payload.post_id, payload.emoji, -1);
         }
+        break;
+      }
+      case 'highlight_reaction_added': {
+        const payload = parsed.data as WsHighlightReactionEvent;
+        if (!payload?.post_id || !payload?.link_id || !payload?.highlight_id) {
+          break;
+        }
+        const userId = get(currentUser)?.id;
+        if (userId && payload.user_id === userId) {
+          break;
+        }
+        postStore.updateHighlightReaction(
+          payload.post_id,
+          payload.link_id,
+          payload.highlight_id,
+          1
+        );
+        break;
+      }
+      case 'highlight_reaction_removed': {
+        const payload = parsed.data as WsHighlightReactionEvent;
+        if (!payload?.post_id || !payload?.link_id || !payload?.highlight_id) {
+          break;
+        }
+        const userId = get(currentUser)?.id;
+        if (userId && payload.user_id === userId) {
+          break;
+        }
+        postStore.updateHighlightReaction(
+          payload.post_id,
+          payload.link_id,
+          payload.highlight_id,
+          -1
+        );
         break;
       }
       case 'notification': {


### PR DESCRIPTION
## Summary
- add highlight reaction persistence and API endpoints with audit logging and WebSocket events
- enrich music highlights with heart counts/viewer state via encoded highlight IDs
- add frontend heart toggle UI, realtime updates, and tests

## Testing
- `go test ./internal/services -run HighlightReaction -v` (skipped: `CLUBHOUSE_TEST_DATABASE_URL` not set)
- `cd frontend && npm run check`
- `cd frontend && npm run test -- -t "HighlightDisplay|websocketStore|postStore"`

Closes #753