### PR TITLE
Fix timestamp click-to-seek not working for music embeds

### DIFF
--- a/backend/internal/middleware/csp.go
+++ b/backend/internal/middleware/csp.go
@@ -11,7 +11,7 @@ func CSPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		csp := []string{
 			"default-src 'self'",
-			"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.youtube.com https://w.soundcloud.com",
 			"style-src 'self' 'unsafe-inline'",
 			"img-src 'self' data: https:",
 			"frame-src 'self' https://www.youtube-nocookie.com https://open.spotify.com https://w.soundcloud.com https://bandcamp.com",

--- a/backend/internal/middleware/csp_test.go
+++ b/backend/internal/middleware/csp_test.go
@@ -26,4 +26,10 @@ func TestCSPMiddlewareSetsHeader(t *testing.T) {
 	if !strings.Contains(header, "https://www.youtube-nocookie.com") {
 		t.Fatalf("expected youtube-nocookie in CSP, got %q", header)
 	}
+	if !strings.Contains(header, "https://www.youtube.com") {
+		t.Fatalf("expected youtube script-src in CSP, got %q", header)
+	}
+	if !strings.Contains(header, "https://w.soundcloud.com") {
+		t.Fatalf("expected soundcloud script-src in CSP, got %q", header)
+	}
 }


### PR DESCRIPTION
## Summary
- allow YouTube + SoundCloud widget APIs in CSP script-src so embed controllers can initialize
- extend CSP test coverage for the new script sources

## Testing
- `cd backend && go test ./internal/middleware -v`
- `task frontend:check`
- `task frontend:test`

Closes #774