### PR TITLE
[Movies] Add Watchlist route and navigation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -103,6 +103,8 @@
       return;
     }
     if (isWatchlistPath(path)) {
+      unauthRoute = 'login';
+      resetToken = null;
       threadRouteStore.clearTarget();
       pendingSectionIdentifier = null;
       pendingThreadPostId = null;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import MusicLinksContainer from './components/MusicLinksContainer.svelte';
   import ThreadView from './components/ThreadView.svelte';
   import UserProfile from './components/UserProfile.svelte';
+  import Watchlist from './components/movies/Watchlist.svelte';
   import Cookbook from './components/recipes/Cookbook.svelte';
   import { Login, Register, AdminPanel, PasswordReset, Settings } from './routes';
   import {
@@ -36,6 +37,7 @@
     getHistoryState,
     isAdminPath,
     isSettingsPath,
+    isWatchlistPath,
     parseStandaloneThreadPostId,
     parseSectionSlug,
     parseThreadCommentId,
@@ -98,6 +100,15 @@
       pendingThreadPostId = null;
       pendingAdminPath = false;
       highlightCommentId = null;
+      return;
+    }
+    if (isWatchlistPath(path)) {
+      threadRouteStore.clearTarget();
+      pendingSectionIdentifier = null;
+      pendingThreadPostId = null;
+      pendingAdminPath = false;
+      highlightCommentId = null;
+      uiStore.setActiveView('watchlist');
       return;
     }
     const profileUserId = parseProfileUserId(path);
@@ -273,6 +284,20 @@
       sectionNotFound = null;
     }
   }
+
+  $: if (
+    typeof window !== 'undefined' &&
+    isWatchlistPath(window.location.pathname) &&
+    $activeView !== 'watchlist'
+  ) {
+    threadRouteStore.clearTarget();
+    highlightCommentId = null;
+    uiStore.setActiveView('watchlist');
+  }
+
+  $: if (typeof document !== 'undefined') {
+    document.title = $activeView === 'watchlist' ? 'My Watchlist - Clubhouse' : 'Clubhouse';
+  }
 </script>
 
 <ErrorBoundary>
@@ -326,6 +351,14 @@
           {/if}
         {:else if $activeView === 'settings'}
           <Settings />
+        {:else if $activeView === 'watchlist'}
+          <div class="space-y-4">
+            <div>
+              <h1 class="text-2xl font-bold text-gray-900">My Watchlist</h1>
+              <p class="text-gray-600">Track and organize movies you want to watch.</p>
+            </div>
+            <Watchlist />
+          </div>
         {:else if sectionNotFound}
           <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <h1 class="text-xl font-semibold text-gray-900 mb-2">Section not found</h1>

