### PR TITLE
[Movies] Create watchlist handler

### DIFF
--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -21,6 +21,9 @@ type postRouteDeps struct {
 	saveRecipe              http.HandlerFunc
 	unsaveRecipe            http.HandlerFunc
 	getPostSaves            http.HandlerFunc
+	addToWatchlist          http.HandlerFunc
+	removeFromWatchlist     http.HandlerFunc
+	getPostWatchlistInfo    http.HandlerFunc
 	logCook                 http.HandlerFunc
 	updateCookLog           http.HandlerFunc
 	removeCookLog           http.HandlerFunc
@@ -75,6 +78,21 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/saves") {
 			// GET /api/v1/posts/{id}/saves
 			requireAuth(http.HandlerFunc(deps.getPostSaves)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watchlist") {
+			// POST /api/v1/posts/{id}/watchlist
+			requireAuthCSRF(http.HandlerFunc(deps.addToWatchlist)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watchlist") {
+			// DELETE /api/v1/posts/{id}/watchlist
+			requireAuthCSRF(http.HandlerFunc(deps.removeFromWatchlist)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watchlist-info") {
+			// GET /api/v1/posts/{id}/watchlist-info
+			requireAuth(http.HandlerFunc(deps.getPostWatchlistInfo)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/reactions/") {

--- a/backend/internal/handlers/pubsub.go
+++ b/backend/internal/handlers/pubsub.go
@@ -82,6 +82,18 @@ type recipeCookRemovedEventData struct {
 	UserID uuid.UUID `json:"user_id"`
 }
 
+type movieWatchlistedEventData struct {
+	PostID     uuid.UUID `json:"post_id"`
+	UserID     uuid.UUID `json:"user_id"`
+	Username   string    `json:"username"`
+	Categories []string  `json:"categories"`
+}
+
+type movieUnwatchlistedEventData struct {
+	PostID uuid.UUID `json:"post_id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
 func publishEvent(ctx context.Context, redisClient *redis.Client, channel string, eventType string, data any) error {
 	if redisClient == nil {
 		return nil

--- a/backend/internal/handlers/watchlist.go
+++ b/backend/internal/handlers/watchlist.go
@@ -1,0 +1,532 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// WatchlistHandler handles movie/series watchlist endpoints.
+type WatchlistHandler struct {
+	watchlistService *services.WatchlistService
+	postService      *services.PostService
+	userService      *services.UserService
+	redis            *redis.Client
+}
+
+// NewWatchlistHandler creates a new watchlist handler.
+func NewWatchlistHandler(db *sql.DB, redisClient *redis.Client) *WatchlistHandler {
+	return &WatchlistHandler{
+		watchlistService: services.NewWatchlistService(db),
+		postService:      services.NewPostService(db),
+		userService:      services.NewUserService(db),
+		redis:            redisClient,
+	}
+}
+
+// AddToWatchlist handles POST /api/v1/posts/{postId}/watchlist.
+func (h *WatchlistHandler) AddToWatchlist(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.AddToWatchlistRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	items, err := h.watchlistService.AddToWatchlist(r.Context(), userID, postID, req.Categories)
+	if err != nil {
+		switch err.Error() {
+		case "movie or series post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+		case "category not found":
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "WATCHLIST_ADD_FAILED", "Failed to add to watchlist")
+		}
+		return
+	}
+
+	categories := uniqueWatchlistCategories(items)
+	publishCtx, cancel := publishContext()
+	username := ""
+	if user, err := h.userService.GetUserByID(publishCtx, userID); err == nil {
+		username = user.Username
+	} else {
+		observability.LogWarn(publishCtx, "failed to load user for movie_watchlisted event",
+			"user_id", userID.String(),
+			"post_id", postID.String(),
+			"error", err.Error(),
+		)
+	}
+	eventData := movieWatchlistedEventData{
+		PostID:     postID,
+		UserID:     userID,
+		Username:   username,
+		Categories: categories,
+	}
+	if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "movie_watchlisted", eventData)
+	}
+	cancel()
+
+	observability.LogInfo(r.Context(), "movie watchlisted",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+		"category_count", strconv.Itoa(len(items)),
+	)
+
+	response := models.AddToWatchlistResponse{
+		WatchlistItems: items,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode add to watchlist response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// RemoveFromWatchlist handles DELETE /api/v1/posts/{postId}/watchlist.
+func (h *WatchlistHandler) RemoveFromWatchlist(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var category *string
+	if categoryParam := strings.TrimSpace(r.URL.Query().Get("category")); categoryParam != "" {
+		category = &categoryParam
+	}
+
+	if err := h.watchlistService.RemoveFromWatchlist(r.Context(), userID, postID, category); err != nil {
+		switch err.Error() {
+		case "movie or series post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+			return
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+			return
+		case "watchlist item not found":
+			w.WriteHeader(http.StatusNoContent)
+			return
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "WATCHLIST_REMOVE_FAILED", "Failed to remove from watchlist")
+			return
+		}
+	}
+
+	publishCtx, cancel := publishContext()
+	eventData := movieUnwatchlistedEventData{
+		PostID: postID,
+		UserID: userID,
+	}
+	if sectionID, err := h.postService.GetSectionIDByPostID(publishCtx, postID); err == nil {
+		_ = publishEvent(publishCtx, h.redis, formatChannel(sectionPrefix, sectionID), "movie_unwatchlisted", eventData)
+	}
+	cancel()
+
+	observability.LogInfo(r.Context(), "movie unwatchlisted",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPostWatchlistInfo handles GET /api/v1/posts/{postId}/watchlist-info.
+func (h *WatchlistHandler) GetPostWatchlistInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.watchlistService.GetPostWatchlistInfo(r.Context(), postID, &userID)
+	if err != nil {
+		if err.Error() == "movie or series post not found" {
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCHLIST_INFO_FAILED", "Failed to get watchlist info")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode post watchlist info response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// ListWatchlist handles GET /api/v1/me/watchlist.
+func (h *WatchlistHandler) ListWatchlist(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	grouped, err := h.watchlistService.GetUserWatchlist(r.Context(), userID)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCHLIST_FAILED", "Failed to get watchlist")
+		return
+	}
+
+	response := models.WatchlistResponse{
+		Categories: buildWatchlistCategoryGroups(grouped),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode watchlist response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// ListWatchlistCategories handles GET /api/v1/me/watchlist-categories.
+func (h *WatchlistHandler) ListWatchlistCategories(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categories, err := h.watchlistService.GetUserWatchlistCategories(r.Context(), userID)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCHLIST_CATEGORIES_FAILED", "Failed to get watchlist categories")
+		return
+	}
+
+	response := models.ListWatchlistCategoriesResponse{
+		Categories: categories,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode watchlist categories response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// CreateWatchlistCategory handles POST /api/v1/me/watchlist-categories.
+func (h *WatchlistHandler) CreateWatchlistCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	var req models.CreateWatchlistCategoryRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_REQUIRED", "Category name is required")
+		return
+	}
+
+	category, err := h.watchlistService.CreateCategory(r.Context(), userID, req.Name)
+	if err != nil {
+		switch err.Error() {
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "CREATE_WATCHLIST_CATEGORY_FAILED", "Failed to create watchlist category")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "watchlist category created",
+		"user_id", userID.String(),
+		"category_id", category.ID.String(),
+	)
+
+	response := models.CreateWatchlistCategoryResponse{
+		Category: *category,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode create watchlist category response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// UpdateWatchlistCategory handles PATCH /api/v1/me/watchlist-categories/{id}.
+func (h *WatchlistHandler) UpdateWatchlistCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only PATCH requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categoryID, err := extractWatchlistCategoryIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CATEGORY_ID", "Invalid category ID format")
+		return
+	}
+
+	var req models.UpdateWatchlistCategoryRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.Name != nil && strings.TrimSpace(*req.Name) == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_REQUIRED", "Category name is required")
+		return
+	}
+
+	if err := h.watchlistService.UpdateCategory(r.Context(), userID, categoryID, req.Name, req.Position); err != nil {
+		switch err.Error() {
+		case "category not found":
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+		case "category name must be 100 characters or less":
+			writeError(r.Context(), w, http.StatusBadRequest, "CATEGORY_NAME_TOO_LONG", err.Error())
+		case "no updates provided":
+			writeError(r.Context(), w, http.StatusBadRequest, "NO_UPDATES", "No updates provided")
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "UPDATE_WATCHLIST_CATEGORY_FAILED", "Failed to update watchlist category")
+		}
+		return
+	}
+
+	updated, err := h.fetchUserWatchlistCategory(r.Context(), userID, categoryID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "UPDATE_WATCHLIST_CATEGORY_FAILED", "Failed to load updated category")
+		return
+	}
+
+	observability.LogInfo(r.Context(), "watchlist category updated",
+		"user_id", userID.String(),
+		"category_id", categoryID.String(),
+	)
+
+	response := models.UpdateWatchlistCategoryResponse{
+		Category: *updated,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode update watchlist category response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// DeleteWatchlistCategory handles DELETE /api/v1/me/watchlist-categories/{id}.
+func (h *WatchlistHandler) DeleteWatchlistCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	categoryID, err := extractWatchlistCategoryIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CATEGORY_ID", "Invalid category ID format")
+		return
+	}
+
+	if err := h.watchlistService.DeleteCategory(r.Context(), userID, categoryID); err != nil {
+		if err.Error() == "category not found" {
+			writeError(r.Context(), w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "DELETE_WATCHLIST_CATEGORY_FAILED", "Failed to delete watchlist category")
+		return
+	}
+
+	observability.LogInfo(r.Context(), "watchlist category deleted",
+		"user_id", userID.String(),
+		"category_id", categoryID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *WatchlistHandler) fetchUserWatchlistCategory(ctx context.Context, userID, categoryID uuid.UUID) (*models.WatchlistCategory, error) {
+	categories, err := h.watchlistService.GetUserWatchlistCategories(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, category := range categories {
+		if category.ID == categoryID {
+			return &category, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func extractWatchlistCategoryIDFromPath(path string) (uuid.UUID, error) {
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part == "watchlist-categories" && i+1 < len(pathParts) {
+			return uuid.Parse(pathParts[i+1])
+		}
+	}
+	return uuid.Nil, sql.ErrNoRows
+}
+
+func buildWatchlistCategoryGroups(grouped map[string][]models.WatchlistItemWithPost) []models.WatchlistCategoryGroup {
+	if len(grouped) == 0 {
+		return []models.WatchlistCategoryGroup{}
+	}
+
+	names := make([]string, 0, len(grouped))
+	for name := range grouped {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	categories := make([]models.WatchlistCategoryGroup, 0, len(names))
+	for _, name := range names {
+		categories = append(categories, models.WatchlistCategoryGroup{
+			Name:  name,
+			Items: grouped[name],
+		})
+	}
+
+	return categories
+}
+
+func uniqueWatchlistCategories(items []models.WatchlistItem) []string {
+	if len(items) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(items))
+	categories := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[item.Category]; ok {
+			continue
+		}
+		seen[item.Category] = struct{}{}
+		categories = append(categories, item.Category)
+	}
+	return categories
+}

--- a/backend/internal/handlers/watchlist_test.go
+++ b/backend/internal/handlers/watchlist_test.go
@@ -1,0 +1,480 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestAddToWatchlistHandlerSuccess(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlisthandleruser", "watchlisthandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := services.NewWatchlistService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Favorites"); err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
+
+	handler := NewWatchlistHandler(db, nil)
+
+	body := bytes.NewBufferString(`{"categories":["Favorites"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watchlist", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlisthandleruser", false))
+	rr := httptest.NewRecorder()
+
+	handler.AddToWatchlist(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.AddToWatchlistResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.WatchlistItems) != 1 {
+		t.Fatalf("expected 1 watchlist item, got %d", len(response.WatchlistItems))
+	}
+	if response.WatchlistItems[0].Category != "Favorites" {
+		t.Fatalf("expected Favorites category, got %s", response.WatchlistItems[0].Category)
+	}
+}
+
+func TestAddToWatchlistPublishesSectionEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	testutil.CleanupRedis(t)
+
+	redisClient := testutil.GetTestRedis(t)
+
+	userID := testutil.CreateTestUser(t, db, "watchlisteventuser", "watchlistevent@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := services.NewWatchlistService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Sci-Fi"); err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
+
+	channel := formatChannel(sectionPrefix, sectionID)
+	pubsub := subscribeTestChannel(t, redisClient, channel)
+
+	handler := NewWatchlistHandler(db, redisClient)
+	body := bytes.NewBufferString(`{"categories":["Sci-Fi"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/watchlist", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "watchlisteventuser", false))
+	rr := httptest.NewRecorder()
+
+	handler.AddToWatchlist(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	event := receiveEvent(t, pubsub)
+	if event.Type != "movie_watchlisted" {
+		t.Fatalf("expected movie_watchlisted event, got %s", event.Type)
+	}
+
+	dataBytes, err := json.Marshal(event.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal event data: %v", err)
+	}
+
+	var payload movieWatchlistedEventData
+	if err := json.Unmarshal(dataBytes, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload.PostID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, payload.PostID.String())
+	}
+	if payload.UserID.String() != userID {
+		t.Fatalf("expected user_id %s, got %s", userID, payload.UserID.String())
+	}
+	if payload.Username != "watchlisteventuser" {
+		t.Fatalf("expected username watchlisteventuser, got %s", payload.Username)
+	}
+	if len(payload.Categories) != 1 || payload.Categories[0] != "Sci-Fi" {
+		t.Fatalf("expected categories [Sci-Fi], got %v", payload.Categories)
+	}
+}
+
+func TestRemoveFromWatchlistPublishesSectionEvent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	testutil.CleanupRedis(t)
+
+	redisClient := testutil.GetTestRedis(t)
+
+	userID := testutil.CreateTestUser(t, db, "unwatchlisteventuser", "unwatchlistevent@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Movie post")
+
+	service := services.NewWatchlistService(db)
+	if _, err := service.AddToWatchlist(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID), nil); err != nil {
+		t.Fatalf("AddToWatchlist failed: %v", err)
+	}
+
+	channel := formatChannel(sectionPrefix, sectionID)
+	pubsub := subscribeTestChannel(t, redisClient, channel)
+
+	handler := NewWatchlistHandler(db, redisClient)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/watchlist", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "unwatchlisteventuser", false))
+	rr := httptest.NewRecorder()
+
+	handler.RemoveFromWatchlist(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	event := receiveEvent(t, pubsub)
+	if event.Type != "movie_unwatchlisted" {
+		t.Fatalf("expected movie_unwatchlisted event, got %s", event.Type)
+	}
+
+	dataBytes, err := json.Marshal(event.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal event data: %v", err)
+	}
+
+	var payload movieUnwatchlistedEventData
+	if err := json.Unmarshal(dataBytes, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload.PostID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, payload.PostID.String())
+	}
+	if payload.UserID.String() != userID {
+		t.Fatalf("expected user_id %s, got %s", userID, payload.UserID.String())
+	}
+}
+
+func TestGetPostWatchlistInfoHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := testutil.CreateTestUser(t, db, "watchlistinfoa", "watchlistinfoa@test.com", false, true)
+	userB := testutil.CreateTestUser(t, db, "watchlistinfob", "watchlistinfob@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postID := testutil.CreateTestPost(t, db, userA, sectionID, "Movie post")
+
+	service := services.NewWatchlistService(db)
+	if _, err := service.AddToWatchlist(reqContext(), uuid.MustParse(userA), uuid.MustParse(postID), nil); err != nil {
+		t.Fatalf("AddToWatchlist userA failed: %v", err)
+	}
+	if _, err := service.AddToWatchlist(reqContext(), uuid.MustParse(userB), uuid.MustParse(postID), nil); err != nil {
+		t.Fatalf("AddToWatchlist userB failed: %v", err)
+	}
+
+	handler := NewWatchlistHandler(db, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/watchlist-info", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userA), "watchlistinfoa", false))
+	rr := httptest.NewRecorder()
+
+	handler.GetPostWatchlistInfo(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.PostWatchlistInfo
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.SaveCount != 2 {
+		t.Fatalf("expected save_count 2, got %d", response.SaveCount)
+	}
+	if !response.ViewerSaved {
+		t.Fatalf("expected viewer_saved true")
+	}
+	if len(response.ViewerCategories) != 1 || response.ViewerCategories[0] != "Uncategorized" {
+		t.Fatalf("expected viewer_categories [Uncategorized], got %v", response.ViewerCategories)
+	}
+}
+
+func TestListWatchlistHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "listwatchlistuser", "listwatchlist@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Movies", "movie")
+	postA := testutil.CreateTestPost(t, db, userID, sectionID, "Movie A")
+	postB := testutil.CreateTestPost(t, db, userID, sectionID, "Movie B")
+
+	service := services.NewWatchlistService(db)
+	if _, err := service.CreateCategory(reqContext(), uuid.MustParse(userID), "Favorites"); err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
+	if _, err := service.AddToWatchlist(reqContext(), uuid.MustParse(userID), uuid.MustParse(postA), []string{"Favorites"}); err != nil {
+		t.Fatalf("AddToWatchlist favorites failed: %v", err)
+	}
+	if _, err := service.AddToWatchlist(reqContext(), uuid.MustParse(userID), uuid.MustParse(postB), nil); err != nil {
+		t.Fatalf("AddToWatchlist uncategorized failed: %v", err)
+	}
+
+	handler := NewWatchlistHandler(db, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/watchlist", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "listwatchlistuser", false))
+	rr := httptest.NewRecorder()
+
+	handler.ListWatchlist(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.WatchlistResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Categories) != 2 {
+		t.Fatalf("expected 2 categories, got %d", len(response.Categories))
+	}
+
+	gotNames := []string{response.Categories[0].Name, response.Categories[1].Name}
+	sort.Strings(gotNames)
+	if gotNames[0] != "Favorites" || gotNames[1] != "Uncategorized" {
+		t.Fatalf("unexpected category names: %v", gotNames)
+	}
+}
+
+func TestWatchlistCategoryCRUDAndListHandlers(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlistcategoryhandler", "watchlistcategoryhandler@test.com", false, true)
+	handler := NewWatchlistHandler(db, nil)
+
+	createBody := bytes.NewBufferString(`{"name":"To Watch"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/me/watchlist-categories", createBody)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq = createReq.WithContext(createTestUserContext(createReq.Context(), uuid.MustParse(userID), "watchlistcategoryhandler", false))
+	createRR := httptest.NewRecorder()
+
+	handler.CreateWatchlistCategory(createRR, createReq)
+
+	if createRR.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", createRR.Code, createRR.Body.String())
+	}
+
+	var createResp models.CreateWatchlistCategoryResponse
+	if err := json.NewDecoder(createRR.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/me/watchlist-categories", nil)
+	listReq = listReq.WithContext(createTestUserContext(listReq.Context(), uuid.MustParse(userID), "watchlistcategoryhandler", false))
+	listRR := httptest.NewRecorder()
+
+	handler.ListWatchlistCategories(listRR, listReq)
+
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", listRR.Code, listRR.Body.String())
+	}
+
+	var listResp models.ListWatchlistCategoriesResponse
+	if err := json.NewDecoder(listRR.Body).Decode(&listResp); err != nil {
+		t.Fatalf("failed to decode list response: %v", err)
+	}
+	if len(listResp.Categories) != 1 || listResp.Categories[0].ID != createResp.Category.ID {
+		t.Fatalf("expected single created category, got %+v", listResp.Categories)
+	}
+
+	updateBody := bytes.NewBufferString(`{"name":"Sci-Fi","position":2}`)
+	updateReq := httptest.NewRequest(http.MethodPatch, "/api/v1/me/watchlist-categories/"+createResp.Category.ID.String(), updateBody)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq = updateReq.WithContext(createTestUserContext(updateReq.Context(), uuid.MustParse(userID), "watchlistcategoryhandler", false))
+	updateRR := httptest.NewRecorder()
+
+	handler.UpdateWatchlistCategory(updateRR, updateReq)
+
+	if updateRR.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", updateRR.Code, updateRR.Body.String())
+	}
+
+	var updateResp models.UpdateWatchlistCategoryResponse
+	if err := json.NewDecoder(updateRR.Body).Decode(&updateResp); err != nil {
+		t.Fatalf("failed to decode update response: %v", err)
+	}
+	if updateResp.Category.Name != "Sci-Fi" {
+		t.Fatalf("expected updated name Sci-Fi, got %s", updateResp.Category.Name)
+	}
+	if updateResp.Category.Position != 2 {
+		t.Fatalf("expected updated position 2, got %d", updateResp.Category.Position)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/v1/me/watchlist-categories/"+createResp.Category.ID.String(), nil)
+	deleteReq = deleteReq.WithContext(createTestUserContext(deleteReq.Context(), uuid.MustParse(userID), "watchlistcategoryhandler", false))
+	deleteRR := httptest.NewRecorder()
+
+	handler.DeleteWatchlistCategory(deleteRR, deleteReq)
+
+	if deleteRR.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", deleteRR.Code)
+	}
+}
+
+func TestWatchlistHandlersRequireAuth(t *testing.T) {
+	handler := &WatchlistHandler{}
+	categoryID := uuid.New().String()
+	postID := uuid.New().String()
+
+	tests := []struct {
+		name     string
+		fn       func(http.ResponseWriter, *http.Request)
+		method   string
+		path     string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "add to watchlist",
+			fn:       handler.AddToWatchlist,
+			method:   http.MethodPost,
+			path:     "/api/v1/posts/" + postID + "/watchlist",
+			body:     `{"categories":["Favorites"]}`,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "remove from watchlist",
+			fn:       handler.RemoveFromWatchlist,
+			method:   http.MethodDelete,
+			path:     "/api/v1/posts/" + postID + "/watchlist",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "get watchlist info",
+			fn:       handler.GetPostWatchlistInfo,
+			method:   http.MethodGet,
+			path:     "/api/v1/posts/" + postID + "/watchlist-info",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "list watchlist",
+			fn:       handler.ListWatchlist,
+			method:   http.MethodGet,
+			path:     "/api/v1/me/watchlist",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "list watchlist categories",
+			fn:       handler.ListWatchlistCategories,
+			method:   http.MethodGet,
+			path:     "/api/v1/me/watchlist-categories",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "create watchlist category",
+			fn:       handler.CreateWatchlistCategory,
+			method:   http.MethodPost,
+			path:     "/api/v1/me/watchlist-categories",
+			body:     `{"name":"Category"}`,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "update watchlist category",
+			fn:       handler.UpdateWatchlistCategory,
+			method:   http.MethodPatch,
+			path:     "/api/v1/me/watchlist-categories/" + categoryID,
+			body:     `{"name":"Updated"}`,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "delete watchlist category",
+			fn:       handler.DeleteWatchlistCategory,
+			method:   http.MethodDelete,
+			path:     "/api/v1/me/watchlist-categories/" + categoryID,
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var body *bytes.Buffer
+			if tc.body != "" {
+				body = bytes.NewBufferString(tc.body)
+			} else {
+				body = bytes.NewBuffer(nil)
+			}
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			rr := httptest.NewRecorder()
+
+			tc.fn(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("expected status %d, got %d. Body: %s", tc.wantCode, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAddToWatchlistValidationErrors(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "watchlistvalidation", "watchlistvalidation@test.com", false, true)
+	recipeSectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	recipePostID := testutil.CreateTestPost(t, db, userID, recipeSectionID, "Recipe post")
+
+	handler := NewWatchlistHandler(db, nil)
+	ctx := createTestUserContext(reqContext(), uuid.MustParse(userID), "watchlistvalidation", false)
+
+	invalidReq := httptest.NewRequest(http.MethodPost, "/api/v1/posts/not-a-uuid/watchlist", bytes.NewBufferString(`{"categories":["Favorites"]}`))
+	invalidReq.Header.Set("Content-Type", "application/json")
+	invalidReq = invalidReq.WithContext(ctx)
+	invalidRR := httptest.NewRecorder()
+
+	handler.AddToWatchlist(invalidRR, invalidReq)
+
+	if invalidRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid post id status 400, got %d. Body: %s", invalidRR.Code, invalidRR.Body.String())
+	}
+
+	var invalidResp models.ErrorResponse
+	if err := json.NewDecoder(invalidRR.Body).Decode(&invalidResp); err != nil {
+		t.Fatalf("failed to decode invalid post id response: %v", err)
+	}
+	if invalidResp.Code != "INVALID_POST_ID" {
+		t.Fatalf("expected INVALID_POST_ID, got %s", invalidResp.Code)
+	}
+
+	nonMovieReq := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+recipePostID+"/watchlist", bytes.NewBufferString(`{"categories":["Favorites"]}`))
+	nonMovieReq.Header.Set("Content-Type", "application/json")
+	nonMovieReq = nonMovieReq.WithContext(ctx)
+	nonMovieRR := httptest.NewRecorder()
+
+	handler.AddToWatchlist(nonMovieRR, nonMovieReq)
+
+	if nonMovieRR.Code != http.StatusNotFound {
+		t.Fatalf("expected non-movie status 404, got %d. Body: %s", nonMovieRR.Code, nonMovieRR.Body.String())
+	}
+
+	var nonMovieResp models.ErrorResponse
+	if err := json.NewDecoder(nonMovieRR.Body).Decode(&nonMovieResp); err != nil {
+		t.Fatalf("failed to decode non-movie response: %v", err)
+	}
+	if nonMovieResp.Code != "POST_NOT_FOUND" {
+		t.Fatalf("expected POST_NOT_FOUND, got %s", nonMovieResp.Code)
+	}
+}

--- a/backend/internal/models/movie.go
+++ b/backend/internal/models/movie.go
@@ -67,7 +67,38 @@ type AddToWatchlistRequest struct {
 	Categories []string `json:"categories,omitempty"`
 }
 
+// AddToWatchlistResponse represents the response for adding to watchlist.
+type AddToWatchlistResponse struct {
+	WatchlistItems []WatchlistItem `json:"watchlist_items"`
+}
+
 // WatchlistResponse represents watchlist items grouped by category.
 type WatchlistResponse struct {
 	Categories []WatchlistCategoryGroup `json:"categories"`
+}
+
+// CreateWatchlistCategoryRequest represents the request body for creating a watchlist category.
+type CreateWatchlistCategoryRequest struct {
+	Name string `json:"name"`
+}
+
+// UpdateWatchlistCategoryRequest represents the request body for updating a watchlist category.
+type UpdateWatchlistCategoryRequest struct {
+	Name     *string `json:"name,omitempty"`
+	Position *int    `json:"position,omitempty"`
+}
+
+// CreateWatchlistCategoryResponse represents the response for creating a watchlist category.
+type CreateWatchlistCategoryResponse struct {
+	Category WatchlistCategory `json:"category"`
+}
+
+// UpdateWatchlistCategoryResponse represents the response for updating a watchlist category.
+type UpdateWatchlistCategoryResponse struct {
+	Category WatchlistCategory `json:"category"`
+}
+
+// ListWatchlistCategoriesResponse represents the response for listing watchlist categories.
+type ListWatchlistCategoriesResponse struct {
+	Categories []WatchlistCategory `json:"categories"`
 }


### PR DESCRIPTION
## Summary
- add `WatchlistHandler` with endpoints for add/remove watchlist items, post watchlist info, user watchlist listing, and watchlist category CRUD
- publish `movie_watchlisted` and `movie_unwatchlisted` websocket events to section subscribers
- wire watchlist routes into the server router and add request/response models for watchlist category and add-item payloads
- add handler tests covering happy paths for all endpoints, auth-required behavior, validation errors, and websocket event publishing

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/handlers -run Watchlist -count=1`
- `cd backend && go test ./internal/services -run Watchlist -count=1`
- `cd backend && go test ./...`

Closes #795