### PR TITLE
[Movies] Create watch log handler

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -167,6 +167,7 @@ func main() {
 	reactionHandler := handlers.NewReactionHandler(dbConn, redisConn, pushService)
 	highlightReactionHandler := handlers.NewHighlightReactionHandler(dbConn, redisConn)
 	cookLogHandler := handlers.NewCookLogHandler(dbConn, redisConn)
+	watchLogHandler := handlers.NewWatchLogHandler(dbConn, redisConn)
 	userHandler := handlers.NewUserHandler(dbConn)
 	sectionHandler := handlers.NewSectionHandler(dbConn)
 	searchHandler := handlers.NewSearchHandler(dbConn)
@@ -323,6 +324,10 @@ func main() {
 		updateCookLog:           cookLogHandler.UpdateCookLog,
 		removeCookLog:           cookLogHandler.RemoveCookLog,
 		getCookLogs:             cookLogHandler.GetPostCookLogs,
+		logWatch:                watchLogHandler.LogWatch,
+		updateWatchLog:          watchLogHandler.UpdateWatchLog,
+		removeWatchLog:          watchLogHandler.RemoveWatchLog,
+		getWatchLogs:            watchLogHandler.GetPostWatchLogs,
 		getPost:                 postHandler.GetPost,
 		updatePost:              postHandler.UpdatePost,
 		deletePost:              postHandler.DeletePost,
@@ -396,6 +401,7 @@ func main() {
 
 	// Cook log routes (protected)
 	mux.Handle("/api/v1/me/cook-logs", requireAuth(http.HandlerFunc(cookLogHandler.GetMyCookLogs)))
+	mux.Handle("/api/v1/me/watch-logs", requireAuth(http.HandlerFunc(watchLogHandler.GetMyWatchLogs)))
 
 	// Link preview route (protected with CSRF - POST only, prevents SSRF)
 	mux.Handle("/api/v1/links/preview", requireAuthCSRF(http.HandlerFunc(linkHandler.PreviewLink)))

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -114,7 +114,7 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuth(http.HandlerFunc(deps.getCookLogs)).ServeHTTP(w, r)
 			return
 		}
-		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/watch-logs") {
+		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-logs") {
 			// GET /api/v1/posts/{id}/watch-logs
 			requireAuth(http.HandlerFunc(deps.getWatchLogs)).ServeHTTP(w, r)
 			return
@@ -124,7 +124,7 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuthCSRF(http.HandlerFunc(deps.logCook)).ServeHTTP(w, r)
 			return
 		}
-		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/watch-log") {
+		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-log") {
 			// POST /api/v1/posts/{id}/watch-log
 			requireAuthCSRF(http.HandlerFunc(deps.logWatch)).ServeHTTP(w, r)
 			return
@@ -134,7 +134,7 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuthCSRF(http.HandlerFunc(deps.updateCookLog)).ServeHTTP(w, r)
 			return
 		}
-		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/watch-log") {
+		if r.Method == http.MethodPut && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-log") {
 			// PUT /api/v1/posts/{id}/watch-log
 			requireAuthCSRF(http.HandlerFunc(deps.updateWatchLog)).ServeHTTP(w, r)
 			return
@@ -144,7 +144,7 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuthCSRF(http.HandlerFunc(deps.removeCookLog)).ServeHTTP(w, r)
 			return
 		}