--- a/frontend/src/__tests__/App.watchlist.test.ts
+++ b/frontend/src/__tests__/App.watchlist.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import * as stores from '../stores';
+import { movieStore } from '../stores/movieStore';
+
+const { default: App } = await import('../App.svelte');
+
+const defaultUser = {
+  id: 'user-1',
+  username: 'moviefan',
+  email: 'moviefan@example.com',
+  isAdmin: false,
+  totpEnabled: false,
+};
+
+beforeEach(() => {
+  vi.spyOn(stores.authStore, 'checkSession').mockResolvedValue(false);
+  vi.spyOn(stores.websocketStore, 'init').mockImplementation(() => {});
+  vi.spyOn(stores.websocketStore, 'cleanup').mockImplementation(() => {});
+  vi.spyOn(stores.sectionStore, 'loadSections').mockResolvedValue();
+  vi.spyOn(stores.pwaStore, 'init').mockResolvedValue();
+  vi.spyOn(stores.configStore, 'load').mockResolvedValue();
+  vi.spyOn(stores, 'initNotifications').mockImplementation(() => {});
+  vi.spyOn(stores, 'cleanupNotifications').mockImplementation(() => {});
+  vi.spyOn(movieStore, 'loadWatchlist').mockResolvedValue();
+  vi.spyOn(movieStore, 'loadWatchlistCategories').mockResolvedValue();
+
+  stores.authStore.setUser(null);
+  stores.sectionStore.setSections([]);
+  stores.uiStore.setActiveView('feed');
+  stores.threadRouteStore.clearTarget();
+  movieStore.reset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('App watchlist routing', () => {
+  it('renders watchlist route for authenticated users', async () => {
+    stores.authStore.setUser(defaultUser);
+    window.history.replaceState(null, '', '/watchlist');
+    expect(window.location.pathname).toBe('/watchlist');
+
+    render(App);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('watchlist')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('heading', { name: 'My Watchlist' })).toBeInTheDocument();
+    expect(document.title).toBe('My Watchlist - Clubhouse');
+  });
+
+  it('renders login for unauthenticated users on watchlist route', async () => {
+    window.history.replaceState(null, '', '/watchlist');
+    expect(window.location.pathname).toBe('/watchlist');
+
+    render(App);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('watchlist')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/App.watchlist.test.ts
+++ b/frontend/src/__tests__/App.watchlist.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import * as stores from '../stores';
 import { movieStore } from '../stores/movieStore';
 
@@ -45,7 +45,7 @@ describe('App watchlist routing', () => {
     expect(window.location.pathname).toBe('/watchlist');
 
     render(App);
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    window.dispatchEvent(new Event('popstate'));
 
     await waitFor(() => {
       expect(screen.getByTestId('watchlist')).toBeInTheDocument();
@@ -59,11 +59,29 @@ describe('App watchlist routing', () => {
     expect(window.location.pathname).toBe('/watchlist');
 
     render(App);
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    window.dispatchEvent(new Event('popstate'));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
     });
     expect(screen.queryByTestId('watchlist')).not.toBeInTheDocument();
+  });
+
+  it('switches unauth register route to login when navigating to watchlist', async () => {
+    const { unmount } = render(App);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'create a new account' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Create your account' })).toBeInTheDocument();
+    });
+
+    unmount();
+    window.history.replaceState(null, '', '/watchlist');
+
+    render(App);
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', { name: 'Create your account' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -10,7 +10,12 @@
     threadRouteStore,
     unreadRegistrationCount,
   } from '../stores';
-  import { buildAdminHref, buildSectionHref, pushPath } from '../services/routeNavigation';
+  import {
+    buildAdminHref,
+    buildSectionHref,
+    buildWatchlistHref,
+    pushPath,
+  } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
   import NotificationSettings from './NotificationSettings.svelte';
 
@@ -25,6 +30,12 @@
     uiStore.setActiveView('admin');
     threadRouteStore.clearTarget();
     pushPath(buildAdminHref());
+  }
+
+  function handleWatchlistClick() {
+    uiStore.setActiveView('watchlist');
+    threadRouteStore.clearTarget();
+    pushPath(buildWatchlistHref());
   }
 </script>
 
@@ -50,6 +61,22 @@
         </li>
       {/each}
     </ul>
+
+    {#if $isAuthenticated}
+      <div class="mt-4 border-t border-gray-200 px-2 pt-4">
+        <button
+          on:click={handleWatchlistClick}
+          class="w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
+            {$activeView === 'watchlist'
+            ? 'bg-indigo-600 text-white'
+            : 'text-gray-700 hover:bg-indigo-50'}"
+          aria-current={$activeView === 'watchlist' ? 'page' : undefined}
+        >
+          <span class="text-lg" aria-hidden="true">🎬</span>
+          <span>My Movies</span>
+        </button>
+      </div>
+    {/if}
   </div>
 
   {#if $isAuthenticated}

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -5,9 +5,11 @@ import {
   buildSectionHref,
   buildStandaloneThreadHref,
   buildSettingsHref,
+  buildWatchlistHref,
   buildThreadHref,
   isAdminPath,
   isSettingsPath,
+  isWatchlistPath,
   parseStandaloneThreadPostId,
   parseSectionSlug,
   parseThreadCommentId,
@@ -61,6 +63,13 @@ describe('routeNavigation', () => {
     expect(isSettingsPath('/settings')).toBe(true);
     expect(isSettingsPath('/settings/profile')).toBe(true);
     expect(isSettingsPath('/admin')).toBe(false);
+  });
+
+  it('builds watchlist hrefs and recognizes watchlist paths', () => {
+    expect(buildWatchlistHref()).toBe('/watchlist');
+    expect(isWatchlistPath('/watchlist')).toBe(true);
+    expect(isWatchlistPath('/watchlist/favorites')).toBe(true);
+    expect(isWatchlistPath('/sections/movies')).toBe(false);
   });
 
   it('builds feed hrefs from section slugs', () => {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -3,6 +3,7 @@ const THREAD_ROOT_PATH = '/posts/';
 const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
+const WATCHLIST_PATH = '/watchlist';
 
 export type SearchHistoryState = {
   query: string;
@@ -78,12 +79,20 @@ export function buildSettingsHref(): string {
   return SETTINGS_PATH;
 }
 
+export function buildWatchlistHref(): string {
+  return WATCHLIST_PATH;
+}
+
 export function isAdminPath(pathname: string): boolean {
   return pathname === ADMIN_PATH || pathname.startsWith(`${ADMIN_PATH}/`);
 }
 
 export function isSettingsPath(pathname: string): boolean {
   return pathname === SETTINGS_PATH || pathname.startsWith(`${SETTINGS_PATH}/`);
+}
+
+export function isWatchlistPath(pathname: string): boolean {
+  return pathname === WATCHLIST_PATH || pathname.startsWith(`${WATCHLIST_PATH}/`);
 }
 
 export function buildFeedHref(sectionSlug?: string | null): string {

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -3,7 +3,7 @@ import { writable, derived } from 'svelte/store';
 interface UIState {
   sidebarOpen: boolean;
   isMobile: boolean;
-  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread';
+  activeView: 'feed' | 'watchlist' | 'admin' | 'profile' | 'settings' | 'thread';
   activeProfileUserId: string | null;
 }
 
@@ -25,7 +25,7 @@ function createUIStore() {
         isMobile,
         sidebarOpen: isMobile ? false : state.sidebarOpen,
       })),
-    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread') =>
+    setActiveView: (activeView: 'feed' | 'watchlist' | 'admin' | 'profile' | 'settings' | 'thread') =>
       update((state) => ({
         ...state,
         activeView,


### PR DESCRIPTION
## Summary
- add first-class `/watchlist` routing helpers (`buildWatchlistHref`, `isWatchlistPath`) and wire the route in `App.svelte`
- add a dedicated watchlist app view with the `Watchlist` component and set page title to `My Watchlist - Clubhouse`
- add a `My Movies` sidebar navigation action (with active state) that routes to `/watchlist`
- extend `uiStore` active view union with `watchlist`
- add tests for route helpers, nav behavior, and app watchlist rendering/auth gating

## Testing
- `cd frontend && npm run test -- src/services/__tests__/routeNavigation.test.ts src/components/__tests__/Nav.test.ts src/__tests__/App.watchlist.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run test`

Closes #808