### PR TITLE
[Movies] Create movie metadata extractor

### DIFF
--- a/backend/internal/services/links/movie_parser.go
+++ b/backend/internal/services/links/movie_parser.go
@@ -1,0 +1,364 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+const (
+	tmdbImageBaseURL         = "https://image.tmdb.org/t/p"
+	tmdbPosterSize           = "w500"
+	tmdbBackdropSize         = "w1280"
+	movieMetadataCastMaxSize = 5
+)
+
+var (
+	imdbIDPattern       = regexp.MustCompile(`^tt\d+$`)
+	leadingDigitsRegexp = regexp.MustCompile(`^(\d+)`)
+)
+
+type MovieData = models.MovieData
+
+func ParseMovieMetadata(ctx context.Context, rawURL string, client *TMDBClient) (*MovieData, error) {
+	if ctx == nil {
+		return nil, errors.New("context is required")
+	}
+	if client == nil {
+		return nil, errors.New("tmdb client is required")
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, nil
+	}
+
+	host := strings.ToLower(strings.TrimSpace(parsedURL.Hostname()))
+	segments := splitURLPath(parsedURL.Path)
+
+	switch {
+	case isIMDbHost(host):
+		imdbID, ok := parseIMDbID(segments)
+		if !ok {
+			return nil, nil
+		}
+		return parseIMDbMovieMetadata(ctx, client, imdbID)
+	case isTMDBHost(host):
+		mediaType, tmdbID, ok := parseTMDBPath(segments)
+		if !ok {
+			return nil, nil
+		}
+		return parseTMDBMovieMetadata(ctx, client, mediaType, tmdbID)
+	case isLetterboxdHost(host):
+		slug, ok := parseLetterboxdSlug(segments)
+		if !ok {
+			return nil, nil
+		}
+		return parseLetterboxdMovieMetadata(ctx, client, slug)
+	default:
+		return nil, nil
+	}
+}
+
+func isIMDbHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "imdb.com" || strings.HasSuffix(host, ".imdb.com")
+}
+
+func isTMDBHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "themoviedb.org" || strings.HasSuffix(host, ".themoviedb.org")
+}
+
+func isLetterboxdHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "letterboxd.com" || strings.HasSuffix(host, ".letterboxd.com")
+}
+
+func splitURLPath(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+
+	rawSegments := strings.Split(path, "/")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		unescaped, err := url.PathUnescape(segment)
+		if err != nil {
+			unescaped = segment
+		}
+		segments = append(segments, unescaped)
+	}
+	return segments
+}
+
+func parseIMDbID(segments []string) (string, bool) {
+	if len(segments) < 2 || !strings.EqualFold(segments[0], "title") {
+		return "", false
+	}
+
+	imdbID := strings.ToLower(strings.TrimSpace(segments[1]))
+	if !imdbIDPattern.MatchString(imdbID) {
+		return "", false
+	}
+	return imdbID, true
+}
+
+func parseTMDBPath(segments []string) (string, int, bool) {
+	if len(segments) < 2 {
+		return "", 0, false
+	}
+
+	mediaType := strings.ToLower(strings.TrimSpace(segments[0]))
+	if mediaType != "movie" && mediaType != "tv" {
+		return "", 0, false
+	}
+
+	match := leadingDigitsRegexp.FindStringSubmatch(strings.TrimSpace(segments[1]))
+	if len(match) != 2 {
+		return "", 0, false
+	}
+
+	tmdbID, err := strconv.Atoi(match[1])
+	if err != nil || tmdbID <= 0 {
+		return "", 0, false
+	}
+	return mediaType, tmdbID, true
+}
+
+func parseLetterboxdSlug(segments []string) (string, bool) {
+	if len(segments) < 2 || !strings.EqualFold(segments[0], "film") {
+		return "", false
+	}
+
+	slug := strings.TrimSpace(segments[1])
+	if slug == "" {
+		return "", false
+	}
+	return slug, true
+}
+
+func parseIMDbMovieMetadata(ctx context.Context, client *TMDBClient, imdbID string) (*MovieData, error) {
+	result, err := client.FindByIMDBID(ctx, imdbID)
+	if err != nil {
+		return nil, fmt.Errorf("find tmdb result by imdb id %s: %w", imdbID, err)
+	}
+
+	if len(result.MovieResults) > 0 {
+		return parseTMDBMovieMetadata(ctx, client, "movie", result.MovieResults[0].ID)
+	}
+	if len(result.TVResults) > 0 {
+		return parseTMDBMovieMetadata(ctx, client, "tv", result.TVResults[0].ID)
+	}
+
+	return nil, nil
+}
+
+func parseTMDBMovieMetadata(ctx context.Context, client *TMDBClient, mediaType string, tmdbID int) (*MovieData, error) {
+	switch mediaType {
+	case "movie":
+		details, err := client.GetMovieDetails(ctx, tmdbID)
+		if err != nil {
+			return nil, fmt.Errorf("get tmdb movie details for id %d: %w", tmdbID, err)
+		}
+		return movieDataFromMovieDetails(details), nil
+	case "tv":
+		details, err := client.GetTVDetails(ctx, tmdbID)
+		if err != nil {
+			return nil, fmt.Errorf("get tmdb tv details for id %d: %w", tmdbID, err)
+		}
+		return movieDataFromTVDetails(details), nil
+	default:
+		return nil, nil
+	}
+}
+
+func parseLetterboxdMovieMetadata(ctx context.Context, client *TMDBClient, slug string) (*MovieData, error) {
+	titleQuery := letterboxdSlugToTitle(slug)
+	if titleQuery == "" {
+		return nil, nil
+	}
+
+	results, err := client.SearchMovie(ctx, titleQuery)
+	if err != nil {
+		return nil, fmt.Errorf("search tmdb movie for letterboxd slug %s: %w", slug, err)
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	return parseTMDBMovieMetadata(ctx, client, "movie", results[0].ID)
+}
+
+func letterboxdSlugToTitle(slug string) string {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	slug = strings.Trim(slug, "/")
+	if slug == "" {
+		return ""
+	}
+
+	title := strings.ReplaceAll(slug, "-", " ")
+	return strings.Join(strings.Fields(title), " ")
+}
+
+func movieDataFromMovieDetails(details *MovieDetails) *MovieData {
+	if details == nil {
+		return nil
+	}
+
+	return &MovieData{
+		Title:       strings.TrimSpace(details.Title),
+		Overview:    strings.TrimSpace(details.Overview),
+		Poster:      tmdbImageURL(details.PosterPath, tmdbPosterSize),
+		Backdrop:    tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
+		Runtime:     details.Runtime,
+		Genres:      tmdbGenreNames(details.Genres),
+		ReleaseDate: strings.TrimSpace(details.ReleaseDate),
+		Cast:        tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
+		Director:    strings.TrimSpace(details.Director),
+		TMDBRating:  details.VoteAverage,
+		TrailerKey:  tmdbTrailerKey(details.Videos.Results),
+	}
+}
+
+func movieDataFromTVDetails(details *TVDetails) *MovieData {
+	if details == nil {
+		return nil
+	}
+
+	return &MovieData{
+		Title:       strings.TrimSpace(details.Name),
+		Overview:    strings.TrimSpace(details.Overview),
+		Poster:      tmdbImageURL(details.PosterPath, tmdbPosterSize),
+		Backdrop:    tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
+		Runtime:     details.Runtime,
+		Genres:      tmdbGenreNames(details.Genres),
+		ReleaseDate: strings.TrimSpace(details.FirstAirDate),
+		Cast:        tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
+		Director:    strings.TrimSpace(details.Director),
+		TMDBRating:  details.VoteAverage,
+		TrailerKey:  tmdbTrailerKey(details.Videos.Results),
+	}
+}
+
+func tmdbImageURL(pathValue, size string) string {
+	pathValue = strings.TrimSpace(pathValue)
+	if pathValue == "" {
+		return ""
+	}
+	if strings.HasPrefix(pathValue, "https://") || strings.HasPrefix(pathValue, "http://") {
+		return pathValue
+	}
+
+	if !strings.HasPrefix(pathValue, "/") {
+		pathValue = "/" + pathValue
+	}
+
+	return fmt.Sprintf("%s/%s%s", tmdbImageBaseURL, size, pathValue)
+}
+
+func tmdbGenreNames(genres []TMDBGenre) []string {
+	if len(genres) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(genres))
+	for _, genre := range genres {
+		name := strings.TrimSpace(genre.Name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+func tmdbCastMembers(cast []TMDBCastMember, limit int) []models.CastMember {
+	if len(cast) == 0 || limit <= 0 {
+		return nil
+	}
+
+	orderedCast := make([]TMDBCastMember, 0, len(cast))
+	for _, member := range cast {
+		if strings.TrimSpace(member.Name) == "" {
+			continue
+		}
+		orderedCast = append(orderedCast, member)
+	}
+	sort.SliceStable(orderedCast, func(i, j int) bool {
+		return orderedCast[i].Order < orderedCast[j].Order
+	})
+
+	if len(orderedCast) > limit {
+		orderedCast = orderedCast[:limit]
+	}
+
+	result := make([]models.CastMember, 0, len(orderedCast))
+	for _, member := range orderedCast {
+		result = append(result, models.CastMember{
+			Name:      strings.TrimSpace(member.Name),
+			Character: strings.TrimSpace(member.Character),
+		})
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func tmdbTrailerKey(videos []TMDBVideo) string {
+	if len(videos) == 0 {
+		return ""
+	}
+
+	type trailerMatcher struct {
+		official bool
+		kind     string
+	}
+
+	matchers := []trailerMatcher{
+		{official: true, kind: "trailer"},
+		{official: false, kind: "trailer"},
+		{official: true, kind: "teaser"},
+		{official: false, kind: ""},
+	}
+
+	for _, matcher := range matchers {
+		for _, video := range videos {
+			if !strings.EqualFold(strings.TrimSpace(video.Site), "youtube") {
+				continue
+			}
+
+			videoType := strings.ToLower(strings.TrimSpace(video.Type))
+			if matcher.kind != "" && videoType != matcher.kind {
+				continue
+			}
+			if matcher.official && !video.Official {
+				continue
+			}
+
+			key := strings.TrimSpace(video.Key)
+			if key != "" {
+				return key
+			}
+		}
+	}
+
+	return ""
+}

--- a/backend/internal/services/links/movie_parser_test.go
+++ b/backend/internal/services/links/movie_parser_test.go
@@ -1,0 +1,250 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseMovieMetadataIMDbURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/find/tt0133093":
+			if got := r.URL.Query().Get("external_source"); got != "imdb_id" {
+				t.Fatalf("external_source = %q, want imdb_id", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"movie_results":[{"id":603,"title":"The Matrix"}],"tv_results":[]}`))
+		case "/movie/603":
+			if got := r.URL.Query().Get("append_to_response"); got != "credits,videos" {
+				t.Fatalf("append_to_response = %q, want credits,videos", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":603,
+				"title":"The Matrix",
+				"overview":"Reality is not what it seems.",
+				"poster_path":"/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
+				"backdrop_path":"/icmmSD4vTTDKOq2vvdulafOGw93.jpg",
+				"runtime":136,
+				"genres":[{"id":28,"name":"Action"},{"id":878,"name":"Science Fiction"}],
+				"release_date":"1999-03-30",
+				"vote_average":8.2,
+				"credits":{
+					"cast":[
+						{"id":1,"name":"Keanu Reeves","character":"Neo","order":0},
+						{"id":2,"name":"Carrie-Anne Moss","character":"Trinity","order":1},
+						{"id":3,"name":"Laurence Fishburne","character":"Morpheus","order":2},
+						{"id":4,"name":"Hugo Weaving","character":"Agent Smith","order":3},
+						{"id":5,"name":"Gloria Foster","character":"Oracle","order":4},
+						{"id":6,"name":"Joe Pantoliano","character":"Cypher","order":5}
+					],
+					"crew":[{"id":101,"name":"Lana Wachowski","job":"Director","department":"Directing"}]
+				},
+				"videos":{
+					"results":[
+						{"id":"v1","key":"teaser-key","name":"Teaser","site":"YouTube","type":"Teaser","official":true},
+						{"id":"v2","key":"trailer-key","name":"Trailer","site":"YouTube","type":"Trailer","official":true}
+					]
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.imdb.com/title/tt0133093/", client)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "The Matrix" {
+		t.Fatalf("Title = %q, want The Matrix", metadata.Title)
+	}
+	if metadata.ReleaseDate != "1999-03-30" {
+		t.Fatalf("ReleaseDate = %q, want 1999-03-30", metadata.ReleaseDate)
+	}
+	if metadata.Runtime != 136 {
+		t.Fatalf("Runtime = %d, want 136", metadata.Runtime)
+	}
+	if metadata.Director != "Lana Wachowski" {
+		t.Fatalf("Director = %q, want Lana Wachowski", metadata.Director)
+	}
+	if metadata.TrailerKey != "trailer-key" {
+		t.Fatalf("TrailerKey = %q, want trailer-key", metadata.TrailerKey)
+	}
+	if len(metadata.Cast) != 5 {
+		t.Fatalf("Cast len = %d, want 5", len(metadata.Cast))
+	}
+	if metadata.Poster != "https://image.tmdb.org/t/p/w500/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg" {
+		t.Fatalf("Poster = %q", metadata.Poster)
+	}
+	if metadata.Backdrop != "https://image.tmdb.org/t/p/w1280/icmmSD4vTTDKOq2vvdulafOGw93.jpg" {
+		t.Fatalf("Backdrop = %q", metadata.Backdrop)
+	}
+}
+
+func TestParseMovieMetadataTMDBMovieURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/movie/550" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":550,
+			"title":"Fight Club",
+			"overview":"Mischief and mayhem.",
+			"poster_path":"/a26cQPRhJPX6GbWfQbvZdrrp9j9.jpg",
+			"backdrop_path":"/fCayJrkfRaCRCTh8GqN30f8oyQF.jpg",
+			"runtime":139,
+			"genres":[{"id":18,"name":"Drama"}],
+			"release_date":"1999-10-15",
+			"vote_average":8.4,
+			"credits":{"cast":[],"crew":[{"id":7467,"name":"David Fincher","job":"Director","department":"Directing"}]},
+			"videos":{"results":[{"id":"abc123","key":"SUXWAEX2jlg","name":"Trailer","site":"YouTube","type":"Trailer","official":true}]}
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.themoviedb.org/movie/550-fight-club", client)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "Fight Club" {
+		t.Fatalf("Title = %q, want Fight Club", metadata.Title)
+	}
+	if metadata.Director != "David Fincher" {
+		t.Fatalf("Director = %q, want David Fincher", metadata.Director)
+	}
+}
+
+func TestParseMovieMetadataTMDBTVURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tv/1399" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":1399,
+			"name":"Game of Thrones",
+			"overview":"Noble families fight for control.",
+			"poster_path":"/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+			"backdrop_path":"/suopoADq0k8YZr4dQXcU6pToj6s.jpg",
+			"runtime":57,
+			"genres":[{"id":18,"name":"Drama"}],
+			"first_air_date":"2011-04-17",
+			"vote_average":8.5,
+			"credits":{"cast":[{"id":239019,"name":"Emilia Clarke","character":"Daenerys Targaryen","order":1}],"crew":[{"id":9813,"name":"Miguel Sapochnik","job":"Director","department":"Directing"}]},
+			"videos":{"results":[{"id":"def456","key":"KPLWWIOCOOQ","name":"Teaser","site":"YouTube","type":"Teaser","official":true}]}
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.themoviedb.org/tv/1399-game-of-thrones", client)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "Game of Thrones" {
+		t.Fatalf("Title = %q, want Game of Thrones", metadata.Title)
+	}
+	if metadata.ReleaseDate != "2011-04-17" {
+		t.Fatalf("ReleaseDate = %q, want 2011-04-17", metadata.ReleaseDate)
+	}
+	if metadata.Runtime != 57 {
+		t.Fatalf("Runtime = %d, want 57", metadata.Runtime)
+	}
+}
+
+func TestParseMovieMetadataLetterboxdURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/movie":
+			if got := strings.TrimSpace(r.URL.Query().Get("query")); got != "the matrix" {
+				t.Fatalf("query = %q, want the matrix", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":603,"title":"The Matrix"}]}`))
+		case "/movie/603":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":603,
+				"title":"The Matrix",
+				"overview":"A hacker learns reality is simulated.",
+				"poster_path":"/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
+				"backdrop_path":"/icmmSD4vTTDKOq2vvdulafOGw93.jpg",
+				"runtime":136,
+				"genres":[{"id":28,"name":"Action"}],
+				"release_date":"1999-03-30",
+				"vote_average":8.2,
+				"credits":{"cast":[],"crew":[]},
+				"videos":{"results":[]}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://letterboxd.com/film/the-matrix/", client)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "The Matrix" {
+		t.Fatalf("Title = %q, want The Matrix", metadata.Title)
+	}
+}
+
+func TestParseMovieMetadataNoMatchingURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s", r.URL.String())
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://example.com/not-a-movie-link", client)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata != nil {
+		t.Fatalf("expected nil metadata, got %+v", metadata)
+	}
+}
+
+func TestParseMovieMetadataTMDBAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"status_message":"Too many requests"}`))
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.themoviedb.org/movie/550", client)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if metadata != nil {
+		t.Fatalf("expected nil metadata, got %+v", metadata)
+	}
+	if !errors.Is(err, ErrTMDBRateLimited) {
+		t.Fatalf("expected ErrTMDBRateLimited, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ParseMovieMetadata` in `backend/internal/services/links/movie_parser.go` to detect IMDB, TMDB movie/TV, and Letterboxd film URLs
- map parsed URLs to TMDB lookups (IMDB `/find`, TMDB details, Letterboxd title search) and normalize responses into `MovieData`
- populate title, overview, poster/backdrop URLs, runtime, genres, release date, top-cast, director, TMDB rating, and trailer key
- add focused parser tests in `backend/internal/services/links/movie_parser_test.go` covering all required URL patterns, non-matching URLs, and TMDB API error handling

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services/links -run 'TestParseMovieMetadata' -v`
- `cd backend && go test ./...`

Closes #792