### PR TITLE
[Movies] Create TMDB client library

### DIFF
--- a/backend/internal/services/links/tmdb.go
+++ b/backend/internal/services/links/tmdb.go
@@ -1,0 +1,500 @@
+package links
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sanderginn/clubhouse/internal/observability"
+)
+
+const (
+	tmdbAPIKeyEnv            = "TMDB_API_KEY"
+	tmdbDefaultBaseURL       = "https://api.themoviedb.org/3"
+	tmdbUserAgent            = "ClubhouseTMDBClient/1.0"
+	tmdbDefaultRateLimit     = 40
+	tmdbErrorBodyMaxBytes    = 4096
+	tmdbRequestTimeout       = 10 * time.Second
+	tmdbDefaultRateLimitSpan = 10 * time.Second
+)
+
+var (
+	ErrTMDBAPIKeyMissing = errors.New("tmdb api key is required")
+	ErrTMDBNotFound      = errors.New("tmdb resource not found")
+	ErrTMDBRateLimited   = errors.New("tmdb rate limited")
+)
+
+// TMDBAPIError captures non-success responses from TMDB.
+type TMDBAPIError struct {
+	StatusCode int
+	Message    string
+	RetryAfter time.Duration
+}
+
+func (e *TMDBAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("tmdb api error (%d): %s (retry after %s)", e.StatusCode, e.Message, e.RetryAfter)
+	}
+
+	return fmt.Sprintf("tmdb api error (%d): %s", e.StatusCode, e.Message)
+}
+
+func (e *TMDBAPIError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	switch e.StatusCode {
+	case http.StatusNotFound:
+		return ErrTMDBNotFound
+	case http.StatusTooManyRequests:
+		return ErrTMDBRateLimited
+	default:
+		return nil
+	}
+}
+
+// TMDBClient provides methods for interacting with the TMDB API.
+type TMDBClient struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+	limiter    *tmdbRateLimiter
+}
+
+// MovieSearchResult is a single movie result from TMDB search.
+type MovieSearchResult struct {
+	ID           int     `json:"id"`
+	Title        string  `json:"title"`
+	Overview     string  `json:"overview"`
+	PosterPath   string  `json:"poster_path"`
+	BackdropPath string  `json:"backdrop_path"`
+	ReleaseDate  string  `json:"release_date"`
+	VoteAverage  float64 `json:"vote_average"`
+}
+
+// TVSearchResult is a single TV result from TMDB search.
+type TVSearchResult struct {
+	ID           int     `json:"id"`
+	Name         string  `json:"name"`
+	Overview     string  `json:"overview"`
+	PosterPath   string  `json:"poster_path"`
+	BackdropPath string  `json:"backdrop_path"`
+	FirstAirDate string  `json:"first_air_date"`
+	VoteAverage  float64 `json:"vote_average"`
+}
+
+// TMDBGenre represents a TMDB genre.
+type TMDBGenre struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// TMDBCastMember represents a credited cast member.
+type TMDBCastMember struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Character string `json:"character"`
+	Order     int    `json:"order"`
+}
+
+// TMDBCrewMember represents a credited crew member.
+type TMDBCrewMember struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Job        string `json:"job"`
+	Department string `json:"department"`
+}
+
+// TMDBCredits contains cast and crew data.
+type TMDBCredits struct {
+	Cast []TMDBCastMember `json:"cast"`
+	Crew []TMDBCrewMember `json:"crew"`
+}
+
+// TMDBVideo contains movie/TV video metadata.
+type TMDBVideo struct {
+	ID       string `json:"id"`
+	Key      string `json:"key"`
+	Name     string `json:"name"`
+	Site     string `json:"site"`
+	Type     string `json:"type"`
+	Official bool   `json:"official"`
+}
+
+// TMDBVideos is the videos payload from append_to_response.
+type TMDBVideos struct {
+	Results []TMDBVideo `json:"results"`
+}
+
+// MovieDetails is the detailed movie response payload.
+type MovieDetails struct {
+	ID           int         `json:"id"`
+	Title        string      `json:"title"`
+	Overview     string      `json:"overview"`
+	PosterPath   string      `json:"poster_path"`
+	BackdropPath string      `json:"backdrop_path"`
+	Runtime      int         `json:"runtime"`
+	Genres       []TMDBGenre `json:"genres"`
+	ReleaseDate  string      `json:"release_date"`
+	Credits      TMDBCredits `json:"credits"`
+	Director     string      `json:"director"`
+	VoteAverage  float64     `json:"vote_average"`
+	Videos       TMDBVideos  `json:"videos"`
+}
+
+// TVDetails is the detailed TV response payload.
+type TVDetails struct {
+	ID             int         `json:"id"`
+	Name           string      `json:"name"`
+	Overview       string      `json:"overview"`
+	PosterPath     string      `json:"poster_path"`
+	BackdropPath   string      `json:"backdrop_path"`
+	EpisodeRunTime []int       `json:"episode_run_time"`
+	Runtime        int         `json:"runtime"`
+	Genres         []TMDBGenre `json:"genres"`
+	FirstAirDate   string      `json:"first_air_date"`
+	Credits        TMDBCredits `json:"credits"`
+	Director       string      `json:"director"`
+	VoteAverage    float64     `json:"vote_average"`
+	Videos         TMDBVideos  `json:"videos"`
+}
+
+// FindResult is the TMDB /find response scoped for IMDB lookups.
+type FindResult struct {
+	MovieResults []MovieSearchResult `json:"movie_results"`
+	TVResults    []TVSearchResult    `json:"tv_results"`
+}
+
+// NewTMDBClientFromEnv creates a TMDB client using TMDB_API_KEY.
+func NewTMDBClientFromEnv() (*TMDBClient, error) {
+	apiKey := strings.TrimSpace(os.Getenv(tmdbAPIKeyEnv))
+	return NewTMDBClient(apiKey, nil)
+}
+
+// NewTMDBClient creates a TMDB client with an optional custom HTTP client.
+func NewTMDBClient(apiKey string, httpClient *http.Client) (*TMDBClient, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, ErrTMDBAPIKeyMissing
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: tmdbRequestTimeout}
+	}
+
+	return &TMDBClient{
+		apiKey:     apiKey,
+		baseURL:    tmdbDefaultBaseURL,
+		httpClient: httpClient,
+		limiter:    newTMDBRateLimiter(tmdbDefaultRateLimit, tmdbDefaultRateLimitSpan),
+	}, nil
+}
+
+// SearchMovie searches TMDB movies by title.
+func (c *TMDBClient) SearchMovie(ctx context.Context, query string) ([]MovieSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, errors.New("movie query is required")
+	}
+
+	values := url.Values{}
+	values.Set("query", query)
+
+	var payload struct {
+		Results []MovieSearchResult `json:"results"`
+	}
+
+	if err := c.get(ctx, "/search/movie", values, &payload); err != nil {
+		return nil, err
+	}
+
+	return payload.Results, nil
+}
+
+// SearchTV searches TMDB TV shows by title.
+func (c *TMDBClient) SearchTV(ctx context.Context, query string) ([]TVSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, errors.New("tv query is required")
+	}
+
+	values := url.Values{}
+	values.Set("query", query)
+
+	var payload struct {
+		Results []TVSearchResult `json:"results"`
+	}
+
+	if err := c.get(ctx, "/search/tv", values, &payload); err != nil {
+		return nil, err
+	}
+
+	return payload.Results, nil
+}
+
+// GetMovieDetails fetches movie metadata, credits, and videos.
+func (c *TMDBClient) GetMovieDetails(ctx context.Context, tmdbID int) (*MovieDetails, error) {
+	if tmdbID <= 0 {
+		return nil, errors.New("tmdb movie id must be positive")
+	}
+
+	values := url.Values{}
+	values.Set("append_to_response", "credits,videos")
+
+	var details MovieDetails
+	if err := c.get(ctx, fmt.Sprintf("/movie/%d", tmdbID), values, &details); err != nil {
+		return nil, err
+	}
+
+	details.Director = extractDirector(details.Credits.Crew)
+
+	return &details, nil
+}
+
+// GetTVDetails fetches TV metadata, credits, and videos.
+func (c *TMDBClient) GetTVDetails(ctx context.Context, tmdbID int) (*TVDetails, error) {
+	if tmdbID <= 0 {
+		return nil, errors.New("tmdb tv id must be positive")
+	}
+
+	values := url.Values{}
+	values.Set("append_to_response", "credits,videos")
+
+	var details TVDetails
+	if err := c.get(ctx, fmt.Sprintf("/tv/%d", tmdbID), values, &details); err != nil {
+		return nil, err
+	}
+
+	details.Director = extractDirector(details.Credits.Crew)
+	if details.Runtime == 0 {
+		details.Runtime = firstPositiveInt(details.EpisodeRunTime)
+	}
+
+	return &details, nil
+}
+
+// FindByIMDBID resolves an IMDB ID to TMDB entities.
+func (c *TMDBClient) FindByIMDBID(ctx context.Context, imdbID string) (*FindResult, error) {
+	imdbID = strings.TrimSpace(imdbID)
+	if imdbID == "" {
+		return nil, errors.New("imdb id is required")
+	}
+
+	values := url.Values{}
+	values.Set("external_source", "imdb_id")
+
+	var result FindResult
+	if err := c.get(ctx, "/find/"+url.PathEscape(imdbID), values, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (c *TMDBClient) get(ctx context.Context, path string, query url.Values, out interface{}) error {
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if c == nil {
+		return errors.New("tmdb client is required")
+	}
+
+	if err := c.limiter.Wait(ctx); err != nil {
+		return fmt.Errorf("tmdb rate limiter wait: %w", err)
+	}
+
+	if query == nil {
+		query = make(url.Values)
+	}
+	query.Set("api_key", c.apiKey)
+
+	base := strings.TrimSuffix(c.baseURL, "/")
+	requestURL := fmt.Sprintf("%s%s", base, path)
+	encoded := query.Encode()
+	if encoded != "" {
+		requestURL = requestURL + "?" + encoded
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("build tmdb request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", tmdbUserAgent)
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		observability.LogWarn(ctx, "tmdb request failed", "path", path, "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return fmt.Errorf("tmdb request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		apiErr := parseTMDBAPIError(resp)
+		observability.LogWarn(ctx, "tmdb request failed", "path", path, "status_code", strconv.Itoa(resp.StatusCode), "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", apiErr.Error())
+		return apiErr
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		observability.LogWarn(ctx, "tmdb response decode failed", "path", path, "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return fmt.Errorf("decode tmdb response: %w", err)
+	}
+
+	observability.LogDebug(ctx, "tmdb request completed", "path", path, "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "status_code", strconv.Itoa(resp.StatusCode))
+
+	return nil
+}
+
+func parseTMDBAPIError(resp *http.Response) error {
+	message := strings.TrimSpace(resp.Status)
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, tmdbErrorBodyMaxBytes))
+	if err == nil && len(body) > 0 {
+		var payload struct {
+			StatusMessage string `json:"status_message"`
+		}
+		if decodeErr := json.Unmarshal(body, &payload); decodeErr == nil {
+			if strings.TrimSpace(payload.StatusMessage) != "" {
+				message = strings.TrimSpace(payload.StatusMessage)
+			}
+		}
+	}
+
+	if message == "" {
+		message = http.StatusText(resp.StatusCode)
+	}
+
+	return &TMDBAPIError{
+		StatusCode: resp.StatusCode,
+		Message:    message,
+		RetryAfter: retryAfter,
+	}
+}
+
+func parseRetryAfter(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+
+	seconds, err := strconv.Atoi(raw)
+	if err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	retryAt, err := http.ParseTime(raw)
+	if err != nil {
+		return 0
+	}
+
+	d := time.Until(retryAt)
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+func extractDirector(crew []TMDBCrewMember) string {
+	for _, member := range crew {
+		if strings.EqualFold(strings.TrimSpace(member.Job), "director") {
+			return strings.TrimSpace(member.Name)
+		}
+	}
+	return ""
+}
+
+func firstPositiveInt(values []int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+type tmdbRateLimiter struct {
+	limit      int
+	window     time.Duration
+	mu         sync.Mutex
+	requestLog []time.Time
+}
+
+func newTMDBRateLimiter(limit int, window time.Duration) *tmdbRateLimiter {
+	return &tmdbRateLimiter{limit: limit, window: window}
+}
+
+func (r *tmdbRateLimiter) Wait(ctx context.Context) error {
+	if r == nil || r.limit <= 0 || r.window <= 0 {
+		return nil
+	}
+
+	for {
+		now := time.Now()
+
+		r.mu.Lock()
+		r.prune(now)
+		if len(r.requestLog) < r.limit {
+			r.requestLog = append(r.requestLog, now)
+			r.mu.Unlock()
+			return nil
+		}
+
+		waitFor := r.requestLog[0].Add(r.window).Sub(now)
+		r.mu.Unlock()
+
+		if waitFor <= 0 {
+			continue
+		}
+
+		timer := time.NewTimer(waitFor)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (r *tmdbRateLimiter) prune(now time.Time) {
+	if len(r.requestLog) == 0 {
+		return
+	}
+
+	cutoff := now.Add(-r.window)
+	firstKept := 0
+	for ; firstKept < len(r.requestLog); firstKept++ {
+		if r.requestLog[firstKept].After(cutoff) {
+			break
+		}
+	}
+
+	if firstKept == 0 {
+		return
+	}
+
+	copy(r.requestLog, r.requestLog[firstKept:])
+	r.requestLog = r.requestLog[:len(r.requestLog)-firstKept]
+}

--- a/backend/internal/services/links/tmdb_test.go
+++ b/backend/internal/services/links/tmdb_test.go
@@ -1,0 +1,338 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewTMDBClientFromEnv(t *testing.T) {
+	t.Setenv(tmdbAPIKeyEnv, "test-api-key")
+
+	client, err := NewTMDBClientFromEnv()
+	if err != nil {
+		t.Fatalf("NewTMDBClientFromEnv error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+	if client.apiKey != "test-api-key" {
+		t.Fatalf("api key = %q, want test-api-key", client.apiKey)
+	}
+}
+
+func TestNewTMDBClientFromEnvMissingAPIKey(t *testing.T) {
+	t.Setenv(tmdbAPIKeyEnv, "")
+
+	_, err := NewTMDBClientFromEnv()
+	if !errors.Is(err, ErrTMDBAPIKeyMissing) {
+		t.Fatalf("expected ErrTMDBAPIKeyMissing, got %v", err)
+	}
+}
+
+func TestTMDBClientSearchMovie(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/movie" {
+			t.Fatalf("path = %q, want /search/movie", r.URL.Path)
+		}
+		if r.URL.Query().Get("api_key") != "test-api-key" {
+			t.Fatalf("api_key = %q", r.URL.Query().Get("api_key"))
+		}
+		if r.URL.Query().Get("query") != "The Matrix" {
+			t.Fatalf("query = %q", r.URL.Query().Get("query"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":603,"title":"The Matrix","overview":"A hacker learns reality is simulated.","poster_path":"/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg","backdrop_path":"/icmmSD4vTTDKOq2vvdulafOGw93.jpg","release_date":"1999-03-30","vote_average":8.2}]}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+
+	results, err := client.SearchMovie(context.Background(), "The Matrix")
+	if err != nil {
+		t.Fatalf("SearchMovie error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Title != "The Matrix" {
+		t.Fatalf("title = %q, want The Matrix", results[0].Title)
+	}
+}
+
+func TestTMDBClientSearchTV(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/tv" {
+			t.Fatalf("path = %q, want /search/tv", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "Dark" {
+			t.Fatalf("query = %q, want Dark", r.URL.Query().Get("query"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":70523,"name":"Dark","overview":"A family saga with a supernatural twist.","poster_path":"/apbrbWs8M9lyOpJYU5WXrpFbk1Z.jpg","backdrop_path":"/nrtM5uRIfho4L6ykvR4gvN2c3T7.jpg","first_air_date":"2017-12-01","vote_average":8.4}]}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+
+	results, err := client.SearchTV(context.Background(), "Dark")
+	if err != nil {
+		t.Fatalf("SearchTV error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0].Name != "Dark" {
+		t.Fatalf("name = %q, want Dark", results[0].Name)
+	}
+}
+
+func TestTMDBClientGetMovieDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/movie/550" {
+			t.Fatalf("path = %q, want /movie/550", r.URL.Path)
+		}
+		if r.URL.Query().Get("append_to_response") != "credits,videos" {
+			t.Fatalf("append_to_response = %q", r.URL.Query().Get("append_to_response"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":550,
+			"title":"Fight Club",
+			"overview":"Mischief and mayhem.",
+			"poster_path":"/a26cQPRhJPX6GbWfQbvZdrrp9j9.jpg",
+			"backdrop_path":"/fCayJrkfRaCRCTh8GqN30f8oyQF.jpg",
+			"runtime":139,
+			"genres":[{"id":18,"name":"Drama"}],
+			"release_date":"1999-10-15",
+			"vote_average":8.4,
+			"credits":{
+				"cast":[{"id":287,"name":"Brad Pitt","character":"Tyler Durden","order":0}],
+				"crew":[{"id":7467,"name":"David Fincher","job":"Director","department":"Directing"}]
+			},
+			"videos":{
+				"results":[{"id":"abc123","key":"SUXWAEX2jlg","name":"Trailer","site":"YouTube","type":"Trailer","official":true}]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+
+	details, err := client.GetMovieDetails(context.Background(), 550)
+	if err != nil {
+		t.Fatalf("GetMovieDetails error: %v", err)
+	}
+	if details.Title != "Fight Club" {
+		t.Fatalf("title = %q, want Fight Club", details.Title)
+	}
+	if details.Director != "David Fincher" {
+		t.Fatalf("director = %q, want David Fincher", details.Director)
+	}
+	if len(details.Videos.Results) != 1 || details.Videos.Results[0].Key != "SUXWAEX2jlg" {
+		t.Fatalf("unexpected videos payload: %+v", details.Videos.Results)
+	}
+}
+
+func TestTMDBClientGetTVDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tv/1399" {
+			t.Fatalf("path = %q, want /tv/1399", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":1399,
+			"name":"Game of Thrones",
+			"overview":"Noble families fight for control.",
+			"poster_path":"/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+			"backdrop_path":"/suopoADq0k8YZr4dQXcU6pToj6s.jpg",
+			"episode_run_time":[57],
+			"genres":[{"id":18,"name":"Drama"}],
+			"first_air_date":"2011-04-17",
+			"vote_average":8.5,
+			"credits":{
+				"cast":[{"id":239019,"name":"Emilia Clarke","character":"Daenerys Targaryen","order":1}],
+				"crew":[{"id":9813,"name":"Miguel Sapochnik","job":"Director","department":"Directing"}]
+			},
+			"videos":{
+				"results":[{"id":"def456","key":"KPLWWIOCOOQ","name":"Teaser","site":"YouTube","type":"Teaser","official":true}]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+
+	details, err := client.GetTVDetails(context.Background(), 1399)
+	if err != nil {
+		t.Fatalf("GetTVDetails error: %v", err)
+	}
+	if details.Name != "Game of Thrones" {
+		t.Fatalf("name = %q, want Game of Thrones", details.Name)
+	}
+	if details.Runtime != 57 {
+		t.Fatalf("runtime = %d, want 57", details.Runtime)
+	}
+	if details.Director != "Miguel Sapochnik" {
+		t.Fatalf("director = %q, want Miguel Sapochnik", details.Director)
+	}
+}
+
+func TestTMDBClientFindByIMDBID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/find/tt0133093" {
+			t.Fatalf("path = %q, want /find/tt0133093", r.URL.Path)
+		}
+		if r.URL.Query().Get("external_source") != "imdb_id" {
+			t.Fatalf("external_source = %q", r.URL.Query().Get("external_source"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"movie_results":[{"id":603,"title":"The Matrix","overview":"A hacker learns reality is simulated."}],
+			"tv_results":[{"id":99999,"name":"The Matrix Chronicles","overview":"Companion interviews."}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+
+	result, err := client.FindByIMDBID(context.Background(), "tt0133093")
+	if err != nil {
+		t.Fatalf("FindByIMDBID error: %v", err)
+	}
+	if len(result.MovieResults) != 1 || result.MovieResults[0].ID != 603 {
+		t.Fatalf("unexpected movie_results: %+v", result.MovieResults)
+	}
+	if len(result.TVResults) != 1 || result.TVResults[0].ID != 99999 {
+		t.Fatalf("unexpected tv_results: %+v", result.TVResults)
+	}
+}
+
+func TestTMDBClientAPIErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		retryAfter string
+		body       string
+		check      func(t *testing.T, err error)
+	}{
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			retryAfter: "12",
+			body:       `{"status_message":"Too many requests"}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrTMDBRateLimited) {
+					t.Fatalf("expected ErrTMDBRateLimited, got %v", err)
+				}
+				var apiErr *TMDBAPIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("expected TMDBAPIError, got %T", err)
+				}
+				if apiErr.RetryAfter != 12*time.Second {
+					t.Fatalf("retry_after = %s, want 12s", apiErr.RetryAfter)
+				}
+			},
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"status_message":"The resource you requested could not be found."}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrTMDBNotFound) {
+					t.Fatalf("expected ErrTMDBNotFound, got %v", err)
+				}
+			},
+		},
+		{
+			name:       "generic api error",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"status_message":"Internal server error"}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var apiErr *TMDBAPIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("expected TMDBAPIError, got %T", err)
+				}
+				if apiErr.StatusCode != http.StatusInternalServerError {
+					t.Fatalf("status code = %d, want 500", apiErr.StatusCode)
+				}
+				if !strings.Contains(apiErr.Message, "Internal server error") {
+					t.Fatalf("message = %q", apiErr.Message)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.retryAfter != "" {
+					w.Header().Set("Retry-After", tt.retryAfter)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := newTestTMDBClient(t, server.URL)
+			_, err := client.SearchMovie(context.Background(), "The Matrix")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			tt.check(t, err)
+		})
+	}
+}
+
+func TestTMDBRateLimiterWaitRespectsWindow(t *testing.T) {
+	limiter := newTMDBRateLimiter(1, 50*time.Millisecond)
+
+	start := time.Now()
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("first wait error: %v", err)
+	}
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("second wait error: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("elapsed = %s, want at least 40ms", elapsed)
+	}
+}
+
+func TestTMDBRateLimiterWaitHonorsContextCancellation(t *testing.T) {
+	limiter := newTMDBRateLimiter(1, time.Second)
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("prime wait error: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := limiter.Wait(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func newTestTMDBClient(t *testing.T, baseURL string) *TMDBClient {
+	t.Helper()
+
+	client, err := NewTMDBClient("test-api-key", &http.Client{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewTMDBClient error: %v", err)
+	}
+
+	client.baseURL = baseURL
+	client.limiter = newTMDBRateLimiter(1000, time.Second)
+
+	return client
+}


### PR DESCRIPTION
## Summary
- add a new `TMDBClient` in `backend/internal/services/links/tmdb.go` configured via `TMDB_API_KEY`
- implement movie search, TV search, movie details, TV details, and IMDB lookup methods
- include built-in rate-limit awareness (40 requests per 10-second window), structured TMDB API error handling, and retry-after parsing
- model key TMDB payloads for search/details/find responses, including credits, director extraction, and videos

## Tests
- add `backend/internal/services/links/tmdb_test.go` with mock HTTP server coverage for search/details/find flows
- add tests for API error handling (rate limit, not found, generic failure) and rate-limiter behavior
- run `cd backend && go test ./...`

Closes #788