### PR TITLE
Remove "Print recipe" button and "View original source" link from RecipeCard

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -1479,7 +1479,6 @@
         {:else if primaryLink && metadata?.recipe}
           <RecipeCard
             recipe={metadata.recipe}
-            sourceUrl={primaryLink.url}
             fallbackImage={metadata.image}
             fallbackTitle={metadata.title}
           />
@@ -1553,7 +1552,6 @@
         {:else if metadata.recipe}
           <RecipeCard
             recipe={metadata.recipe}
-            sourceUrl={primaryLink.url}
             fallbackImage={metadata.image}
             fallbackTitle={metadata.title}
           />

--- a/frontend/src/components/__tests__/RecipeCard.test.ts
+++ b/frontend/src/components/__tests__/RecipeCard.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe('RecipeCard', () => {
   it('renders collapsed summary by default', () => {
-    render(RecipeCard, { recipe, sourceUrl: 'https://example.com' });
+    render(RecipeCard, { recipe });
 
     expect(screen.getByTestId('recipe-title')).toHaveTextContent('Lemon Pasta');
     expect(screen.getByTestId('recipe-time')).toHaveTextContent('Prep: 10m');
@@ -42,7 +42,7 @@ describe('RecipeCard', () => {
   });
 
   it('expands to show ingredients, instructions, and checkboxes', async () => {
-    render(RecipeCard, { recipe, sourceUrl: 'https://example.com' });
+    render(RecipeCard, { recipe });
 
     await fireEvent.click(screen.getByTestId('recipe-toggle'));
 
@@ -56,7 +56,7 @@ describe('RecipeCard', () => {
   });
 
   it('copies ingredients to clipboard when requested', async () => {
-    render(RecipeCard, { recipe, sourceUrl: 'https://example.com' });
+    render(RecipeCard, { recipe });
 
     await fireEvent.click(screen.getByTestId('recipe-toggle'));
     await fireEvent.click(screen.getByTestId('recipe-copy'));
@@ -65,24 +65,4 @@ describe('RecipeCard', () => {
     expect(clipboard.writeText).toHaveBeenCalledWith('1 lemon\n200g pasta');
   });
 
-  it('opens a print window for the recipe', async () => {
-    const printWindow = {
-      document: {
-        open: vi.fn(),
-        write: vi.fn(),
-        close: vi.fn(),
-      },
-      focus: vi.fn(),
-      print: vi.fn(),
-      close: vi.fn(),
-    };
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(printWindow as unknown as Window);
-
-    render(RecipeCard, { recipe, sourceUrl: 'https://example.com' });
-    await fireEvent.click(screen.getByTestId('recipe-toggle'));
-    await fireEvent.click(screen.getByTestId('recipe-print'));
-
-    expect(openSpy).toHaveBeenCalled();
-    expect(printWindow.print).toHaveBeenCalled();
-  });
 });

--- a/frontend/src/components/posts/PostForm.svelte
+++ b/frontend/src/components/posts/PostForm.svelte
@@ -514,7 +514,6 @@
       {#if linkMetadata.recipe}
         <RecipeCard
           recipe={linkMetadata.recipe}
-          sourceUrl={linkMetadata.url}
           fallbackImage={linkMetadata.image}
           fallbackTitle={linkMetadata.title}
         />

--- a/frontend/src/components/recipes/RecipeCard.svelte
+++ b/frontend/src/components/recipes/RecipeCard.svelte
@@ -8,7 +8,6 @@
   import type { RecipeMetadata } from '../../stores/postStore';
 
   export let recipe: RecipeMetadata;
-  export let sourceUrl: string | null = null;
   export let fallbackImage: string | null = null;
   export let fallbackTitle: string | null = null;
 
@@ -81,70 +80,6 @@
         copiedIngredients = false;
       }, 2000);
     }
-  }
-
-  function escapeHtml(input: string) {
-    return input
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  function handlePrint() {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const printWindow = window.open('', '_blank', 'noopener,noreferrer');
-    if (!printWindow) {
-      window.print();
-      return;
-    }
-
-    const ingredientList = ingredients
-      .map((ingredient) => `<li>${escapeHtml(ingredient)}</li>`)
-      .join('');
-    const instructionList = instructions
-      .map((instruction) => `<li>${escapeHtml(instruction)}</li>`)
-      .join('');
-
-    const printHtml = `<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>${escapeHtml(recipeTitle)}</title>
-  <style>
-    body { font-family: "Georgia", serif; margin: 32px; color: #111827; }
-    h1 { margin: 0 0 8px; font-size: 28px; }
-    .meta { color: #4b5563; margin-bottom: 16px; }
-    .section { margin: 24px 0; }
-    ul, ol { padding-left: 20px; }
-    li { margin-bottom: 6px; }
-    img { max-width: 100%; height: auto; border-radius: 12px; margin-bottom: 16px; }
-  </style>
-</head>
-<body>
-  ${imageUrl ? `<img src="${escapeHtml(imageUrl)}" alt="${escapeHtml(recipeTitle)}" />` : ''}
-  <h1>${escapeHtml(recipeTitle)}</h1>
-  <div class="meta">
-    ${timeLabel ? escapeHtml(timeLabel) : ''}
-    ${!timeLabel && totalTimeLabel ? escapeHtml(totalTimeLabel) : ''}
-    ${yieldLabel ? ` · ${escapeHtml(yieldLabel)}` : ''}
-  </div>
-  ${recipe?.description ? `<p>${escapeHtml(recipe.description)}</p>` : ''}
-  ${ingredients.length > 0 ? `<div class="section"><h2>Ingredients</h2><ul>${ingredientList}</ul></div>` : ''}
-  ${instructions.length > 0 ? `<div class="section"><h2>Instructions</h2><ol>${instructionList}</ol></div>` : ''}
-</body>
-</html>`;
-
-    printWindow.document.open();
-    printWindow.document.write(printHtml);
-    printWindow.document.close();
-    printWindow.focus();
-    printWindow.print();
-    printWindow.close();
   }
 
   onDestroy(() => {
@@ -264,36 +199,7 @@
           </section>
         {/if}
 
-        <section class="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            class="rounded-full border border-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 hover:border-gray-300 hover:bg-gray-50"
-            on:click={handlePrint}
-            data-testid="recipe-print"
-          >
-            Print recipe
-          </button>
-          {#if sourceUrl}
-            <a
-              href={sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xs font-semibold text-blue-600 hover:text-blue-800"
-            >
-              View original source
-            </a>
-          {/if}
-        </section>
       </div>
     {/if}
   </div>
 </article>
-
-<style>
-  @media print {
-    .recipe-card button,
-    .recipe-card a {
-      display: none;
-    }
-  }
-</style>


### PR DESCRIPTION
## Summary
- remove the print/source UI block from RecipeCard
- drop the unused RecipeCard `sourceUrl` prop and update callers
- update RecipeCard tests to match the simplified UI

## Testing
- `frontend-checks` (via pre-commit hooks)

Closes #777