### PR TITLE
[Movies] Register movie extractor in metadata pipeline

### DIFF
--- a/backend/internal/services/comment.go
+++ b/backend/internal/services/comment.go
@@ -191,7 +191,7 @@ func (s *CommentService) CreateComment(ctx context.Context, req *models.CreateCo
 	// Create comment ID
 	commentID := uuid.New()
 
-	linkMetadata := fetchLinkMetadata(ctx, req.Links)
+	linkMetadata := fetchLinkMetadata(ctx, req.Links, sectionType)
 
 	// Begin transaction
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -376,7 +376,7 @@ func (s *CommentService) UpdateComment(ctx context.Context, commentID uuid.UUID,
 
 		linksChanged = !linkRequestsMatchURLs(existingURLs, *req.Links)
 		if linksChanged && len(*req.Links) > 0 {
-			linkMetadata = fetchLinkMetadata(ctx, *req.Links)
+			linkMetadata = fetchLinkMetadata(ctx, *req.Links, sectionType)
 		}
 	}
 

--- a/backend/internal/services/link_metadata_test.go
+++ b/backend/internal/services/link_metadata_test.go
@@ -29,7 +29,7 @@ func TestFetchLinkMetadataIncludesSpotifyEmbed(t *testing.T) {
 	})
 
 	links := []models.LinkRequest{{URL: "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp"}}
-	metadata := fetchLinkMetadata(context.Background(), links)
+	metadata := fetchLinkMetadata(context.Background(), links, "music")
 	if len(metadata) != 1 {
 		t.Fatalf("expected 1 metadata entry, got %d", len(metadata))
 	}

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -353,7 +353,7 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 
 		linksChanged = !linkRequestsMatchExistingLinks(existingLinks, *req.Links)
 		if linksChanged && len(*req.Links) > 0 {
-			linkMetadata = fetchLinkMetadata(ctx, *req.Links)
+			linkMetadata = fetchLinkMetadata(ctx, *req.Links, sectionType)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- gate movie metadata extraction by section type so it only runs for `movie` and `series` sections
- wire section type context through synchronous link metadata fetches and metadata worker jobs
- attach parsed movie metadata to `metadata["movie"]` when TMDB lookup succeeds, while gracefully falling back to HTML metadata if TMDB client/parsing fails
- add link metadata integration tests for movie section behavior and fallback handling

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services/links -run 'TestFetchMetadataMovieSectionIncludesMovieMetadata|TestFetchMetadataGeneralSectionSkipsMovieMetadata|TestFetchMetadataMovieParserFailureFallsBackToHTMLMetadata' -v`
- `cd backend && go test ./internal/services -run 'TestFetchLinkMetadataIncludesSpotifyEmbed' -v`
- `cd backend && go test ./...`

Closes #797