### PR TITLE
[Movies] Create WatchLog model and types

### DIFF
--- a/backend/internal/models/watch_log.go
+++ b/backend/internal/models/watch_log.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WatchLog represents a user's watched movie entry for a post.
+type WatchLog struct {
+	ID        uuid.UUID  `json:"id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	PostID    uuid.UUID  `json:"post_id"`
+	Rating    int        `json:"rating"`
+	Notes     *string    `json:"notes,omitempty"`
+	WatchedAt time.Time  `json:"watched_at"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+// LogWatchRequest represents the request body for logging a watch.
+type LogWatchRequest struct {
+	Rating    int       `json:"rating"`
+	Notes     *string   `json:"notes,omitempty"`
+	WatchedAt time.Time `json:"watched_at"`
+}
+
+// UpdateWatchLogRequest represents the request body for updating a watch log.
+type UpdateWatchLogRequest struct {
+	Rating *int    `json:"rating,omitempty"`
+	Notes  *string `json:"notes,omitempty"`
+}
+
+// WatchLogUser represents user information attached to a watch log response.
+type WatchLogUser struct {
+	ID                uuid.UUID `json:"id"`
+	Username          string    `json:"username"`
+	ProfilePictureUrl *string   `json:"profile_picture_url,omitempty"`
+}
+
+// WatchLogResponse represents a single watch log with user information.
+type WatchLogResponse struct {
+	WatchLog WatchLog     `json:"watch_log"`
+	User     WatchLogUser `json:"user"`
+}
+
+// PostWatchLogsResponse represents watch log summary and entries for a post.
+type PostWatchLogsResponse struct {
+	WatchCount    int                `json:"watch_count"`
+	AvgRating     *float64           `json:"avg_rating,omitempty"`
+	Logs          []WatchLogResponse `json:"logs"`
+	ViewerWatched bool               `json:"viewer_watched"`
+	ViewerRating  *int               `json:"viewer_rating,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add `backend/internal/models/watch_log.go` with `WatchLog` and movie watch log request/response types
- mirror existing model conventions (UUID IDs, nullable fields as pointers, `omitempty` JSON tags)
- include post-level watch log summary shape with `watch_count`, `avg_rating`, `logs`, `viewer_watched`, and `viewer_rating`

## Testing
- `cd backend && go test ./internal/models -v`

Closes #787