-		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/watch-log") {
+		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-log") {
 			// DELETE /api/v1/posts/{id}/watch-log
 			requireAuthCSRF(http.HandlerFunc(deps.removeWatchLog)).ServeHTTP(w, r)
 			return

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -28,6 +28,10 @@ type postRouteDeps struct {
 	updateCookLog           http.HandlerFunc
 	removeCookLog           http.HandlerFunc
 	getCookLogs             http.HandlerFunc
+	logWatch                http.HandlerFunc
+	updateWatchLog          http.HandlerFunc
+	removeWatchLog          http.HandlerFunc
+	getWatchLogs            http.HandlerFunc
 	getPost                 http.HandlerFunc
 	updatePost              http.HandlerFunc
 	deletePost              http.HandlerFunc
@@ -110,9 +114,19 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuth(http.HandlerFunc(deps.getCookLogs)).ServeHTTP(w, r)
 			return
 		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/watch-logs") {
+			// GET /api/v1/posts/{id}/watch-logs
+			requireAuth(http.HandlerFunc(deps.getWatchLogs)).ServeHTTP(w, r)
+			return
+		}
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/cook-log") {
 			// POST /api/v1/posts/{id}/cook-log
 			requireAuthCSRF(http.HandlerFunc(deps.logCook)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/watch-log") {
+			// POST /api/v1/posts/{id}/watch-log
+			requireAuthCSRF(http.HandlerFunc(deps.logWatch)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/cook-log") {
@@ -120,9 +134,19 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuthCSRF(http.HandlerFunc(deps.updateCookLog)).ServeHTTP(w, r)
 			return
 		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/watch-log") {
+			// PUT /api/v1/posts/{id}/watch-log
+			requireAuthCSRF(http.HandlerFunc(deps.updateWatchLog)).ServeHTTP(w, r)
+			return
+		}
 		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cook-log") {
 			// DELETE /api/v1/posts/{id}/cook-log
 			requireAuthCSRF(http.HandlerFunc(deps.removeCookLog)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/watch-log") {
+			// DELETE /api/v1/posts/{id}/watch-log
+			requireAuthCSRF(http.HandlerFunc(deps.removeWatchLog)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPatch && isPostIDPath(r.URL.Path) {

--- a/backend/cmd/server/routes_test.go
+++ b/backend/cmd/server/routes_test.go
@@ -617,6 +617,163 @@ func TestPostRouteHandlerGetCookLogsRequiresAuth(t *testing.T) {
 	}
 }
 
+func TestPostRouteHandlerLogWatchUsesCSRFAuth(t *testing.T) {
+	authCalled := false
+	logCalled := false
+
+	requireAuth := func(next http.Handler) http.Handler {
+		return next
+	}
+	requireAuthCSRF := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authCalled = true
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	deps := postRouteDeps{
+		getThread: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getThread should not be called")
+		},
+		restorePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("restorePost should not be called")
+		},
+		addReactionToPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("addReactionToPost should not be called")
+		},
+		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeReactionFromPost should not be called")
+		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
+		logWatch: func(w http.ResponseWriter, r *http.Request) {
+			logCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+		getPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPost should not be called")
+		},
+		updatePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updatePost should not be called")
+		},
+		deletePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("deletePost should not be called")
+		},
+	}
+
+	handler := newPostRouteHandler(requireAuth, requireAuthCSRF, deps)
+	postID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID.String()+"/watch-log", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("expected status %v, got %v", http.StatusOK, status)
+	}
+
+	if !authCalled {
+		t.Fatal("expected CSRF auth middleware to be called")
+	}
+
+	if !logCalled {
+		t.Fatal("expected watch log handler to be called")
+	}
+}
+
+func TestPostRouteHandlerGetWatchLogsRequiresAuth(t *testing.T) {
+	authCalled := false
+
+	requireAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authCalled = true
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	deps := postRouteDeps{
+		getThread: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getThread should not be called")
+		},
+		restorePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("restorePost should not be called")
+		},
+		addReactionToPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("addReactionToPost should not be called")
+		},
+		removeReactionFromPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeReactionFromPost should not be called")
+		},
+		saveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("saveRecipe should not be called")
+		},
+		unsaveRecipe: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("unsaveRecipe should not be called")
+		},
+		getPostSaves: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPostSaves should not be called")
+		},
+		logCook: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("logCook should not be called")
+		},
+		updateCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updateCookLog should not be called")
+		},
+		removeCookLog: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("removeCookLog should not be called")
+		},
+		getCookLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getCookLogs should not be called")
+		},
+		getWatchLogs: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getWatchLogs should not be called without auth")
+		},
+		getPost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("getPost should not be called")
+		},
+		updatePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("updatePost should not be called")
+		},
+		deletePost: func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("deletePost should not be called")
+		},
+	}
+
+	handler := newPostRouteHandler(requireAuth, requireAuth, deps)
+	postID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID.String()+"/watch-logs", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Fatalf("expected status %v, got %v", http.StatusUnauthorized, status)
+	}
+
+	if !authCalled {
+		t.Fatal("expected auth middleware to be called")
+	}
+}
+
 func TestSectionRouteHandlerFeedRequiresAuth(t *testing.T) {
 	authCalled := false
 

--- a/backend/internal/handlers/pubsub.go
+++ b/backend/internal/handlers/pubsub.go
@@ -94,6 +94,18 @@ type movieUnwatchlistedEventData struct {
 	UserID uuid.UUID `json:"user_id"`
 }
 
+type movieWatchedEventData struct {
+	PostID   uuid.UUID `json:"post_id"`
+	UserID   uuid.UUID `json:"user_id"`
+	Username string    `json:"username"`
+	Rating   int       `json:"rating"`
+}
+
+type movieWatchRemovedEventData struct {
+	PostID uuid.UUID `json:"post_id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
 func publishEvent(ctx context.Context, redisClient *redis.Client, channel string, eventType string, data any) error {
 	if redisClient == nil {
 		return nil

--- a/backend/internal/handlers/watch_log.go
+++ b/backend/internal/handlers/watch_log.go
@@ -1,0 +1,349 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// WatchLogHandler handles movie/series watch log endpoints.
+type WatchLogHandler struct {
+	watchLogService *services.WatchLogService
+	postService     *services.PostService
+	userService     *services.UserService
+	redis           *redis.Client
+}
+
+// NewWatchLogHandler creates a new watch log handler.
+func NewWatchLogHandler(db *sql.DB, redisClient *redis.Client) *WatchLogHandler {
+	return &WatchLogHandler{
+		watchLogService: services.NewWatchLogService(db, nil),
+		postService:     services.NewPostService(db),
+		userService:     services.NewUserService(db),
+		redis:           redisClient,
+	}
+}
+
+// LogWatch handles POST /api/v1/posts/{postId}/watch-log.
+func (h *WatchLogHandler) LogWatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.LogWatchRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.WatchedAt.IsZero() {
+		writeError(r.Context(), w, http.StatusBadRequest, "WATCHED_AT_REQUIRED", "watched_at is required")
+		return
+	}
+
+	notes := ""
+	if req.Notes != nil {
+		notes = *req.Notes
+	}
+
+	watchLog, err := h.watchLogService.LogWatchAt(r.Context(), userID, postID, req.Rating, notes, &req.WatchedAt)
+	if err != nil {
+		switch err.Error() {
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a movie or series":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_MOVIE_OR_SERIES", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "WATCH_LOG_CREATE_FAILED", "Failed to log watch")
+		}
+		return
+	}
+
+	publishCtx, cancel := publishContext()
+	username := ""
+	if user, err := h.userService.GetUserByID(publishCtx, userID); err == nil {
+		username = user.Username
+	} else {
+		observability.LogWarn(publishCtx, "failed to load user for movie_watched event",
+			"user_id", userID.String(),
+			"post_id", postID.String(),
+			"error", err.Error(),
+		)
+	}
+
+	eventData := movieWatchedEventData{
+		PostID:   postID,
+		UserID:   userID,
+		Username: username,
+		Rating:   watchLog.Rating,
+	}
+	_ = publishEvent(publishCtx, h.redis, formatChannel(postPrefix, postID), "movie_watched", eventData)
+	if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "movie_watched", eventData)
+	}
+	cancel()
+
+	observability.LogInfo(r.Context(), "watch log created",
+		"watch_log_id", watchLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"rating", strconv.Itoa(watchLog.Rating),
+	)
+
+	response := models.CreateWatchLogResponse{WatchLog: *watchLog}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode create watch log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// UpdateWatchLog handles PUT /api/v1/posts/{postId}/watch-log.
+func (h *WatchLogHandler) UpdateWatchLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only PUT requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.UpdateWatchLogRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	watchLog, err := h.watchLogService.UpdateWatchLog(r.Context(), userID, postID, req.Rating, req.Notes)
+	if err != nil {
+		switch err.Error() {
+		case "no fields to update":
+			writeError(r.Context(), w, http.StatusBadRequest, "NO_FIELDS_TO_UPDATE", err.Error())
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a movie or series":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_MOVIE_OR_SERIES", err.Error())
+		case "watch log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "WATCH_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "WATCH_LOG_UPDATE_FAILED", "Failed to update watch log")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "watch log updated",
+		"watch_log_id", watchLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	response := models.UpdateWatchLogResponse{WatchLog: *watchLog}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode update watch log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// RemoveWatchLog handles DELETE /api/v1/posts/{postId}/watch-log.
+func (h *WatchLogHandler) RemoveWatchLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	if err := h.watchLogService.RemoveWatchLog(r.Context(), userID, postID); err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a movie or series":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_MOVIE_OR_SERIES", err.Error())
+		case "watch log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "WATCH_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "WATCH_LOG_DELETE_FAILED", "Failed to remove watch log")
+		}
+		return
+	}
+
+	publishCtx, cancel := publishContext()
+	eventData := movieWatchRemovedEventData{PostID: postID, UserID: userID}
+	_ = publishEvent(publishCtx, h.redis, formatChannel(postPrefix, postID), "movie_watch_removed", eventData)
+	if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "movie_watch_removed", eventData)
+	}
+	cancel()
+
+	observability.LogInfo(r.Context(), "watch log removed",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPostWatchLogs handles GET /api/v1/posts/{postId}/watch-logs.
+func (h *WatchLogHandler) GetPostWatchLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.watchLogService.GetPostWatchLogs(r.Context(), postID, &userID)
+	if err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a movie or series":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_MOVIE_OR_SERIES", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCH_LOGS_FAILED", "Failed to get watch logs")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode get post watch logs response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// GetMyWatchLogs handles GET /api/v1/me/watch-logs.
+func (h *WatchLogHandler) GetMyWatchLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	limit := 20
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	cursor := r.URL.Query().Get("cursor")
+	var cursorPtr *string
+	if cursor != "" {
+		cursorPtr = &cursor
+	}
+
+	logs, nextCursor, err := h.watchLogService.GetUserWatchLogs(r.Context(), userID, limit, cursorPtr)
+	if err != nil {
+		switch err.Error() {
+		case "user not found":
+			writeError(r.Context(), w, http.StatusNotFound, "USER_NOT_FOUND", err.Error())
+		case "invalid cursor":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CURSOR", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCH_LOGS_FAILED", "Failed to get watch logs")
+		}
+		return
+	}
+
+	response := models.ListWatchLogsResponse{
+		WatchLogs:  logs,
+		NextCursor: nextCursor,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode list watch logs response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}

--- a/backend/internal/handlers/watch_log_test.go
+++ b/backend/internal/handlers/watch_log_test.go
@@ -1,0 +1,489 @@
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestWatchLogHandlerLogWatch(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchloguser", "watchlog@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	handler := NewWatchLogHandler(db, nil)
+
+	watchedAt := time.Date(2025, 1, 15, 20, 0, 0, 0, time.UTC)
+	body := bytes.NewBufferString(`{"rating":5,"notes":"Great film!","watched_at":"2025-01-15T20:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchloguser", false))
+	w := httptest.NewRecorder()
+
+	handler.LogWatch(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.CreateWatchLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.WatchLog.Rating != 5 {
+		t.Fatalf("expected rating 5, got %d", response.WatchLog.Rating)
+	}
+
+	if response.WatchLog.PostID != uuid.MustParse(postID) {
+		t.Fatalf("expected post_id %s, got %s", postID, response.WatchLog.PostID.String())
+	}
+
+	if !response.WatchLog.WatchedAt.Equal(watchedAt) {
+		t.Fatalf("expected watched_at %s, got %s", watchedAt.Format(time.RFC3339), response.WatchLog.WatchedAt.Format(time.RFC3339))
+	}
+}
+
+func TestWatchLogHandlerLogWatchRequiresAuth(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewWatchLogHandler(db, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+uuid.New().String()+"/watch-log", bytes.NewBufferString(`{"rating":5,"watched_at":"2025-01-15T20:00:00Z"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.LogWatch(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestWatchLogHandlerLogWatchInvalidRating(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchloginvalid", "watchloginvalid@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	handler := NewWatchLogHandler(db, nil)
+	body := bytes.NewBufferString(`{"rating":6,"watched_at":"2025-01-15T20:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchloginvalid", false))
+	w := httptest.NewRecorder()
+
+	handler.LogWatch(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "INVALID_RATING" {
+		t.Fatalf("expected INVALID_RATING, got %s", response.Code)
+	}
+}
+
+func TestWatchLogHandlerLogWatchNotMovieSection(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlogrecipe", "watchlogrecipe@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test recipe")
+
+	handler := NewWatchLogHandler(db, nil)
+	body := bytes.NewBufferString(`{"rating":4,"watched_at":"2025-01-15T20:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogrecipe", false))
+	w := httptest.NewRecorder()
+
+	handler.LogWatch(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "POST_NOT_MOVIE_OR_SERIES" {
+		t.Fatalf("expected POST_NOT_MOVIE_OR_SERIES, got %s", response.Code)
+	}
+}
+
+func TestWatchLogPublishesSectionEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	testutil.CleanupRedis(t)
+
+	redisClient := testutil.GetTestRedis(t)
+
+	userID := testutil.CreateTestUser(t, db, "watchlogeventuser", "watchlogevent@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	channel := formatChannel(sectionPrefix, sectionID)
+	pubsub := subscribeTestChannel(t, redisClient, channel)
+
+	handler := NewWatchLogHandler(db, redisClient)
+
+	body := bytes.NewBufferString(`{"rating":4,"notes":"Nice","watched_at":"2025-01-15T20:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogeventuser", false))
+	w := httptest.NewRecorder()
+
+	handler.LogWatch(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	event := receiveEvent(t, pubsub)
+	if event.Type != "movie_watched" {
+		t.Fatalf("expected movie_watched event, got %s", event.Type)
+	}
+
+	dataBytes, err := json.Marshal(event.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal event data: %v", err)
+	}
+
+	var payload movieWatchedEventData
+	if err := json.Unmarshal(dataBytes, &payload); err != nil {
+		t.Fatalf("failed to unmarshal movie watched payload: %v", err)
+	}
+
+	if payload.PostID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, payload.PostID.String())
+	}
+	if payload.UserID.String() != userID {
+		t.Fatalf("expected user_id %s, got %s", userID, payload.UserID.String())
+	}
+	if payload.Username != "watchlogeventuser" {
+		t.Fatalf("expected username watchlogeventuser, got %s", payload.Username)
+	}
+	if payload.Rating != 4 {
+		t.Fatalf("expected rating 4, got %d", payload.Rating)
+	}
+}
+
+func TestWatchLogRemovePublishesSectionEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	testutil.CleanupRedis(t)
+
+	redisClient := testutil.GetTestRedis(t)
+
+	userID := testutil.CreateTestUser(t, db, "watchlogremoveevent", "watchlogremove@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	logID := uuid.New()
+	if _, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, now(), now())
+	`, logID, userID, postID, 5); err != nil {
+		t.Fatalf("failed to create watch log: %v", err)
+	}
+
+	channel := formatChannel(sectionPrefix, sectionID)
+	pubsub := subscribeTestChannel(t, redisClient, channel)
+
+	handler := NewWatchLogHandler(db, redisClient)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/watch-log", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogremoveevent", false))
+	w := httptest.NewRecorder()
+
+	handler.RemoveWatchLog(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	event := receiveEvent(t, pubsub)
+	if event.Type != "movie_watch_removed" {
+		t.Fatalf("expected movie_watch_removed event, got %s", event.Type)
+	}
+
+	dataBytes, err := json.Marshal(event.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal event data: %v", err)
+	}
+
+	var payload movieWatchRemovedEventData
+	if err := json.Unmarshal(dataBytes, &payload); err != nil {
+		t.Fatalf("failed to unmarshal movie watch removed payload: %v", err)
+	}
+
+	if payload.PostID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, payload.PostID.String())
+	}
+	if payload.UserID.String() != userID {
+		t.Fatalf("expected user_id %s, got %s", userID, payload.UserID.String())
+	}
+}
+
+func TestWatchLogHandlerUpdateWatchLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlogupdateuser", "watchlogupdate@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	_, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, now(), now())
+	`, uuid.New(), userID, postID, 3)
+	if err != nil {
+		t.Fatalf("failed to create watch log: %v", err)
+	}
+
+	handler := NewWatchLogHandler(db, nil)
+
+	body := bytes.NewBufferString(`{"rating":4,"notes":"Updated notes"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogupdateuser", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateWatchLog(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.UpdateWatchLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.WatchLog.Rating != 4 {
+		t.Fatalf("expected rating 4, got %d", response.WatchLog.Rating)
+	}
+}
+
+func TestWatchLogHandlerUpdateWatchLogNoFields(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlognofields", "watchlognofields@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	_, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, now(), now())
+	`, uuid.New(), userID, postID, 3)
+	if err != nil {
+		t.Fatalf("failed to create watch log: %v", err)
+	}
+
+	handler := NewWatchLogHandler(db, nil)
+
+	body := bytes.NewBufferString(`{}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/watch-log", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlognofields", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateWatchLog(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "NO_FIELDS_TO_UPDATE" {
+		t.Fatalf("expected NO_FIELDS_TO_UPDATE, got %s", response.Code)
+	}
+}
+
+func TestWatchLogHandlerRemoveWatchLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlogdeleteuser", "watchlogdelete@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	logID := uuid.New()
+	_, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, now(), now())
+	`, logID, userID, postID, 5)
+	if err != nil {
+		t.Fatalf("failed to create watch log: %v", err)
+	}
+
+	handler := NewWatchLogHandler(db, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/watch-log", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogdeleteuser", false))
+	w := httptest.NewRecorder()
+
+	handler.RemoveWatchLog(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var deletedAt sql.NullTime
+	if err := db.QueryRow(`SELECT deleted_at FROM watch_logs WHERE id = $1`, logID).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query deleted watch log: %v", err)
+	}
+	if !deletedAt.Valid {
+		t.Fatalf("expected deleted_at to be set")
+	}
+}
+
+func TestWatchLogHandlerGetPostWatchLogs(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchloglistuser1", "watchloglist1@test.com", false, true)
+	user2ID := testutil.CreateTestUser(t, db, "watchloglistuser2", "watchloglist2@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+
+	_, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, now(), now()), ($5, $6, $7, $8, now(), now())
+	`,
+		uuid.New(), userID, postID, 5,
+		uuid.New(), user2ID, postID, 4,
+	)
+	if err != nil {
+		t.Fatalf("failed to create watch logs: %v", err)
+	}
+
+	handler := NewWatchLogHandler(db, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/watch-logs", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchloglistuser1", false))
+	w := httptest.NewRecorder()
+
+	handler.GetPostWatchLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.PostWatchLogsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.WatchCount != 2 {
+		t.Fatalf("expected watch_count 2, got %d", response.WatchCount)
+	}
+
+	if response.AvgRating == nil || *response.AvgRating < 4.4 || *response.AvgRating > 4.6 {
+		t.Fatalf("expected avg_rating around 4.5, got %v", response.AvgRating)
+	}
+
+	if len(response.Logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(response.Logs))
+	}
+
+	if !response.ViewerWatched || response.ViewerRating == nil {
+		t.Fatalf("expected viewer watch data")
+	}
+
+	if *response.ViewerRating != 5 {
+		t.Fatalf("expected viewer rating 5, got %d", *response.ViewerRating)
+	}
+}
+
+func TestWatchLogHandlerGetMyWatchLogsPagination(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlogmeuser", "watchlogme@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Test movie")
+	post2ID := testutil.CreateTestPost(t, db, userID, sectionID, "Another movie")
+
+	log1ID := uuid.New()
+	log2ID := uuid.New()
+	if _, err := db.Exec(`
+		INSERT INTO watch_logs (id, user_id, post_id, rating, watched_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, now()), ($6, $7, $8, $9, $10, now())
+	`,
+		log1ID, userID, postID, 5, time.Date(2025, 1, 10, 20, 0, 0, 0, time.UTC),
+		log2ID, userID, post2ID, 4, time.Date(2025, 1, 11, 20, 0, 0, 0, time.UTC),
+	); err != nil {
+		t.Fatalf("failed to create watch logs: %v", err)
+	}
+
+	handler := NewWatchLogHandler(db, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/watch-logs?limit=1", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlogmeuser", false))
+	w := httptest.NewRecorder()
+
+	handler.GetMyWatchLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ListWatchLogsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.WatchLogs) != 1 {
+		t.Fatalf("expected 1 watch log, got %d", len(response.WatchLogs))
+	}
+	if response.NextCursor == nil {
+		t.Fatalf("expected next_cursor to be set")
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/me/watch-logs?limit=1&cursor="+*response.NextCursor, nil)
+	req2 = req2.WithContext(createTestUserContext(req2.Context(), uuid.MustParse(userID), "watchlogmeuser", false))
+	w2 := httptest.NewRecorder()
+
+	handler.GetMyWatchLogs(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w2.Code, w2.Body.String())
+	}
+
+	var response2 models.ListWatchLogsResponse
+	if err := json.NewDecoder(w2.Body).Decode(&response2); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response2.WatchLogs) != 1 {
+		t.Fatalf("expected 1 watch log, got %d", len(response2.WatchLogs))
+	}
+	if response2.NextCursor != nil {
+		t.Fatalf("expected next_cursor to be nil")
+	}
+}

--- a/backend/internal/models/watch_log.go
+++ b/backend/internal/models/watch_log.go
@@ -32,6 +32,16 @@ type UpdateWatchLogRequest struct {
 	Notes  *string `json:"notes,omitempty"`
 }
 
+// CreateWatchLogResponse represents the response for creating a watch log.
+type CreateWatchLogResponse struct {
+	WatchLog WatchLog `json:"watch_log"`
+}
+
+// UpdateWatchLogResponse represents the response for updating a watch log.
+type UpdateWatchLogResponse struct {
+	WatchLog WatchLog `json:"watch_log"`
+}
+
 // WatchLogUser represents user information attached to a watch log response.
 type WatchLogUser struct {
 	ID                uuid.UUID `json:"id"`
@@ -58,4 +68,10 @@ type PostWatchLogsResponse struct {
 	Logs          []WatchLogResponse `json:"logs"`
 	ViewerWatched bool               `json:"viewer_watched"`
 	ViewerRating  *int               `json:"viewer_rating,omitempty"`
+}
+
+// ListWatchLogsResponse represents the response for listing a user's watch logs.
+type ListWatchLogsResponse struct {
+	WatchLogs  []WatchLogWithPost `json:"watch_logs"`
+	NextCursor *string            `json:"next_cursor,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add `WatchLogHandler` with full CRUD/list endpoints for watch logs and route wiring for `/api/v1/posts/{postId}/watch-log`, `/api/v1/posts/{postId}/watch-logs`, and `/api/v1/me/watch-logs`
- publish WebSocket events for section/post subscribers: `movie_watched` and `movie_watch_removed`
- support explicit `watched_at` values by extending watch log service with `LogWatchAt` and response models for handler payloads
- add handler and routing tests covering happy paths, validation/auth errors, pagination, and event publication

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run WatchLog -count=1`
- `cd backend && go test ./internal/handlers -run WatchLog -count=1`
- `cd backend && go test ./cmd/server -run 'PostRouteHandler.*(Watch|Cook)' -count=1`
- `cd backend && go test ./...`

Closes #796