### PR TITLE
[Movies] Create MovieStatsBar component

### DIFF
--- a/frontend/src/components/__tests__/MovieStatsBar.test.ts
+++ b/frontend/src/components/__tests__/MovieStatsBar.test.ts
@@ -1,0 +1,198 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const apiGetPostWatchlistInfo = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    saveCount: 2,
+    users: [
+      {
+        id: 'user-1',
+        username: 'sander',
+        displayName: 'Sander',
+        avatar: undefined,
+      },
+    ],
+    viewerSaved: false,
+    viewerCategories: [],
+  })
+);
+
+const apiGetPostWatchLogs = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    watchCount: 1,
+    avgRating: 4.2,
+    logs: [
+      {
+        id: 'log-1',
+        userId: 'user-2',
+        postId: 'post-1',
+        rating: 4.5,
+        watchedAt: '2026-02-01T00:00:00Z',
+        user: {
+          id: 'user-2',
+          username: 'alex',
+          displayName: 'Alex',
+          avatar: undefined,
+        },
+      },
+    ],
+    viewerWatched: false,
+    viewerRating: undefined,
+  })
+);
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getPostWatchlistInfo: apiGetPostWatchlistInfo,
+    getPostWatchLogs: apiGetPostWatchLogs,
+  },
+}));
+
+vi.mock('../movies/WatchlistSaveButton.svelte', async () => ({
+  default: (await import('./WatchlistSaveButtonPropsStub.svelte')).default,
+}));
+
+vi.mock('../movies/WatchButton.svelte', async () => ({
+  default: (await import('./WatchButtonPropsStub.svelte')).default,
+}));
+
+const { default: MovieStatsBar } = await import('../movies/MovieStatsBar.svelte');
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('MovieStatsBar', () => {
+  it('renders stats and action buttons', () => {
+    render(MovieStatsBar, {
+      postId: 'post-1',
+      stats: {
+        watchlistCount: 12,
+        watchCount: 8,
+        avgRating: 4.2,
+        viewerWatchlisted: true,
+        viewerWatched: true,
+        viewerRating: 4,
+        viewerCategories: ['Favorites'],
+      },
+    });
+
+    expect(screen.getByTestId('movie-stats-bar')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('saved')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('watched')).toBeInTheDocument();
+    expect(screen.getByTestId('movie-average-rating')).toHaveTextContent('4.2');
+    expect(screen.getByTestId('watchlist-save-button-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('watch-button-stub')).toBeInTheDocument();
+  });
+
+  it('hides average rating when it is not provided', () => {
+    render(MovieStatsBar, {
+      postId: 'post-2',
+      stats: {
+        watchlistCount: 0,
+        watchCount: 0,
+        viewerWatchlisted: false,
+        viewerWatched: false,
+      },
+    });
+
+    expect(screen.queryByTestId('movie-average-rating')).not.toBeInTheDocument();
+  });
+
+  it('loads watchlist tooltip users on hover', async () => {
+    vi.useFakeTimers();
+
+    render(MovieStatsBar, {
+      postId: 'post-3',
+      stats: {
+        watchlistCount: 2,
+        watchCount: 0,
+        viewerWatchlisted: false,
+        viewerWatched: false,
+      },
+    });
+
+    expect(apiGetPostWatchlistInfo).not.toHaveBeenCalled();
+
+    await fireEvent.mouseEnter(screen.getByTestId('movie-watchlist-stat'));
+    await vi.runAllTimersAsync();
+
+    expect(apiGetPostWatchlistInfo).toHaveBeenCalledWith('post-3');
+    expect(await screen.findByText('Sander')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('loads watch tooltip logs on hover', async () => {
+    vi.useFakeTimers();
+
+    render(MovieStatsBar, {
+      postId: 'post-4',
+      stats: {
+        watchlistCount: 0,
+        watchCount: 1,
+        avgRating: 4.2,
+        viewerWatchlisted: false,
+        viewerWatched: false,
+      },
+    });
+
+    expect(apiGetPostWatchLogs).not.toHaveBeenCalled();
+
+    await fireEvent.mouseEnter(screen.getByTestId('movie-watch-stat'));
+    await vi.runAllTimersAsync();
+
+    expect(apiGetPostWatchLogs).toHaveBeenCalledWith('post-4');
+    expect(await screen.findByText('Alex')).toBeInTheDocument();
+    expect(screen.getByText('4.5')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('uses mobile-first responsive layout classes', () => {
+    render(MovieStatsBar, {
+      postId: 'post-5',
+      stats: {
+        watchlistCount: 1,
+        watchCount: 1,
+        avgRating: 4,
+        viewerWatchlisted: false,
+        viewerWatched: false,
+      },
+    });
+
+    const container = screen.getByTestId('movie-stats-bar');
+    expect(container.className).toContain('flex-col');
+    expect(container.className).toContain('sm:flex-row');
+  });
+
+  it('passes viewer state props to action buttons', () => {
+    render(MovieStatsBar, {
+      postId: 'post-6',
+      stats: {
+        watchlistCount: 5,
+        watchCount: 3,
+        avgRating: 3.5,
+        viewerWatchlisted: true,
+        viewerWatched: true,
+        viewerRating: 5,
+        viewerCategories: ['Favorites', 'Sci-Fi'],
+      },
+    });
+
+    const watchlistButton = screen.getByTestId('watchlist-save-button-stub');
+    expect(watchlistButton).toHaveAttribute('data-post-id', 'post-6');
+    expect(watchlistButton).toHaveAttribute('data-initial-saved', 'true');
+    expect(watchlistButton).toHaveAttribute('data-categories', 'Favorites,Sci-Fi');
+    expect(watchlistButton).toHaveAttribute('data-save-count', '5');
+
+    const watchButton = screen.getByTestId('watch-button-stub');
+    expect(watchButton).toHaveAttribute('data-post-id', 'post-6');
+    expect(watchButton).toHaveAttribute('data-initial-watched', 'true');
+    expect(watchButton).toHaveAttribute('data-initial-rating', '5');
+    expect(watchButton).toHaveAttribute('data-watch-count', '3');
+  });
+});

--- a/frontend/src/components/__tests__/WatchButtonPropsStub.svelte
+++ b/frontend/src/components/__tests__/WatchButtonPropsStub.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let postId = '';
+  export let initialWatched = false;
+  export let initialRating: number | null = null;
+  export let watchCount = 0;
+</script>
+
+<div
+  data-testid="watch-button-stub"
+  data-post-id={postId}
+  data-initial-watched={initialWatched}
+  data-initial-rating={initialRating}
+  data-watch-count={watchCount}
+>
+  WatchButton
+</div>

--- a/frontend/src/components/__tests__/WatchlistSaveButtonPropsStub.svelte
+++ b/frontend/src/components/__tests__/WatchlistSaveButtonPropsStub.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let postId = '';
+  export let initialSaved = false;
+  export let initialCategories: string[] = [];
+  export let saveCount = 0;
+</script>
+
+<div
+  data-testid="watchlist-save-button-stub"
+  data-post-id={postId}
+  data-initial-saved={initialSaved}
+  data-categories={initialCategories.join(',')}
+  data-save-count={saveCount}
+>
+  WatchlistSaveButton
+</div>

--- a/frontend/src/components/movies/MovieStatsBar.svelte
+++ b/frontend/src/components/movies/MovieStatsBar.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { api, type WatchlistUser, type WatchLog } from '../../services/api';
+  import RatingStars from '../recipes/RatingStars.svelte';
+  import WatchButton from './WatchButton.svelte';
+  import WatchlistSaveButton from './WatchlistSaveButton.svelte';
+
+  type MovieStats = {
+    watchlistCount: number;
+    watchCount: number;
+    avgRating?: number;
+    viewerWatchlisted: boolean;
+    viewerWatched: boolean;
+    viewerRating?: number;
+    viewerCategories?: string[];
+  };
+
+  export let postId: string;
+  export let stats: MovieStats;
+
+  const TOOLTIP_DELAY = 150;
+
+  let watchlistTooltipContainer: HTMLDivElement | null = null;
+  let watchTooltipContainer: HTMLDivElement | null = null;
+  let showWatchlistTooltip = false;
+  let showWatchTooltip = false;
+  let watchlistTooltipLoading = false;
+  let watchTooltipLoading = false;
+  let watchlistTooltipError: string | null = null;
+  let watchTooltipError: string | null = null;
+  let watchlistUsers: WatchlistUser[] = [];
+  let watchLogs: WatchLog[] = [];
+  let watchlistTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+  let watchTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+  let lastWatchlistKey = '';
+  let lastWatchKey = '';
+
+  const clampCount = (value: number) => Math.max(0, Number.isFinite(value) ? value : 0);
+  const clampRating = (value: number) => Math.min(5, Math.max(0, value));
+
+  $: normalizedWatchlistCount = clampCount(stats?.watchlistCount ?? 0);
+  $: normalizedWatchCount = clampCount(stats?.watchCount ?? 0);
+  $: normalizedAvgRating =
+    typeof stats?.avgRating === 'number' && Number.isFinite(stats.avgRating)
+      ? clampRating(stats.avgRating)
+      : null;
+  $: hasAvgRating = normalizedAvgRating !== null;
+  $: formattedAvgRating =
+    normalizedAvgRating === null
+      ? ''
+      : Number.isInteger(normalizedAvgRating)
+        ? normalizedAvgRating.toFixed(0)
+        : normalizedAvgRating.toFixed(1);
+
+  $: watchlistKey = `${postId}:${normalizedWatchlistCount}`;
+  $: watchKey = `${postId}:${normalizedWatchCount}:${normalizedAvgRating ?? 'none'}`;
+
+  function getInitial(name?: string | null) {
+    const trimmed = name?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed.charAt(0).toUpperCase() : '?';
+  }
+
+  function handleFocusOut(event: FocusEvent, container: HTMLDivElement | null, hide: () => void) {
+    if (container && event.relatedTarget) {
+      const target = event.relatedTarget as Node;
+      if (container.contains(target)) {
+        return;
+      }
+    }
+
+    hide();
+  }
+
+  function hideWatchlistTooltip() {
+    showWatchlistTooltip = false;
+    if (watchlistTooltipTimeout) {
+      clearTimeout(watchlistTooltipTimeout);
+      watchlistTooltipTimeout = null;
+    }
+  }
+
+  function hideWatchTooltip() {
+    showWatchTooltip = false;
+    if (watchTooltipTimeout) {
+      clearTimeout(watchTooltipTimeout);
+      watchTooltipTimeout = null;
+    }
+  }
+
+  async function loadWatchlistTooltipData(force = false) {
+    if (!postId || normalizedWatchlistCount <= 0) {
+      return;
+    }
+
+    if (!force && watchlistUsers.length > 0 && watchlistKey === lastWatchlistKey) {
+      return;
+    }
+
+    watchlistTooltipLoading = true;
+    watchlistTooltipError = null;
+
+    try {
+      const response = await api.getPostWatchlistInfo(postId);
+      watchlistUsers = response.users ?? [];
+      lastWatchlistKey = watchlistKey;
+    } catch (error) {
+      watchlistTooltipError =
+        error instanceof Error ? error.message : 'Failed to load watchlist users.';
+    } finally {
+      watchlistTooltipLoading = false;
+    }
+  }
+
+  async function loadWatchTooltipData(force = false) {
+    if (!postId || normalizedWatchCount <= 0) {
+      return;
+    }
+
+    if (!force && watchLogs.length > 0 && watchKey === lastWatchKey) {
+      return;
+    }
+
+    watchTooltipLoading = true;
+    watchTooltipError = null;
+
+    try {
+      const response = await api.getPostWatchLogs(postId);
+      watchLogs = response.logs ?? [];
+      lastWatchKey = watchKey;
+    } catch (error) {
+      watchTooltipError = error instanceof Error ? error.message : 'Failed to load watches.';
+    } finally {
+      watchTooltipLoading = false;
+    }
+  }
+
+  function showWatchlistTooltipWithDelay() {
+    if (!postId || normalizedWatchlistCount <= 0) {
+      return;
+    }
+
+    if (watchlistTooltipTimeout) {
+      clearTimeout(watchlistTooltipTimeout);
+    }
+
+    watchlistTooltipTimeout = setTimeout(async () => {
+      showWatchlistTooltip = true;
+      await loadWatchlistTooltipData();
+    }, TOOLTIP_DELAY);
+  }
+
+  function showWatchTooltipWithDelay() {
+    if (!postId || normalizedWatchCount <= 0) {
+      return;
+    }
+
+    if (watchTooltipTimeout) {
+      clearTimeout(watchTooltipTimeout);
+    }
+
+    watchTooltipTimeout = setTimeout(async () => {
+      showWatchTooltip = true;
+      await loadWatchTooltipData();
+    }, TOOLTIP_DELAY);
+  }
+
+  onDestroy(() => {
+    if (watchlistTooltipTimeout) {
+      clearTimeout(watchlistTooltipTimeout);
+    }
+
+    if (watchTooltipTimeout) {
+      clearTimeout(watchTooltipTimeout);
+    }
+  });
+</script>
+
+<div
+  class="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-600 sm:flex-row sm:items-center sm:justify-between"
+  data-testid="movie-stats-bar"
+>
+  <div class="flex flex-wrap items-center gap-3">
+    <div
+      class="relative"
+      role="group"
+      bind:this={watchlistTooltipContainer}
+      on:mouseenter={showWatchlistTooltipWithDelay}
+      on:mouseleave={hideWatchlistTooltip}
+      on:focusin={showWatchlistTooltipWithDelay}
+      on:focusout={(event) => handleFocusOut(event, watchlistTooltipContainer, hideWatchlistTooltip)}
+      data-testid="movie-watchlist-stat"
+    >
+      <div class="inline-flex items-center gap-1.5">
+        <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-violet-50 text-violet-700">
+          📋
+        </span>
+        <span class="font-semibold text-gray-800">{normalizedWatchlistCount}</span>
+        <span>saved</span>
+      </div>
+
+      {#if showWatchlistTooltip}
+        <div
+          class="absolute left-0 top-full z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 text-xs shadow-lg"
+          role="tooltip"
+          data-testid="movie-watchlist-tooltip"
+        >
+          {#if watchlistTooltipLoading}
+            <p class="text-gray-500">Loading watchlist users...</p>
+          {:else if watchlistTooltipError}
+            <p class="text-red-500">{watchlistTooltipError}</p>
+          {:else if watchlistUsers.length === 0}
+            <p class="text-gray-500">No saves yet.</p>
+          {:else}
+            <div class="space-y-2">
+              {#each watchlistUsers as user}
+                <div class="flex items-center gap-2">
+                  {#if user.avatar}
+                    <img
+                      src={user.avatar}
+                      alt={user.displayName}
+                      class="h-7 w-7 rounded-full object-cover"
+                    />
+                  {:else}
+                    <div class="h-7 w-7 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs font-semibold">
+                      {getInitial(user.displayName)}
+                    </div>
+                  {/if}
+                  <span class="text-gray-700">{user.displayName || user.username || 'Unknown'}</span>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+    <div
+      class="relative"
+      role="group"
+      bind:this={watchTooltipContainer}
+      on:mouseenter={showWatchTooltipWithDelay}
+      on:mouseleave={hideWatchTooltip}
+      on:focusin={showWatchTooltipWithDelay}
+      on:focusout={(event) => handleFocusOut(event, watchTooltipContainer, hideWatchTooltip)}
+      data-testid="movie-watch-stat"
+    >
+      <div class="inline-flex items-center gap-1.5">
+        <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+          👁
+        </span>
+        <span class="font-semibold text-gray-800">{normalizedWatchCount}</span>
+        <span>watched</span>
+      </div>
+
+      {#if showWatchTooltip}
+        <div
+          class="absolute left-0 top-full z-20 mt-2 w-72 rounded-lg border border-gray-200 bg-white p-3 text-xs shadow-lg"
+          role="tooltip"
+          data-testid="movie-watch-tooltip"
+        >
+          {#if watchTooltipLoading}
+            <p class="text-gray-500">Loading watch logs...</p>
+          {:else if watchTooltipError}
+            <p class="text-red-500">{watchTooltipError}</p>
+          {:else if watchLogs.length === 0}
+            <p class="text-gray-500">No watches yet.</p>
+          {:else}
+            <div class="space-y-2">
+              {#each watchLogs as log}
+                <div class="flex items-center justify-between gap-2">
+                  <div class="flex items-center gap-2 min-w-0">
+                    {#if log.user?.avatar}
+                      <img
+                        src={log.user.avatar}
+                        alt={log.user.displayName}
+                        class="h-7 w-7 rounded-full object-cover"
+                      />
+                    {:else}
+                      <div class="h-7 w-7 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs font-semibold">
+                        {getInitial(log.user?.displayName)}
+                      </div>
+                    {/if}
+                    <span class="text-gray-700 truncate">{log.user?.displayName || log.user?.username || 'Unknown'}</span>
+                  </div>
+                  <div class="flex items-center gap-1">
+                    <RatingStars
+                      value={log.rating}
+                      readonly
+                      size="sm"
+                      ariaLabel={`${log.user?.displayName || 'User'} rating`}
+                    />
+                    <span class="text-gray-500 font-semibold">{log.rating.toFixed(1)}</span>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+    {#if hasAvgRating}
+      <div class="inline-flex items-center gap-1.5" data-testid="movie-average-rating">
+        <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+          ★
+        </span>
+        <span class="font-semibold text-gray-800">{formattedAvgRating}</span>
+        <span>avg</span>
+        <RatingStars
+          value={normalizedAvgRating ?? 0}
+          readonly
+          size="sm"
+          ariaLabel={`Average rating ${formattedAvgRating}`}
+        />
+      </div>
+    {/if}
+  </div>
+
+  <div class="flex flex-wrap items-center gap-2" data-testid="movie-stats-actions">
+    <WatchlistSaveButton
+      postId={postId}
+      initialSaved={stats?.viewerWatchlisted ?? false}
+      initialCategories={stats?.viewerCategories ?? []}
+      saveCount={normalizedWatchlistCount}
+    />
+    <WatchButton
+      postId={postId}
+      initialWatched={stats?.viewerWatched ?? false}
+      initialRating={stats?.viewerRating ?? null}
+      watchCount={normalizedWatchCount}
+    />
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add `MovieStatsBar` component with watchlist count, watch count, and optional average rating display
- add lazy-loaded hover tooltips for watchlist users and watch logs with user ratings
- include `WatchlistSaveButton` and `WatchButton` actions with viewer state props
- use responsive mobile-first layout (`flex-col` on mobile, `sm:flex-row` on desktop)
- add `MovieStatsBar` component tests for stats rendering, tooltip loading, responsive classes, and button prop passthrough via stubs

## Validation
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/MovieStatsBar.test.ts`
- `cd frontend && npm run test`

Closes #804