### PR TITLE
[Movies] Create Watchlist view component

### DIFF
--- a/frontend/src/components/__tests__/Watchlist.test.ts
+++ b/frontend/src/components/__tests__/Watchlist.test.ts
@@ -1,0 +1,242 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Post } from '../../stores/postStore';
+import type { WatchLog, WatchlistCategory, WatchlistItem } from '../../stores/movieStore';
+import { postStore } from '../../stores/postStore';
+import { movieStore } from '../../stores/movieStore';
+
+const pushPath = vi.fn();
+
+vi.mock('../../services/routeNavigation', () => ({
+  buildStandaloneThreadHref: (postId: string) => `/posts/${postId}`,
+  pushPath,
+}));
+
+const { default: Watchlist } = await import('../movies/Watchlist.svelte');
+
+type MovieStatsLike = {
+  avgRating: number;
+  watchCount: number;
+  watchlistCount: number;
+};
+
+const postOne: Post & { movieStats: MovieStatsLike } = {
+  id: 'post-1',
+  userId: 'user-1',
+  sectionId: 'section-movie',
+  content: 'The Matrix',
+  createdAt: '2026-01-02T00:00:00Z',
+  links: [
+    {
+      url: 'https://example.com/matrix',
+      metadata: {
+        title: 'The Matrix',
+        image: 'https://example.com/matrix.jpg',
+      },
+    },
+  ],
+  movieStats: {
+    avgRating: 4.9,
+    watchCount: 14,
+    watchlistCount: 6,
+  },
+};
+
+const postTwo: Post & { movieStats: MovieStatsLike } = {
+  id: 'post-2',
+  userId: 'user-2',
+  sectionId: 'section-movie',
+  content: 'Alien',
+  createdAt: '2026-01-03T00:00:00Z',
+  links: [
+    {
+      url: 'https://example.com/alien',
+      metadata: {
+        title: 'Alien',
+        image: 'https://example.com/alien.jpg',
+      },
+    },
+  ],
+  movieStats: {
+    avgRating: 3.8,
+    watchCount: 22,
+    watchlistCount: 3,
+  },
+};
+
+const postThree: Post & { movieStats: MovieStatsLike } = {
+  id: 'post-3',
+  userId: 'user-3',
+  sectionId: 'section-series',
+  content: 'Severance',
+  createdAt: '2026-01-04T00:00:00Z',
+  links: [
+    {
+      url: 'https://example.com/severance',
+      metadata: {
+        title: 'Severance',
+        image: 'https://example.com/severance.jpg',
+      },
+    },
+  ],
+  movieStats: {
+    avgRating: 4.5,
+    watchCount: 8,
+    watchlistCount: 11,
+  },
+};
+
+const categories: WatchlistCategory[] = [
+  { id: 'cat-1', name: 'Favorites', position: 1 },
+  { id: 'cat-2', name: 'Horror', position: 2 },
+];
+
+const watchlistMap = new Map<string, WatchlistItem[]>([
+  [
+    'Favorites',
+    [
+      {
+        id: 'watch-1',
+        userId: 'user-1',
+        postId: 'post-1',
+        category: 'Favorites',
+        createdAt: '2026-01-05T00:00:00Z',
+        post: postOne,
+      },
+    ],
+  ],
+  [
+    'Horror',
+    [
+      {
+        id: 'watch-2',
+        userId: 'user-1',
+        postId: 'post-2',
+        category: 'Horror',
+        createdAt: '2026-01-06T00:00:00Z',
+        post: postTwo,
+      },
+    ],
+  ],
+]);
+
+const watchLogs: WatchLog[] = [
+  {
+    id: 'log-1',
+    userId: 'user-1',
+    postId: 'post-1',
+    rating: 5,
+    watchedAt: '2026-01-07T00:00:00Z',
+    post: postOne,
+  },
+];
+
+beforeEach(() => {
+  postStore.reset();
+  movieStore.reset();
+
+  postStore.setPosts([postOne, postTwo, postThree], null, false);
+  movieStore.setCategories([...categories]);
+  movieStore.setWatchlist(new Map(watchlistMap));
+  movieStore.setWatchLogs([...watchLogs]);
+
+  vi.spyOn(movieStore, 'loadWatchlistCategories').mockResolvedValue();
+  vi.spyOn(movieStore, 'loadWatchlist').mockResolvedValue();
+  vi.spyOn(movieStore, 'loadWatchLogs').mockResolvedValue();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  pushPath.mockReset();
+  postStore.reset();
+  movieStore.reset();
+});
+
+describe('Watchlist', () => {
+  it('renders My List tab by default with saved movies', () => {
+    render(Watchlist);
+
+    expect(screen.getByTestId('watchlist-tab-my')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('watchlist-my-item-post-1')).toBeInTheDocument();
+    expect(screen.getByTestId('watchlist-my-item-post-2')).toBeInTheDocument();
+    expect(screen.getByTestId('watchlist-watched-post-1')).toBeInTheDocument();
+  });
+
+  it('renders All Movies tab and supports sorting', async () => {
+    render(Watchlist);
+
+    await fireEvent.click(screen.getByTestId('watchlist-tab-all'));
+
+    let items = screen.getAllByTestId(/watchlist-all-item-/);
+    expect(items[0]).toHaveTextContent('The Matrix');
+
+    await fireEvent.change(screen.getByTestId('watchlist-sort'), {
+      target: { value: 'watch_count' },
+    });
+
+    items = screen.getAllByTestId(/watchlist-all-item-/);
+    expect(items[0]).toHaveTextContent('Alien');
+
+    await fireEvent.change(screen.getByTestId('watchlist-sort'), {
+      target: { value: 'watchlist_count' },
+    });
+
+    items = screen.getAllByTestId(/watchlist-all-item-/);
+    expect(items[0]).toHaveTextContent('Severance');
+  });
+
+  it('filters My List by selected category', async () => {
+    render(Watchlist);
+
+    await fireEvent.click(screen.getByTestId('watchlist-category-Horror'));
+
+    expect(screen.getByTestId('watchlist-my-item-post-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('watchlist-my-item-post-1')).not.toBeInTheDocument();
+  });
+
+  it('shows empty states for no saved movies and empty selected category', async () => {
+    movieStore.reset();
+    postStore.setPosts([], null, false);
+
+    const { unmount } = render(Watchlist);
+    expect(screen.getByText('No movies saved yet')).toBeInTheDocument();
+
+    unmount();
+
+    movieStore.setCategories([
+      { id: 'cat-1', name: 'Favorites', position: 1 },
+      { id: 'cat-2', name: 'Classics', position: 2 },
+    ]);
+    movieStore.setWatchlist(
+      new Map([
+        [
+          'Favorites',
+          [
+            {
+              id: 'watch-1',
+              userId: 'user-1',
+              postId: 'post-1',
+              category: 'Favorites',
+              createdAt: '2026-01-05T00:00:00Z',
+              post: postOne,
+            },
+          ],
+        ],
+      ])
+    );
+
+    render(Watchlist);
+
+    await fireEvent.click(screen.getByTestId('watchlist-category-Classics'));
+    expect(screen.getByText('No movies in this category')).toBeInTheDocument();
+  });
+
+  it('navigates to the post when a movie card is clicked', async () => {
+    render(Watchlist);
+
+    await fireEvent.click(screen.getByTestId('watchlist-my-item-post-1'));
+
+    expect(pushPath).toHaveBeenCalledWith('/posts/post-1');
+  });
+});

--- a/frontend/src/components/__tests__/Watchlist.test.ts
+++ b/frontend/src/components/__tests__/Watchlist.test.ts
@@ -1,7 +1,8 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Post } from '../../stores/postStore';
 import type { WatchLog, WatchlistCategory, WatchlistItem } from '../../stores/movieStore';
+import type { ApiPost } from '../../stores/postMapper';
+import { mapApiPost } from '../../stores/postMapper';
 import { postStore } from '../../stores/postStore';
 import { movieStore } from '../../stores/movieStore';
 
@@ -14,77 +15,104 @@ vi.mock('../../services/routeNavigation', () => ({
 
 const { default: Watchlist } = await import('../movies/Watchlist.svelte');
 
-type MovieStatsLike = {
-  avgRating: number;
-  watchCount: number;
-  watchlistCount: number;
-};
-
-const postOne: Post & { movieStats: MovieStatsLike } = {
+const apiPostOne: ApiPost = {
   id: 'post-1',
-  userId: 'user-1',
-  sectionId: 'section-movie',
+  user_id: 'user-1',
+  section_id: 'section-movie',
   content: 'The Matrix',
-  createdAt: '2026-01-02T00:00:00Z',
+  created_at: '2026-01-02T00:00:00Z',
   links: [
     {
       url: 'https://example.com/matrix',
       metadata: {
         title: 'The Matrix',
         image: 'https://example.com/matrix.jpg',
+        movie: {
+          title: 'The Matrix',
+          poster: 'https://example.com/matrix.jpg',
+        },
       },
     },
   ],
-  movieStats: {
-    avgRating: 4.9,
-    watchCount: 14,
-    watchlistCount: 6,
+  movie_stats: {
+    avg_rating: 4.9,
+    watch_count: 14,
+    watchlist_count: 6,
   },
 };
 
-const postTwo: Post & { movieStats: MovieStatsLike } = {
+const apiPostTwo: ApiPost = {
   id: 'post-2',
-  userId: 'user-2',
-  sectionId: 'section-movie',
+  user_id: 'user-2',
+  section_id: 'section-movie',
   content: 'Alien',
-  createdAt: '2026-01-03T00:00:00Z',
+  created_at: '2026-01-03T00:00:00Z',
   links: [
     {
       url: 'https://example.com/alien',
       metadata: {
         title: 'Alien',
         image: 'https://example.com/alien.jpg',
+        movie: {
+          title: 'Alien',
+          poster: 'https://example.com/alien.jpg',
+        },
       },
     },
   ],
-  movieStats: {
-    avgRating: 3.8,
-    watchCount: 22,
-    watchlistCount: 3,
+  movie_stats: {
+    avg_rating: 3.8,
+    watch_count: 22,
+    watchlist_count: 3,
   },
 };
 
-const postThree: Post & { movieStats: MovieStatsLike } = {
+const apiPostThree: ApiPost = {
   id: 'post-3',
-  userId: 'user-3',
-  sectionId: 'section-series',
+  user_id: 'user-3',
+  section_id: 'section-series',
   content: 'Severance',
-  createdAt: '2026-01-04T00:00:00Z',
+  created_at: '2026-01-04T00:00:00Z',
   links: [
     {
       url: 'https://example.com/severance',
       metadata: {
         title: 'Severance',
         image: 'https://example.com/severance.jpg',
+        movie: {
+          title: 'Severance',
+          poster: 'https://example.com/severance.jpg',
+        },
       },
     },
   ],
-  movieStats: {
-    avgRating: 4.5,
-    watchCount: 8,
-    watchlistCount: 11,
+  movie_stats: {
+    avg_rating: 4.5,
+    watch_count: 8,
+    watchlist_count: 11,
   },
 };
+
+const apiNonMoviePost: ApiPost = {
+  id: 'post-4',
+  user_id: 'user-4',
+  section_id: 'section-general',
+  content: 'General update',
+  created_at: '2026-01-05T00:00:00Z',
+  links: [
+    {
+      url: 'https://example.com/general',
+      metadata: {
+        title: 'General update',
+      },
+    },
+  ],
+};
+
+const postOne = mapApiPost(apiPostOne);
+const postTwo = mapApiPost(apiPostTwo);
+const postThree = mapApiPost(apiPostThree);
+const nonMoviePost = mapApiPost(apiNonMoviePost);
 
 const categories: WatchlistCategory[] = [
   { id: 'cat-1', name: 'Favorites', position: 1 },
@@ -135,7 +163,7 @@ beforeEach(() => {
   postStore.reset();
   movieStore.reset();
 
-  postStore.setPosts([postOne, postTwo, postThree], null, false);
+  postStore.setPosts([postOne, postTwo, postThree, nonMoviePost], null, false);
   movieStore.setCategories([...categories]);
   movieStore.setWatchlist(new Map(watchlistMap));
   movieStore.setWatchLogs([...watchLogs]);
@@ -163,12 +191,14 @@ describe('Watchlist', () => {
     expect(screen.getByTestId('watchlist-watched-post-1')).toBeInTheDocument();
   });
 
-  it('renders All Movies tab and supports sorting', async () => {
+  it('renders All Movies tab, excludes non-movie posts, and supports sorting', async () => {
     render(Watchlist);
 
     await fireEvent.click(screen.getByTestId('watchlist-tab-all'));
 
     let items = screen.getAllByTestId(/watchlist-all-item-/);
+    expect(items).toHaveLength(3);
+    expect(screen.queryByTestId('watchlist-all-item-post-4')).not.toBeInTheDocument();
     expect(items[0]).toHaveTextContent('The Matrix');
 
     await fireEvent.change(screen.getByTestId('watchlist-sort'), {

--- a/frontend/src/components/movies/Watchlist.svelte
+++ b/frontend/src/components/movies/Watchlist.svelte
@@ -1,0 +1,633 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import type { Link, LinkMetadata, Post } from '../../stores/postStore';
+  import type { WatchlistItem } from '../../stores/movieStore';
+  import { posts } from '../../stores/postStore';
+  import {
+    movieStore,
+    sortedCategories,
+    watchlistByCategory,
+  } from '../../stores/movieStore';
+  import { buildStandaloneThreadHref, pushPath } from '../../services/routeNavigation';
+
+  type TabKey = 'my' | 'all';
+  type SortKey = 'rating' | 'date' | 'watch_count' | 'watchlist_count';
+
+  type MovieListItem = {
+    postId: string;
+    title: string;
+    poster: string | null;
+    rating: number | null;
+    watchCount: number;
+    watchlistCount: number;
+    watched: boolean;
+    createdAt: number;
+  };
+
+  type MovieStatsLike = {
+    avgRating?: number | null;
+    avg_rating?: number | null;
+    watchCount?: number;
+    watch_count?: number;
+    watchlistCount?: number;
+    watchlist_count?: number;
+  };
+
+  type MovieMetadataLike = {
+    title?: string;
+    poster?: string;
+    backdrop?: string;
+    tmdb_rating?: number;
+    tmdbRating?: number;
+  };
+
+  type MetadataWithMovie = LinkMetadata & {
+    movie?: MovieMetadataLike;
+  };
+
+  type CategoryAction = {
+    categoryName: string;
+  };
+
+  const ALL_CATEGORY_VALUE = '__all__';
+  const ALL_CATEGORY_LABEL = 'All';
+
+  const dispatch = createEventDispatcher<{
+    createCategory: undefined;
+    editCategory: CategoryAction;
+    deleteCategory: CategoryAction;
+  }>();
+
+  let activeTab: TabKey = 'my';
+  let selectedCategory = ALL_CATEGORY_VALUE;
+  let sortKey: SortKey = 'rating';
+  let searchTerm = '';
+
+  const tabOptions: Array<{ key: TabKey; label: string }> = [
+    { key: 'my', label: 'My List' },
+    { key: 'all', label: 'All Movies' },
+  ];
+
+  const sortOptions: Array<{ key: SortKey; label: string }> = [
+    { key: 'rating', label: 'Rating' },
+    { key: 'date', label: 'Date posted' },
+    { key: 'watch_count', label: 'Watch count' },
+    { key: 'watchlist_count', label: 'Watchlist count' },
+  ];
+
+  onMount(() => {
+    const state = get(movieStore);
+
+    if (!state.isLoadingCategories && state.categories.length === 0) {
+      movieStore.loadWatchlistCategories();
+    }
+
+    if (!state.isLoadingWatchlist && state.watchlist.size === 0) {
+      movieStore.loadWatchlist();
+    }
+
+    if (!state.isLoadingWatchLogs && state.watchLogs.length === 0) {
+      movieStore.loadWatchLogs();
+    }
+  });
+
+  $: categoryCounts = buildCategoryCounts($watchlistByCategory);
+  $: postWatchlistCounts = buildPostWatchlistCounts($watchlistByCategory);
+  $: totalSavedCount = Array.from(categoryCounts.values()).reduce((total, count) => total + count, 0);
+  $: watchedPostIDs = new Set($movieStore.watchLogs.map((log) => log.postId));
+  $: categoryOptions = buildCategoryOptions($sortedCategories, $watchlistByCategory);
+  $: selectedCategoryLabel =
+    categoryOptions.find((option) => option.value === selectedCategory)?.label ?? ALL_CATEGORY_LABEL;
+
+  $: if (
+    selectedCategory !== ALL_CATEGORY_VALUE &&
+    !categoryOptions.some((option) => option.value === selectedCategory)
+  ) {
+    selectedCategory = ALL_CATEGORY_VALUE;
+  }
+
+  $: selectedWatchlistItems = getWatchlistItemsForCategory($watchlistByCategory, selectedCategory);
+  $: myMovies = buildWatchlistMovieItems(selectedWatchlistItems, watchedPostIDs, postWatchlistCounts);
+  $: allMovies = sortMovies(
+    filterMoviesBySearch(buildAllMovieItems($posts, watchedPostIDs, postWatchlistCounts), searchTerm),
+    sortKey
+  );
+
+  function buildCategoryCounts(map: Map<string, WatchlistItem[]>): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const [categoryName, items] of map.entries()) {
+      counts.set(categoryName, items.length);
+    }
+    return counts;
+  }
+
+  function buildCategoryOptions(
+    categories: Array<{ name: string }>,
+    watchlistMap: Map<string, WatchlistItem[]>
+  ): Array<{ value: string; label: string }> {
+    const options: Array<{ value: string; label: string }> = [
+      { value: ALL_CATEGORY_VALUE, label: ALL_CATEGORY_LABEL },
+    ];
+    const seen = new Set<string>([ALL_CATEGORY_VALUE]);
+
+    for (const category of categories) {
+      if (!seen.has(category.name)) {
+        options.push({ value: category.name, label: category.name });
+        seen.add(category.name);
+      }
+    }
+
+    for (const categoryName of watchlistMap.keys()) {
+      if (!seen.has(categoryName)) {
+        options.push({ value: categoryName, label: categoryName });
+        seen.add(categoryName);
+      }
+    }
+
+    return options;
+  }
+
+  function buildPostWatchlistCounts(watchlistMap: Map<string, WatchlistItem[]>): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const items of watchlistMap.values()) {
+      for (const item of items) {
+        counts.set(item.postId, (counts.get(item.postId) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }
+
+  function getWatchlistItemsForCategory(
+    watchlistMap: Map<string, WatchlistItem[]>,
+    category: string
+  ): WatchlistItem[] {
+    if (category === ALL_CATEGORY_VALUE) {
+      const allItems: WatchlistItem[] = [];
+      for (const items of watchlistMap.values()) {
+        allItems.push(...items);
+      }
+      return allItems;
+    }
+
+    return watchlistMap.get(category) ?? [];
+  }
+
+  function normalizeNumber(value: unknown, fallback = 0): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return fallback;
+  }
+
+  function extractMovieStats(post?: Post): MovieStatsLike | null {
+    if (!post || typeof post !== 'object') {
+      return null;
+    }
+
+    const withStats = post as Post & {
+      movieStats?: MovieStatsLike;
+      movie_stats?: MovieStatsLike;
+    };
+
+    return withStats.movieStats ?? withStats.movie_stats ?? null;
+  }
+
+  function findMovieLink(post?: Post): Link | null {
+    if (!post?.links?.length) {
+      return null;
+    }
+
+    for (const link of post.links) {
+      const metadata = link.metadata as MetadataWithMovie | undefined;
+      if (!metadata) {
+        continue;
+      }
+      if (metadata.movie) {
+        return link;
+      }
+      if (metadata.type === 'movie' || metadata.type === 'series') {
+        return link;
+      }
+    }
+
+    return post.links.find((link) => !!link.metadata) ?? null;
+  }
+
+  function extractMovieMetadata(link: Link | null): MovieMetadataLike | null {
+    if (!link?.metadata) {
+      return null;
+    }
+
+    const metadata = link.metadata as MetadataWithMovie;
+    return metadata.movie ?? null;
+  }
+
+  function buildMovieTitle(post?: Post, link?: Link | null): string {
+    const metadata = link?.metadata as MetadataWithMovie | undefined;
+    const movieMetadata = extractMovieMetadata(link ?? null);
+
+    return (
+      movieMetadata?.title ??
+      metadata?.title ??
+      post?.content?.trim() ??
+      'Movie'
+    );
+  }
+
+  function buildPoster(link?: Link | null): string | null {
+    const metadata = link?.metadata as MetadataWithMovie | undefined;
+    const movieMetadata = extractMovieMetadata(link ?? null);
+
+    return movieMetadata?.poster ?? movieMetadata?.backdrop ?? metadata?.image ?? null;
+  }
+
+  function buildRating(post?: Post, link?: Link | null): number | null {
+    const stats = extractMovieStats(post);
+    const movieMetadata = extractMovieMetadata(link ?? null);
+
+    const statsRating =
+      stats?.avgRating ??
+      stats?.avg_rating ??
+      null;
+
+    if (typeof statsRating === 'number' && Number.isFinite(statsRating)) {
+      return statsRating;
+    }
+
+    const metadataRating = movieMetadata?.tmdbRating ?? movieMetadata?.tmdb_rating;
+    if (typeof metadataRating === 'number' && Number.isFinite(metadataRating)) {
+      return metadataRating;
+    }
+
+    return null;
+  }
+
+  function buildWatchCount(post?: Post): number {
+    const stats = extractMovieStats(post);
+    return normalizeNumber(stats?.watchCount ?? stats?.watch_count, 0);
+  }
+
+  function buildWatchlistCount(post: Post | undefined, fallbackCounts: Map<string, number>): number {
+    const stats = extractMovieStats(post);
+    const fromStats = normalizeNumber(stats?.watchlistCount ?? stats?.watchlist_count, -1);
+
+    if (fromStats >= 0) {
+      return fromStats;
+    }
+
+    if (!post) {
+      return 0;
+    }
+
+    return fallbackCounts.get(post.id) ?? 0;
+  }
+
+  function buildWatchlistMovieItems(
+    items: WatchlistItem[],
+    watchedIDs: Set<string>,
+    fallbackCounts: Map<string, number>
+  ): MovieListItem[] {
+    return items.map((watchlistItem) => {
+      const post = watchlistItem.post;
+      const link = findMovieLink(post);
+
+      return {
+        postId: watchlistItem.postId,
+        title: buildMovieTitle(post, link),
+        poster: buildPoster(link),
+        rating: buildRating(post, link),
+        watchCount: buildWatchCount(post),
+        watchlistCount: buildWatchlistCount(post, fallbackCounts),
+        watched: watchedIDs.has(watchlistItem.postId),
+        createdAt: new Date(watchlistItem.createdAt).getTime(),
+      };
+    });
+  }
+
+  function buildAllMovieItems(
+    postList: Post[],
+    watchedIDs: Set<string>,
+    fallbackCounts: Map<string, number>
+  ): MovieListItem[] {
+    return postList.map((post) => {
+      const link = findMovieLink(post);
+      return {
+        postId: post.id,
+        title: buildMovieTitle(post, link),
+        poster: buildPoster(link),
+        rating: buildRating(post, link),
+        watchCount: buildWatchCount(post),
+        watchlistCount: buildWatchlistCount(post, fallbackCounts),
+        watched: watchedIDs.has(post.id),
+        createdAt: new Date(post.createdAt).getTime(),
+      };
+    });
+  }
+
+  function filterMoviesBySearch(items: MovieListItem[], search: string): MovieListItem[] {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return items;
+    }
+
+    return items.filter((item) => item.title.toLowerCase().includes(query));
+  }
+
+  function sortMovies(items: MovieListItem[], sort: SortKey): MovieListItem[] {
+    const next = [...items];
+
+    switch (sort) {
+      case 'watch_count':
+        return next.sort((a, b) => b.watchCount - a.watchCount || b.createdAt - a.createdAt);
+      case 'watchlist_count':
+        return next.sort((a, b) => b.watchlistCount - a.watchlistCount || b.createdAt - a.createdAt);
+      case 'date':
+        return next.sort((a, b) => b.createdAt - a.createdAt);
+      case 'rating':
+      default:
+        return next.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0) || b.createdAt - a.createdAt);
+    }
+  }
+
+  function navigateToPost(postID: string) {
+    const href = buildStandaloneThreadHref(postID);
+    pushPath(href);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }));
+    }
+  }
+
+  function handleCreateCategory() {
+    dispatch('createCategory', undefined);
+  }
+
+  function handleEditCategory(categoryName: string) {
+    dispatch('editCategory', { categoryName });
+  }
+
+  function handleDeleteCategory(categoryName: string) {
+    dispatch('deleteCategory', { categoryName });
+  }
+</script>
+
+<section class="rounded-2xl border border-gray-200 bg-white shadow-sm" data-testid="watchlist">
+  <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 px-4 py-3">
+    <div>
+      <h2 class="text-base font-semibold text-gray-900">Watchlist</h2>
+      <p class="text-xs text-gray-500">Track what you want to watch and what your club is rating.</p>
+    </div>
+
+    <div class="flex items-center gap-2" role="tablist" aria-label="Watchlist views">
+      {#each tabOptions as tab}
+        <button
+          type="button"
+          role="tab"
+          class={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+            activeTab === tab.key ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+          }`}
+          aria-selected={activeTab === tab.key}
+          on:click={() => (activeTab = tab.key)}
+          data-testid={`watchlist-tab-${tab.key}`}
+        >
+          {tab.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="p-4">
+    {#if activeTab === 'my'}
+      <div class="flex flex-col gap-4 lg:flex-row">
+        <aside class="lg:w-64" data-testid="watchlist-category-panel">
+          <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+            <div class="flex items-center justify-between">
+              <h3 class="text-sm font-semibold text-gray-900">Categories</h3>
+              <span class="text-xs text-gray-500">{totalSavedCount} saved</span>
+            </div>
+
+            <div class="mt-3 space-y-1">
+              {#each categoryOptions as option}
+                <div class="group flex items-center gap-1">
+                  <button
+                    type="button"
+                    class={`flex flex-1 items-center justify-between rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+                      selectedCategory === option.value
+                        ? 'bg-blue-50 text-blue-700'
+                        : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                    on:click={() => (selectedCategory = option.value)}
+                    data-testid={`watchlist-category-${option.value}`}
+                  >
+                    <span>{option.label}</span>
+                    <span class="rounded-full bg-white px-2 py-0.5 text-[11px] text-gray-500">
+                      {option.value === ALL_CATEGORY_VALUE
+                        ? totalSavedCount
+                        : categoryCounts.get(option.value) ?? 0}
+                    </span>
+                  </button>
+
+                  {#if option.value !== ALL_CATEGORY_VALUE}
+                    <div class="hidden items-center gap-1 group-hover:flex" data-testid={`watchlist-category-actions-${option.value}`}>
+                      <button
+                        type="button"
+                        class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50"
+                        aria-label={`Edit ${option.label}`}
+                        on:click={() => handleEditCategory(option.label)}
+                      >
+                        ⚙
+                      </button>
+                      <button
+                        type="button"
+                        class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50"
+                        aria-label={`Delete ${option.label}`}
+                        on:click={() => handleDeleteCategory(option.label)}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+
+            <button
+              type="button"
+              class="mt-3 w-full rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-semibold text-gray-600 hover:border-gray-400 hover:bg-gray-50"
+              on:click={handleCreateCategory}
+              data-testid="watchlist-create-category"
+            >
+              + Create category
+            </button>
+          </div>
+        </aside>
+
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center justify-between">
+            <div>
+              <h3 class="text-sm font-semibold text-gray-900">{selectedCategoryLabel}</h3>
+              <p class="text-xs text-gray-500">Movies saved to your list.</p>
+            </div>
+            <span class="text-xs text-gray-400">{myMovies.length} movies</span>
+          </div>
+
+          {#if myMovies.length === 0}
+            <div
+              class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+              data-testid="watchlist-empty"
+            >
+              {#if totalSavedCount === 0}
+                No movies saved yet
+              {:else if selectedCategory !== ALL_CATEGORY_VALUE}
+                No movies in this category
+              {:else}
+                No movies saved yet
+              {/if}
+            </div>
+          {:else}
+            <div
+              class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4"
+              data-testid="watchlist-my-grid"
+            >
+              {#each myMovies as movie}
+                <button
+                  type="button"
+                  class="group relative overflow-hidden rounded-xl border border-gray-200 bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-gray-300"
+                  on:click={() => navigateToPost(movie.postId)}
+                  data-testid={`watchlist-my-item-${movie.postId}`}
+                >
+                  {#if movie.watched}
+                    <span
+                      class="absolute right-2 top-2 z-10 rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-semibold text-green-700"
+                      data-testid={`watchlist-watched-${movie.postId}`}
+                    >
+                      ✓ Watched
+                    </span>
+                  {/if}
+
+                  <div class="aspect-[2/3] w-full overflow-hidden bg-gray-100">
+                    {#if movie.poster}
+                      <img src={movie.poster} alt={movie.title} class="h-full w-full object-cover" loading="lazy" />
+                    {:else}
+                      <div class="flex h-full w-full items-center justify-center px-3 text-center text-xs text-gray-400">
+                        No poster
+                      </div>
+                    {/if}
+                  </div>
+
+                  <div class="space-y-1 px-3 py-3">
+                    <h4 class="line-clamp-2 text-sm font-semibold text-gray-900">{movie.title}</h4>
+                    <p class="text-xs text-gray-500">
+                      {#if movie.rating !== null}
+                        ★ {movie.rating.toFixed(1)}
+                      {:else}
+                        No rating yet
+                      {/if}
+                    </p>
+                  </div>
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {:else}
+      <div>
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 class="text-sm font-semibold text-gray-900">All Movies</h3>
+            <p class="text-xs text-gray-500">Browse everything shared in movie and series sections.</p>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <label class="text-xs font-semibold text-gray-600" for="watchlist-search">Search</label>
+            <input
+              id="watchlist-search"
+              type="search"
+              class="rounded-lg border border-gray-200 px-3 py-2 text-xs"
+              placeholder="Search titles"
+              bind:value={searchTerm}
+              data-testid="watchlist-search"
+            />
+
+            <label class="text-xs font-semibold text-gray-600" for="watchlist-sort">Sort</label>
+            <select
+              id="watchlist-sort"
+              class="rounded-lg border border-gray-200 px-3 py-2 text-xs"
+              bind:value={sortKey}
+              data-testid="watchlist-sort"
+            >
+              {#each sortOptions as option}
+                <option value={option.key}>{option.label}</option>
+              {/each}
+            </select>
+          </div>
+        </div>
+
+        {#if allMovies.length === 0}
+          <div
+            class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+            data-testid="watchlist-all-empty"
+          >
+            No movies available
+          </div>
+        {:else}
+          <div
+            class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4"
+            data-testid="watchlist-all-grid"
+          >
+            {#each allMovies as movie}
+              <button
+                type="button"
+                class="group relative overflow-hidden rounded-xl border border-gray-200 bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-gray-300"
+                on:click={() => navigateToPost(movie.postId)}
+                data-testid={`watchlist-all-item-${movie.postId}`}
+              >
+                {#if movie.watched}
+                  <span
+                    class="absolute right-2 top-2 z-10 rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-semibold text-green-700"
+                    data-testid={`watchlist-watched-${movie.postId}`}
+                  >
+                    ✓ Watched
+                  </span>
+                {/if}
+
+                <div class="aspect-[2/3] w-full overflow-hidden bg-gray-100">
+                  {#if movie.poster}
+                    <img src={movie.poster} alt={movie.title} class="h-full w-full object-cover" loading="lazy" />
+                  {:else}
+                    <div class="flex h-full w-full items-center justify-center px-3 text-center text-xs text-gray-400">
+                      No poster
+                    </div>
+                  {/if}
+                </div>
+
+                <div class="space-y-1 px-3 py-3">
+                  <h4 class="line-clamp-2 text-sm font-semibold text-gray-900">{movie.title}</h4>
+                  <p class="text-xs text-gray-500">
+                    {#if movie.rating !== null}
+                      ★ {movie.rating.toFixed(1)}
+                    {:else}
+                      No rating yet
+                    {/if}
+                  </p>
+                  <p class="text-[11px] text-gray-500">
+                    Watched {movie.watchCount} · In lists {movie.watchlistCount}
+                  </p>
+                </div>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</section>

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -112,6 +112,33 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.recipe?.nutrition?.calories).toBe('200');
   });
 
+  it('maps movie stats from API shape', () => {
+    const post = mapApiPost({
+      id: 'post-movie-stats',
+      user_id: 'user-movie-stats',
+      section_id: 'section-movie',
+      content: 'Movie stats',
+      created_at: '2025-01-01T00:00:00Z',
+      movie_stats: {
+        watchlist_count: 9,
+        watch_count: 4,
+        avg_rating: 4.25,
+        viewer_watchlisted: true,
+        viewer_watched: false,
+        viewer_rating: 5,
+        viewer_categories: ['Top Picks'],
+      },
+    });
+
+    expect(post.movieStats?.watchlistCount).toBe(9);
+    expect(post.movieStats?.watchCount).toBe(4);
+    expect(post.movieStats?.averageRating).toBe(4.25);
+    expect(post.movieStats?.viewerWatchlisted).toBe(true);
+    expect(post.movieStats?.viewerWatched).toBe(false);
+    expect(post.movieStats?.viewerRating).toBe(5);
+    expect(post.movieStats?.viewerCategories).toEqual(['Top Picks']);
+  });
+
   it('handles missing user and links gracefully', () => {
     const post = mapApiPost({
       id: 'post-2',

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -74,6 +74,16 @@ export interface RecipeStats {
   averageRating: number | null;
 }
 
+export interface MovieStats {
+  watchlistCount: number;
+  watchCount: number;
+  averageRating: number | null;
+  viewerWatchlisted?: boolean;
+  viewerWatched?: boolean;
+  viewerRating?: number | null;
+  viewerCategories?: string[];
+}
+
 export interface Post {
   id: string;
   userId: string;
@@ -91,6 +101,8 @@ export interface Post {
   commentCount?: number;
   recipeStats?: RecipeStats;
   recipe_stats?: RecipeStats;
+  movieStats?: MovieStats;
+  movie_stats?: MovieStats;
   createdAt: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- add `Watchlist.svelte` as the main movies watchlist/library view with:
  - `My List` and `All Movies` tabs
  - category sidebar with item counts, filter controls, and create/edit/delete action events
  - sorting and search controls for all movies
  - responsive movie card grid (1/2/4 columns by breakpoint)
  - watched status overlay, rating display, and empty states
  - navigation to standalone post thread on card click
- add `Watchlist.test.ts` covering:
  - My List default rendering
  - All Movies tab + sorting behavior
  - category filtering
  - empty states
  - post navigation

## Testing
- `cd frontend && npm run check`
- `cd frontend && npm run lint`
- `cd frontend && npm run test -- src/components/__tests__/Watchlist.test.ts`

Closes #805