### PR TITLE
[Movies] Create watch log service

### DIFF
--- a/backend/internal/models/watch_log.go
+++ b/backend/internal/models/watch_log.go
@@ -45,6 +45,12 @@ type WatchLogResponse struct {
 	User     WatchLogUser `json:"user"`
 }
 
+// WatchLogWithPost represents a watch log with its related post.
+type WatchLogWithPost struct {
+	WatchLog
+	Post *Post `json:"post,omitempty"`
+}
+
 // PostWatchLogsResponse represents watch log summary and entries for a post.
 type PostWatchLogsResponse struct {
 	WatchCount    int                `json:"watch_count"`

--- a/backend/internal/services/watch_log.go
+++ b/backend/internal/services/watch_log.go
@@ -1,0 +1,694 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const watchLogCursorLayout = "2006-01-02T15:04:05.000Z07:00"
+
+// WatchLogServiceDependencies holds optional dependencies for WatchLogService.
+type WatchLogServiceDependencies struct {
+	AuditService *AuditService
+	Now          func() time.Time
+}
+
+// WatchLogService handles watch log operations.
+type WatchLogService struct {
+	db           *sql.DB
+	auditService *AuditService
+	now          func() time.Time
+}
+
+// NewWatchLogService creates a new watch log service.
+func NewWatchLogService(db *sql.DB, deps *WatchLogServiceDependencies) *WatchLogService {
+	auditService := NewAuditService(db)
+	now := time.Now
+	if deps != nil {
+		if deps.AuditService != nil {
+			auditService = deps.AuditService
+		}
+		if deps.Now != nil {
+			now = deps.Now
+		}
+	}
+
+	return &WatchLogService{
+		db:           db,
+		auditService: auditService,
+		now:          now,
+	}
+}
+
+// LogWatch creates or restores a watch log for a movie or series post.
+func (s *WatchLogService) LogWatch(ctx context.Context, userID, postID uuid.UUID, rating int, notes string) (*models.WatchLog, error) {
+	ctx, span := otel.Tracer("clubhouse.watch_logs").Start(ctx, "WatchLogService.LogWatch")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+		attribute.Int("rating", rating),
+		attribute.Bool("has_notes", strings.TrimSpace(notes) != ""),
+	)
+	defer span.End()
+
+	if err := validateWatchLogRating(rating); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.verifyWatchablePost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	existing, err := s.getExistingWatchLog(ctx, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if existing != nil {
+		if existing.DeletedAt != nil {
+			watchLog, err := s.restoreWatchLog(ctx, existing.ID, rating, notes)
+			if err != nil {
+				recordSpanError(span, err)
+				return nil, err
+			}
+
+			if err := s.logWatchAudit(ctx, "log_watch", userID, map[string]interface{}{
+				"post_id": postID.String(),
+				"rating":  rating,
+			}); err != nil {
+				recordSpanError(span, err)
+				return nil, err
+			}
+			return watchLog, nil
+		}
+
+		return existing, nil
+	}
+
+	watchLog, err := s.createWatchLog(ctx, userID, postID, rating, notes)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.logWatchAudit(ctx, "log_watch", userID, map[string]interface{}{
+		"post_id": postID.String(),
+		"rating":  rating,
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return watchLog, nil
+}
+
+// UpdateWatchLog updates an existing watch log for a movie or series post.
+func (s *WatchLogService) UpdateWatchLog(ctx context.Context, userID, postID uuid.UUID, rating *int, notes *string) (*models.WatchLog, error) {
+	ctx, span := otel.Tracer("clubhouse.watch_logs").Start(ctx, "WatchLogService.UpdateWatchLog")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+		attribute.Bool("has_rating", rating != nil),
+		attribute.Bool("has_notes", notes != nil),
+	)
+	if rating != nil {
+		span.SetAttributes(attribute.Int("rating", *rating))
+	}
+	defer span.End()
+
+	if rating == nil && notes == nil {
+		err := errors.New("no fields to update")
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if rating != nil {
+		if err := validateWatchLogRating(*rating); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+	}
+
+	if err := s.verifyWatchablePost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	existing, err := s.getExistingWatchLog(ctx, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	if existing == nil || existing.DeletedAt != nil {
+		notFoundErr := errors.New("watch log not found")
+		recordSpanError(span, notFoundErr)
+		return nil, notFoundErr
+	}
+
+	updated, err := s.updateWatchLog(ctx, existing.ID, rating, notes)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	metadata := map[string]interface{}{
+		"post_id": postID.String(),
+	}
+	if rating != nil {
+		metadata["old_rating"] = existing.Rating
+		metadata["new_rating"] = updated.Rating
+	}
+	if notes != nil {
+		metadata["notes_updated"] = true
+	}
+	if err := s.logWatchAudit(ctx, "update_watch_log", userID, metadata); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+// RemoveWatchLog soft deletes a watch log for a movie or series post.
+func (s *WatchLogService) RemoveWatchLog(ctx context.Context, userID, postID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.watch_logs").Start(ctx, "WatchLogService.RemoveWatchLog")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+	)
+	defer span.End()
+
+	if err := s.verifyWatchablePost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	query := `
+		UPDATE watch_logs
+		SET deleted_at = now(), updated_at = now()
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`
+	result, err := s.db.ExecContext(ctx, query, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to remove watch log: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	if rowsAffected == 0 {
+		notFoundErr := errors.New("watch log not found")
+		recordSpanError(span, notFoundErr)
+		return notFoundErr
+	}
+
+	if err := s.logWatchAudit(ctx, "remove_watch_log", userID, map[string]interface{}{
+		"post_id": postID.String(),
+	}); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	return nil
+}
+
+// GetUserWatchLogs retrieves paginated watch history for a user.
+func (s *WatchLogService) GetUserWatchLogs(ctx context.Context, userID uuid.UUID, limit int, cursor *string) ([]models.WatchLogWithPost, *string, error) {
+	ctx, span := otel.Tracer("clubhouse.watch_logs").Start(ctx, "WatchLogService.GetUserWatchLogs")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && *cursor != ""),
+	)
+	defer span.End()
+
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM users WHERE id = $1 AND deleted_at IS NULL AND approved_at IS NOT NULL)
+	`, userID).Scan(&exists); err != nil {
+		recordSpanError(span, err)
+		return nil, nil, fmt.Errorf("failed to check user: %w", err)
+	}
+	if !exists {
+		notFoundErr := errors.New("user not found")
+		recordSpanError(span, notFoundErr)
+		return nil, nil, notFoundErr
+	}
+
+	query := `
+		SELECT
+			wl.id, wl.user_id, wl.post_id, wl.rating, wl.notes, wl.watched_at, wl.created_at, wl.updated_at, wl.deleted_at,
+			p.id, p.user_id, p.section_id, p.content, p.created_at, p.updated_at, p.deleted_at, p.deleted_by_user_id
+		FROM watch_logs wl
+		JOIN posts p ON wl.post_id = p.id AND p.deleted_at IS NULL
+		WHERE wl.user_id = $1 AND wl.deleted_at IS NULL
+	`
+
+	args := []interface{}{userID}
+	argIndex := 2
+	if cursor != nil && strings.TrimSpace(*cursor) != "" {
+		query += fmt.Sprintf(" AND wl.watched_at < $%d", argIndex)
+		args = append(args, strings.TrimSpace(*cursor))
+		argIndex++
+	}
+
+	query += fmt.Sprintf(" ORDER BY wl.watched_at DESC, wl.id DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, nil, fmt.Errorf("failed to query watch logs: %w", err)
+	}
+	defer rows.Close()
+
+	logs := make([]models.WatchLogWithPost, 0, limit)
+	for rows.Next() {
+		watchLog, post, err := scanWatchLogWithPost(rows)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, nil, err
+		}
+
+		logs = append(logs, models.WatchLogWithPost{
+			WatchLog: *watchLog,
+			Post:     post,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, nil, fmt.Errorf("failed to iterate watch logs: %w", err)
+	}
+
+	hasMore := len(logs) > limit
+	if hasMore {
+		logs = logs[:limit]
+	}
+
+	var nextCursor *string
+	if hasMore && len(logs) > 0 {
+		cursorValue := logs[len(logs)-1].WatchedAt.Format(watchLogCursorLayout)
+		nextCursor = &cursorValue
+	}
+
+	return logs, nextCursor, nil
+}
+
+// GetPostWatchLogs retrieves watch log summary and entries for a post.
+func (s *WatchLogService) GetPostWatchLogs(ctx context.Context, postID uuid.UUID, viewerID *uuid.UUID) (*models.PostWatchLogsResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.watch_logs").Start(ctx, "WatchLogService.GetPostWatchLogs")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.Bool("has_viewer", viewerID != nil),
+	)
+	defer span.End()
+
+	if err := s.verifyWatchablePost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	var watchCount int
+	var avgRating sql.NullFloat64
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), AVG(rating)
+		FROM watch_logs
+		WHERE post_id = $1 AND deleted_at IS NULL
+	`, postID).Scan(&watchCount, &avgRating); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to fetch watch log summary: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			wl.id, wl.user_id, wl.post_id, wl.rating, wl.notes, wl.watched_at, wl.created_at, wl.updated_at, wl.deleted_at,
+			u.id, u.username, u.profile_picture_url
+		FROM watch_logs wl
+		JOIN users u ON wl.user_id = u.id
+		WHERE wl.post_id = $1 AND wl.deleted_at IS NULL
+		ORDER BY wl.watched_at DESC, wl.id DESC
+	`, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query post watch logs: %w", err)
+	}
+	defer rows.Close()
+
+	logs := make([]models.WatchLogResponse, 0)
+	for rows.Next() {
+		watchLog, watchUser, err := scanWatchLogWithUser(rows)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+
+		logs = append(logs, models.WatchLogResponse{
+			WatchLog: *watchLog,
+			User:     *watchUser,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate post watch logs: %w", err)
+	}
+
+	response := &models.PostWatchLogsResponse{
+		WatchCount: watchCount,
+		Logs:       logs,
+	}
+	if avgRating.Valid {
+		avg := avgRating.Float64
+		response.AvgRating = &avg
+	}
+
+	if viewerID != nil {
+		viewerLog, err := s.getViewerWatchLog(ctx, postID, *viewerID)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		if viewerLog != nil {
+			response.ViewerWatched = true
+			response.ViewerRating = &viewerLog.Rating
+		}
+	}
+
+	return response, nil
+}
+
+func validateWatchLogRating(rating int) error {
+	if rating < 1 || rating > 5 {
+		return errors.New("rating must be between 1 and 5")
+	}
+	return nil
+}
+
+func (s *WatchLogService) verifyWatchablePost(ctx context.Context, postID uuid.UUID) error {
+	var sectionType string
+	query := `
+		SELECT s.type
+		FROM posts p
+		JOIN sections s ON p.section_id = s.id
+		WHERE p.id = $1 AND p.deleted_at IS NULL
+	`
+	if err := s.db.QueryRowContext(ctx, query, postID).Scan(&sectionType); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("post not found")
+		}
+		return fmt.Errorf("failed to verify watchable post: %w", err)
+	}
+	if sectionType != "movie" && sectionType != "series" {
+		return errors.New("post is not a movie or series")
+	}
+	return nil
+}
+
+func (s *WatchLogService) getExistingWatchLog(ctx context.Context, userID, postID uuid.UUID) (*models.WatchLog, error) {
+	query := `
+		SELECT id, user_id, post_id, rating, notes, watched_at, created_at, updated_at, deleted_at
+		FROM watch_logs
+		WHERE user_id = $1 AND post_id = $2
+		ORDER BY deleted_at NULLS FIRST, watched_at DESC
+		LIMIT 1
+	`
+
+	var log models.WatchLog
+	var notes sql.NullString
+	var updatedAt sql.NullTime
+	var deletedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, userID, postID).Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &notes, &log.WatchedAt, &log.CreatedAt, &updatedAt, &deletedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to check existing watch log: %w", err)
+	}
+
+	if notes.Valid {
+		log.Notes = &notes.String
+	}
+	if updatedAt.Valid {
+		log.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		log.DeletedAt = &deletedAt.Time
+	}
+
+	return &log, nil
+}
+
+func (s *WatchLogService) createWatchLog(ctx context.Context, userID, postID uuid.UUID, rating int, notes string) (*models.WatchLog, error) {
+	query := `
+		INSERT INTO watch_logs (id, user_id, post_id, rating, notes, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, now())
+		RETURNING id, user_id, post_id, rating, notes, watched_at, created_at, updated_at, deleted_at
+	`
+
+	watchLogID := uuid.New()
+	watchedAt := s.now().UTC()
+	var log models.WatchLog
+	var note sql.NullString
+	var updatedAt sql.NullTime
+	var deletedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, watchLogID, userID, postID, rating, normalizeWatchLogNote(notes), watchedAt).Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &note, &log.WatchedAt, &log.CreatedAt, &updatedAt, &deletedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to create watch log: %w", err)
+	}
+
+	if note.Valid {
+		log.Notes = &note.String
+	}
+	if updatedAt.Valid {
+		log.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		log.DeletedAt = &deletedAt.Time
+	}
+
+	return &log, nil
+}
+
+func (s *WatchLogService) restoreWatchLog(ctx context.Context, watchLogID uuid.UUID, rating int, notes string) (*models.WatchLog, error) {
+	query := `
+		UPDATE watch_logs
+		SET deleted_at = NULL,
+			rating = $2,
+			notes = $3,
+			watched_at = $4,
+			updated_at = now()
+		WHERE id = $1
+		RETURNING id, user_id, post_id, rating, notes, watched_at, created_at, updated_at, deleted_at
+	`
+
+	watchedAt := s.now().UTC()
+	var log models.WatchLog
+	var note sql.NullString
+	var updatedAt sql.NullTime
+	var deletedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, watchLogID, rating, normalizeWatchLogNote(notes), watchedAt).Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &note, &log.WatchedAt, &log.CreatedAt, &updatedAt, &deletedAt,
+	); err != nil {
+		return nil, fmt.Errorf("failed to restore watch log: %w", err)
+	}
+
+	if note.Valid {
+		log.Notes = &note.String
+	}
+	if updatedAt.Valid {
+		log.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		log.DeletedAt = &deletedAt.Time
+	}
+
+	return &log, nil
+}
+
+func (s *WatchLogService) updateWatchLog(ctx context.Context, watchLogID uuid.UUID, rating *int, notes *string) (*models.WatchLog, error) {
+	setClauses := make([]string, 0, 3)
+	args := make([]interface{}, 0, 4)
+	args = append(args, watchLogID)
+	argIndex := 2
+
+	if rating != nil {
+		setClauses = append(setClauses, fmt.Sprintf("rating = $%d", argIndex))
+		args = append(args, *rating)
+		argIndex++
+	}
+	if notes != nil {
+		setClauses = append(setClauses, fmt.Sprintf("notes = $%d", argIndex))
+		args = append(args, normalizeWatchLogNote(*notes))
+	}
+	setClauses = append(setClauses, "updated_at = now()")
+
+	query := fmt.Sprintf(`
+		UPDATE watch_logs
+		SET %s
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, user_id, post_id, rating, notes, watched_at, created_at, updated_at, deleted_at
+	`, strings.Join(setClauses, ", "))
+
+	var log models.WatchLog
+	var note sql.NullString
+	var updatedAt sql.NullTime
+	var deletedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &note, &log.WatchedAt, &log.CreatedAt, &updatedAt, &deletedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("watch log not found")
+		}
+		return nil, fmt.Errorf("failed to update watch log: %w", err)
+	}
+
+	if note.Valid {
+		log.Notes = &note.String
+	}
+	if updatedAt.Valid {
+		log.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		log.DeletedAt = &deletedAt.Time
+	}
+
+	return &log, nil
+}
+
+func (s *WatchLogService) getViewerWatchLog(ctx context.Context, postID, viewerID uuid.UUID) (*models.WatchLog, error) {
+	query := `
+		SELECT id, user_id, post_id, rating, notes, watched_at, created_at, updated_at, deleted_at
+		FROM watch_logs
+		WHERE post_id = $1 AND user_id = $2 AND deleted_at IS NULL
+	`
+
+	var log models.WatchLog
+	var notes sql.NullString
+	var updatedAt sql.NullTime
+	var deletedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, postID, viewerID).Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &notes, &log.WatchedAt, &log.CreatedAt, &updatedAt, &deletedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to fetch viewer watch log: %w", err)
+	}
+
+	if notes.Valid {
+		log.Notes = &notes.String
+	}
+	if updatedAt.Valid {
+		log.UpdatedAt = &updatedAt.Time
+	}
+	if deletedAt.Valid {
+		log.DeletedAt = &deletedAt.Time
+	}
+
+	return &log, nil
+}
+
+func (s *WatchLogService) logWatchAudit(ctx context.Context, action string, userID uuid.UUID, metadata map[string]interface{}) error {
+	if err := s.auditService.LogAuditWithMetadata(ctx, action, uuid.Nil, userID, metadata); err != nil {
+		return fmt.Errorf("failed to create watch log audit log: %w", err)
+	}
+	return nil
+}
+
+func normalizeWatchLogNote(note string) interface{} {
+	trimmed := strings.TrimSpace(note)
+	if trimmed == "" {
+		return nil
+	}
+	return trimmed
+}
+
+func scanWatchLogWithPost(rows *sql.Rows) (*models.WatchLog, *models.Post, error) {
+	var log models.WatchLog
+	var logNotes sql.NullString
+	var logUpdatedAt sql.NullTime
+	var logDeletedAt sql.NullTime
+	var post models.Post
+	var postUpdatedAt sql.NullTime
+	var postDeletedAt sql.NullTime
+	var postDeletedBy sql.NullString
+
+	if err := rows.Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &logNotes, &log.WatchedAt, &log.CreatedAt, &logUpdatedAt, &logDeletedAt,
+		&post.ID, &post.UserID, &post.SectionID, &post.Content, &post.CreatedAt, &postUpdatedAt, &postDeletedAt, &postDeletedBy,
+	); err != nil {
+		return nil, nil, fmt.Errorf("failed to scan watch log: %w", err)
+	}
+
+	if logNotes.Valid {
+		log.Notes = &logNotes.String
+	}
+	if logUpdatedAt.Valid {
+		log.UpdatedAt = &logUpdatedAt.Time
+	}
+	if logDeletedAt.Valid {
+		log.DeletedAt = &logDeletedAt.Time
+	}
+
+	if postUpdatedAt.Valid {
+		post.UpdatedAt = &postUpdatedAt.Time
+	}
+	if postDeletedAt.Valid {
+		post.DeletedAt = &postDeletedAt.Time
+	}
+	if postDeletedBy.Valid {
+		parsedID, err := uuid.Parse(postDeletedBy.String)
+		if err == nil {
+			post.DeletedByUserID = &parsedID
+		}
+	}
+
+	return &log, &post, nil
+}
+
+func scanWatchLogWithUser(rows *sql.Rows) (*models.WatchLog, *models.WatchLogUser, error) {
+	var log models.WatchLog
+	var logNotes sql.NullString
+	var logUpdatedAt sql.NullTime
+	var logDeletedAt sql.NullTime
+	var user models.WatchLogUser
+
+	if err := rows.Scan(
+		&log.ID, &log.UserID, &log.PostID, &log.Rating, &logNotes, &log.WatchedAt, &log.CreatedAt, &logUpdatedAt, &logDeletedAt,
+		&user.ID, &user.Username, &user.ProfilePictureUrl,
+	); err != nil {
+		return nil, nil, fmt.Errorf("failed to scan post watch log: %w", err)
+	}
+
+	if logNotes.Valid {
+		log.Notes = &logNotes.String
+	}
+	if logUpdatedAt.Valid {
+		log.UpdatedAt = &logUpdatedAt.Time
+	}
+	if logDeletedAt.Valid {
+		log.DeletedAt = &logDeletedAt.Time
+	}
+
+	return &log, &user, nil
+}

--- a/backend/internal/services/watch_log_test.go
+++ b/backend/internal/services/watch_log_test.go
@@ -1,0 +1,380 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestLogWatchCreatesWatchLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchloguser", "watchloguser@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "A great movie")
+
+	service := NewWatchLogService(db, nil)
+	watchLog, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 5, "Amazing film")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+	if watchLog.Rating != 5 {
+		t.Fatalf("expected rating 5, got %d", watchLog.Rating)
+	}
+	if watchLog.Notes == nil || *watchLog.Notes != "Amazing film" {
+		t.Fatalf("expected notes %q, got %v", "Amazing film", watchLog.Notes)
+	}
+	if watchLog.WatchedAt.IsZero() {
+		t.Fatalf("expected watched_at to be set")
+	}
+}
+
+func TestLogWatchAllowsSeriesPosts(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "serieswatchuser", "serieswatchuser@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Series", "series")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "A great show")
+
+	service := NewWatchLogService(db, nil)
+	if _, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 4, ""); err != nil {
+		t.Fatalf("LogWatch failed for series post: %v", err)
+	}
+}
+
+func TestLogWatchRejectsNonMovieOrSeriesPost(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "badwatchpost", "badwatchpost@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "A recipe")
+
+	service := NewWatchLogService(db, nil)
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 4, "")
+	if err == nil {
+		t.Fatalf("expected error for non-movie post")
+	}
+	if err.Error() != "post is not a movie or series" {
+		t.Fatalf("expected post type error, got %v", err)
+	}
+}
+
+func TestLogWatchCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "auditwatchlog", "auditwatchlog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 5, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'log_watch' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if int(metadata["rating"].(float64)) != 5 {
+		t.Errorf("expected rating 5, got %v", metadata["rating"])
+	}
+}
+
+func TestLogWatchRestoresDeletedWatchLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "restorewatchlog", "restorewatchlog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	initial, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 3, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+	if err := service.RemoveWatchLog(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("RemoveWatchLog failed: %v", err)
+	}
+
+	restored, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 5, "Second watch")
+	if err != nil {
+		t.Fatalf("LogWatch restore failed: %v", err)
+	}
+	if restored.ID != initial.ID {
+		t.Fatalf("expected restore of same log ID")
+	}
+	if restored.DeletedAt != nil {
+		t.Fatalf("expected deleted_at to be nil")
+	}
+	if restored.Rating != 5 {
+		t.Fatalf("expected rating 5, got %d", restored.Rating)
+	}
+	if restored.Notes == nil || *restored.Notes != "Second watch" {
+		t.Fatalf("expected restored notes %q, got %v", "Second watch", restored.Notes)
+	}
+}
+
+func TestUpdateWatchLogCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "updatewatchlog", "updatewatchlog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 2, "Old notes")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	newRating := 4
+	newNotes := "Updated notes"
+	updated, err := service.UpdateWatchLog(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), &newRating, &newNotes)
+	if err != nil {
+		t.Fatalf("UpdateWatchLog failed: %v", err)
+	}
+	if updated.Rating != 4 {
+		t.Fatalf("expected rating 4, got %d", updated.Rating)
+	}
+	if updated.Notes == nil || *updated.Notes != newNotes {
+		t.Fatalf("expected notes %q, got %v", newNotes, updated.Notes)
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'update_watch_log' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+	if int(metadata["old_rating"].(float64)) != 2 {
+		t.Errorf("expected old_rating 2, got %v", metadata["old_rating"])
+	}
+	if int(metadata["new_rating"].(float64)) != 4 {
+		t.Errorf("expected new_rating 4, got %v", metadata["new_rating"])
+	}
+	if notesUpdated, ok := metadata["notes_updated"].(bool); !ok || !notesUpdated {
+		t.Errorf("expected notes_updated true, got %v", metadata["notes_updated"])
+	}
+}
+
+func TestRemoveWatchLogCreatesAuditLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "removewatchlog", "removewatchlog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 3, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	if err := service.RemoveWatchLog(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("RemoveWatchLog failed: %v", err)
+	}
+
+	var deletedAt time.Time
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT deleted_at FROM watch_logs WHERE user_id = $1 AND post_id = $2
+	`, uuid.MustParse(userID), uuid.MustParse(postID)).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query watch log row: %v", err)
+	}
+	if deletedAt.IsZero() {
+		t.Fatalf("expected deleted_at to be set")
+	}
+
+	var metadataBytes []byte
+	query := `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = 'remove_watch_log' AND target_user_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1
+	`
+	if err := db.QueryRowContext(context.Background(), query, uuid.MustParse(userID)).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query audit log: %v", err)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["post_id"] != postID {
+		t.Errorf("expected post_id %s, got %v", postID, metadata["post_id"])
+	}
+}
+
+func TestGetPostWatchLogs(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchviewer", "watchviewer@test.com", false, true)
+	otherUserID := testutil.CreateTestUser(t, db, "watchother", "watchother@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 4, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+	_, err = service.LogWatch(context.Background(), uuid.MustParse(otherUserID), uuid.MustParse(postID), 2, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	viewer := uuid.MustParse(userID)
+	info, err := service.GetPostWatchLogs(context.Background(), uuid.MustParse(postID), &viewer)
+	if err != nil {
+		t.Fatalf("GetPostWatchLogs failed: %v", err)
+	}
+
+	if info.WatchCount != 2 {
+		t.Fatalf("expected watch count 2, got %d", info.WatchCount)
+	}
+	if info.AvgRating == nil || math.Abs(*info.AvgRating-3.0) > 0.001 {
+		t.Fatalf("expected avg rating 3.0, got %v", info.AvgRating)
+	}
+	if len(info.Logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(info.Logs))
+	}
+	if !info.ViewerWatched || info.ViewerRating == nil || *info.ViewerRating != 4 {
+		t.Fatalf("expected viewer watch data for rating 4")
+	}
+
+	for _, entry := range info.Logs {
+		if entry.User.ID == uuid.Nil {
+			t.Fatalf("expected user id in watch log response")
+		}
+		if entry.User.Username == "" {
+			t.Fatalf("expected username in watch log response")
+		}
+	}
+}
+
+func TestGetUserWatchLogsPagination(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchhistory", "watchhistory@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID1 := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post one")
+	postID2 := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post two")
+
+	service := NewWatchLogService(db, nil)
+	log1, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID1), 3, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+	log2, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID2), 4, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now().Add(-1 * time.Hour)
+	if _, err := db.ExecContext(context.Background(), `UPDATE watch_logs SET watched_at = $1 WHERE id = $2`, older, log1.ID); err != nil {
+		t.Fatalf("failed to update watched_at: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `UPDATE watch_logs SET watched_at = $1 WHERE id = $2`, newer, log2.ID); err != nil {
+		t.Fatalf("failed to update watched_at: %v", err)
+	}
+
+	logs, nextCursor, err := service.GetUserWatchLogs(context.Background(), uuid.MustParse(userID), 1, nil)
+	if err != nil {
+		t.Fatalf("GetUserWatchLogs failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	if nextCursor == nil {
+		t.Fatalf("expected next cursor")
+	}
+	if logs[0].Post == nil || logs[0].Post.ID != uuid.MustParse(postID2) {
+		t.Fatalf("expected most recent post")
+	}
+
+	logs, nextCursor, err = service.GetUserWatchLogs(context.Background(), uuid.MustParse(userID), 1, nextCursor)
+	if err != nil {
+		t.Fatalf("GetUserWatchLogs with cursor failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	if nextCursor != nil {
+		t.Fatalf("expected next cursor nil")
+	}
+	if logs[0].Post == nil || logs[0].Post.ID != uuid.MustParse(postID1) {
+		t.Fatalf("expected older post")
+	}
+}
+
+func TestWatchLogRatingValidation(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchrating", "watchrating@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := NewWatchLogService(db, nil)
+	if _, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 6, ""); err == nil {
+		t.Fatalf("expected error for invalid rating")
+	}
+
+	_, err := service.LogWatch(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), 4, "")
+	if err != nil {
+		t.Fatalf("LogWatch failed: %v", err)
+	}
+
+	invalid := 0
+	_, err = service.UpdateWatchLog(context.Background(), uuid.MustParse(userID), uuid.MustParse(postID), &invalid, nil)
+	if err == nil {
+		t.Fatalf("expected update validation error for invalid rating")
+	}
+}


### PR DESCRIPTION
## Summary
- add `WatchLogService` with movie/series post validation, rating validation, soft-delete restore behavior, pagination, and post-level aggregation methods
- emit required audit events for all watch-log mutations (`log_watch`, `update_watch_log`, `remove_watch_log`) with metadata
- add comprehensive service tests for CRUD, restore flow, pagination, summary response, and audit logging coverage
- add `models.WatchLogWithPost` to support paginated watch history responses with embedded post data

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run WatchLog -v`
- `cd backend && go test ./...`

Closes #794