### PR TITLE
[Movies] Integrate MovieStatsBar and MovieCard into PostCard

### DIFF
--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -26,6 +26,25 @@ vi.mock('../../services/api', () => ({
 
 const { default: PostCard } = await import('../PostCard.svelte');
 
+type MovieMetadataForTest = {
+  title: string;
+  overview?: string;
+  poster?: string;
+  runtime?: number;
+  genres?: string[];
+  release_date?: string;
+  director?: string;
+  tmdb_rating?: number;
+  trailer_key?: string;
+  cast?: Array<{ name: string; character: string }>;
+};
+
+type LinkMetadataWithMovieForTest = NonNullable<
+  NonNullable<Post['links']>[number]['metadata']
+> & {
+  movie?: MovieMetadataForTest;
+};
+
 const basePost: Post = {
   id: 'post-1',
   userId: 'user-1',
@@ -156,6 +175,160 @@ describe('PostCard', () => {
     render(PostCard, { post: postWithRecipe });
     expect(screen.getByText('Tomato Soup')).toBeInTheDocument();
     expect(screen.getByText('View Recipe')).toBeInTheDocument();
+  });
+
+  it('renders movie stats bar for movie sections', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Movies',
+        type: 'movie',
+        icon: '🎬',
+        slug: 'movies',
+      },
+    ]);
+
+    const postWithMovieStats: Post = {
+      ...basePost,
+      movieStats: {
+        watchlistCount: 5,
+        watchCount: 3,
+        averageRating: 4.5,
+        viewerWatchlisted: true,
+        viewerWatched: false,
+        viewerRating: null,
+        viewerCategories: ['Favorites'],
+      },
+    };
+
+    render(PostCard, { post: postWithMovieStats });
+    expect(screen.getByTestId('movie-stats-bar')).toBeInTheDocument();
+  });
+
+  it('renders movie card for movie metadata links in movie sections', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Movies',
+        type: 'movie',
+        icon: '🎬',
+        slug: 'movies',
+      },
+    ]);
+
+    const metadataWithMovie: LinkMetadataWithMovieForTest = {
+      url: 'https://www.imdb.com/title/tt0816692/',
+      provider: 'imdb',
+      title: 'Interstellar',
+      movie: {
+        title: 'Interstellar',
+        overview: "A team travels through a wormhole to save humanity's future.",
+        runtime: 169,
+        genres: ['Sci-Fi', 'Drama'],
+        release_date: '2014-11-07',
+        director: 'Christopher Nolan',
+        tmdb_rating: 8.6,
+      },
+    };
+
+    const moviePost: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://www.imdb.com/title/tt0816692/',
+          metadata: metadataWithMovie,
+        },
+      ],
+    };
+
+    render(PostCard, { post: moviePost });
+    expect(screen.getByTestId('movie-card')).toBeInTheDocument();
+    expect(screen.getByTestId('movie-title')).toHaveTextContent('Interstellar');
+  });
+
+  it('does not render movie components for non-movie sections', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'General',
+        type: 'general',
+        icon: '💬',
+        slug: 'general',
+      },
+    ]);
+
+    const metadataWithMovie: LinkMetadataWithMovieForTest = {
+      url: 'https://www.imdb.com/title/tt0816692/',
+      provider: 'imdb',
+      title: 'Interstellar',
+      movie: {
+        title: 'Interstellar',
+      },
+    };
+
+    const generalPostWithMovieData: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://www.imdb.com/title/tt0816692/',
+          metadata: metadataWithMovie,
+        },
+      ],
+      movieStats: {
+        watchlistCount: 5,
+        watchCount: 2,
+        averageRating: 4,
+      },
+    };
+
+    render(PostCard, { post: generalPostWithMovieData });
+
+    expect(screen.queryByTestId('movie-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('movie-stats-bar')).not.toBeInTheDocument();
+  });
+
+  it('keeps recipe section rendering intact', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Recipes',
+        type: 'recipe',
+        icon: '🍳',
+        slug: 'recipes',
+      },
+    ]);
+
+    const postWithRecipe: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://example.com/recipe',
+          metadata: {
+            url: 'https://example.com/recipe',
+            title: 'Example Recipe',
+            image: 'https://example.com/recipe.jpg',
+            recipe: {
+              name: 'Tomato Soup',
+              prep_time: '10m',
+              cook_time: '20m',
+              yield: '2',
+              ingredients: ['Tomatoes', 'Salt'],
+              instructions: ['Simmer', 'Serve'],
+            },
+          },
+        },
+      ],
+      recipeStats: {
+        saveCount: 12,
+        cookCount: 6,
+        averageRating: 4.8,
+      },
+    };
+
+    render(PostCard, { post: postWithRecipe });
+    expect(screen.getByText('Tomato Soup')).toBeInTheDocument();
+    expect(screen.getByTestId('recipe-stats-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('movie-card')).not.toBeInTheDocument();
   });
 
   it('renders highlights when link includes them', () => {

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -3,6 +3,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import type { Post } from '../../stores/postStore';
 import { authStore } from '../../stores';
 import { sectionStore } from '../../stores/sectionStore';
+import { mapApiPost } from '../../stores/postMapper';
 import { tick } from 'svelte';
 
 const loadThreadComments = vi.hoisted(() => vi.fn());
@@ -244,6 +245,46 @@ describe('PostCard', () => {
     render(PostCard, { post: moviePost });
     expect(screen.getByTestId('movie-card')).toBeInTheDocument();
     expect(screen.getByTestId('movie-title')).toHaveTextContent('Interstellar');
+  });
+
+  it('renders movie card from mapped API metadata payload', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Movies',
+        type: 'movie',
+        icon: '🎬',
+        slug: 'movies',
+      },
+    ]);
+
+    const mappedPost = mapApiPost({
+      id: 'post-from-api',
+      user_id: 'user-1',
+      section_id: 'section-1',
+      content: 'Interstellar',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          url: 'https://www.imdb.com/title/tt0816692/',
+          metadata: {
+            movie: {
+              title: 'Interstellar',
+              runtime: 169,
+              genres: ['Sci-Fi', 'Drama'],
+              release_date: '2014-11-07',
+              tmdb_rating: 8.6,
+            },
+          },
+        },
+      ],
+    });
+
+    render(PostCard, { post: mappedPost });
+
+    expect(screen.getByTestId('movie-card')).toBeInTheDocument();
+    expect(screen.getByTestId('movie-title')).toHaveTextContent('Interstellar');
+    expect(screen.getByTestId('movie-meta-line')).toHaveTextContent('★ 8.6 · 2h 49m');
   });
 
   it('does not render movie components for non-movie sections', () => {

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -139,6 +139,56 @@ describe('mapApiPost', () => {
     expect(post.movieStats?.viewerCategories).toEqual(['Top Picks']);
   });
 
+  it('preserves and normalizes nested movie metadata payload', () => {
+    const post = mapApiPost({
+      id: 'post-movie-metadata',
+      user_id: 'user-movie-metadata',
+      section_id: 'section-movie',
+      content: 'Movie metadata',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-movie',
+          url: 'https://www.imdb.com/title/tt0816692/',
+          metadata: {
+            movie: {
+              title: 'Interstellar',
+              overview: 'A team travels through a wormhole.',
+              poster_url: 'https://example.com/poster.jpg',
+              backdrop_url: 'https://example.com/backdrop.jpg',
+              runtime: '169',
+              genres: ['Sci-Fi', 'Drama'],
+              release_date: '2014-11-07',
+              director: 'Christopher Nolan',
+              tmdb_rating: 8.6,
+              trailer_key: 'zSWdZVtXT7E',
+              cast: [
+                { name: 'Matthew McConaughey', character: 'Cooper' },
+                { name: 'Anne Hathaway', character: 'Brand' },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const movie = post.links?.[0].metadata?.movie;
+    expect(movie?.title).toBe('Interstellar');
+    expect(movie?.overview).toBe('A team travels through a wormhole.');
+    expect(movie?.poster).toBe('https://example.com/poster.jpg');
+    expect(movie?.backdrop).toBe('https://example.com/backdrop.jpg');
+    expect(movie?.runtime).toBe(169);
+    expect(movie?.genres).toEqual(['Sci-Fi', 'Drama']);
+    expect(movie?.releaseDate).toBe('2014-11-07');
+    expect(movie?.director).toBe('Christopher Nolan');
+    expect(movie?.tmdbRating).toBe(8.6);
+    expect(movie?.trailerKey).toBe('zSWdZVtXT7E');
+    expect(movie?.cast).toEqual([
+      { name: 'Matthew McConaughey', character: 'Cooper' },
+      { name: 'Anne Hathaway', character: 'Brand' },
+    ]);
+  });
+
   it('handles missing user and links gracefully', () => {
     const post = mapApiPost({
       id: 'post-2',

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -27,6 +27,7 @@ export interface LinkMetadata {
   embed?: EmbedData;
   type?: string;
   recipe?: RecipeMetadata;
+  movie?: MovieMetadata;
 }
 
 export interface EmbedData {
@@ -57,6 +58,25 @@ export interface RecipeMetadata {
   cuisine?: string;
   category?: string;
   nutrition?: RecipeNutritionInfo;
+}
+
+export interface MovieCastMember {
+  name: string;
+  character?: string;
+}
+
+export interface MovieMetadata {
+  title?: string;
+  overview?: string;
+  poster?: string;
+  backdrop?: string;
+  runtime?: number;
+  genres?: string[];
+  releaseDate?: string;
+  cast?: MovieCastMember[];
+  director?: string;
+  tmdbRating?: number;
+  trailerKey?: string;
 }
 
 export interface PostImage {


### PR DESCRIPTION
## Summary
- integrate `MovieCard` rendering into `PostCard` for movie/series sections where link previews render
- integrate `MovieStatsBar` into the post footer for movie/series sections when movie stats are present
- normalize snake_case and camelCase movie metadata keys before passing props to `MovieCard`
- keep recipe/general behavior unchanged and add section-type fallback from `post.section?.type` when available
- add `PostCard` tests covering movie stats rendering, movie card rendering, non-movie suppression, and recipe regression

## Testing
- `cd frontend && npm run test -- src/components/__tests__/PostCard.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run test`

Closes #807