### PR TITLE
[Movies] Watchlist "All Movies" tab always shows "No movies available"

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -339,6 +339,7 @@ func main() {
 		http.HandlerFunc(postHandler.CreatePost),
 	)
 	mux.Handle("/api/v1/posts", postCreateHandler)
+	mux.Handle("/api/v1/posts/movies", requireAuth(http.HandlerFunc(postHandler.GetMovieFeed)))
 
 	// Protected comment routes
 	commentCreateHandler := requireAuthCSRF(

--- a/frontend/src/components/__tests__/Watchlist.test.ts
+++ b/frontend/src/components/__tests__/Watchlist.test.ts
@@ -241,6 +241,27 @@ describe('Watchlist', () => {
     expect(items[0]).toHaveTextContent('Severance');
   });
 
+  it('does not auto-retry movie feed after failure without user action', async () => {
+    vi.mocked(api.getMoviePosts).mockRejectedValueOnce(new Error('Movie feed failed'));
+
+    render(Watchlist);
+    await fireEvent.click(screen.getByTestId('watchlist-tab-all'));
+
+    await screen.findByTestId('watchlist-all-error');
+    await waitFor(() => {
+      expect(api.getMoviePosts).toHaveBeenCalledTimes(1);
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(api.getMoviePosts).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByTestId('watchlist-all-retry'));
+    await waitFor(() => {
+      expect(api.getMoviePosts).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('filters My List by selected category', async () => {
     render(Watchlist);
 

--- a/frontend/src/components/movies/Watchlist.svelte
+++ b/frontend/src/components/movies/Watchlist.svelte
@@ -3,12 +3,12 @@
   import { get } from 'svelte/store';
   import type { Link, LinkMetadata, Post } from '../../stores/postStore';
   import type { WatchlistItem } from '../../stores/movieStore';
-  import { posts } from '../../stores/postStore';
   import {
     movieStore,
     sortedCategories,
     watchlistByCategory,
   } from '../../stores/movieStore';
+  import { api } from '../../services/api';
   import { buildStandaloneThreadHref, pushPath } from '../../services/routeNavigation';
 
   type TabKey = 'my' | 'all';
@@ -53,6 +53,7 @@
 
   const ALL_CATEGORY_VALUE = '__all__';
   const ALL_CATEGORY_LABEL = 'All';
+  const ALL_MOVIES_PAGE_SIZE = 20;
 
   const dispatch = createEventDispatcher<{
     createCategory: undefined;
@@ -64,6 +65,12 @@
   let selectedCategory = ALL_CATEGORY_VALUE;
   let sortKey: SortKey = 'rating';
   let searchTerm = '';
+  let allMoviePosts: Post[] = [];
+  let allMoviesHasMore = false;
+  let allMoviesNextCursor: string | null = null;
+  let allMoviesLoading = false;
+  let allMoviesLoaded = false;
+  let allMoviesError: string | null = null;
 
   const tabOptions: Array<{ key: TabKey; label: string }> = [
     { key: 'my', label: 'My List' },
@@ -111,9 +118,12 @@
   $: selectedWatchlistItems = getWatchlistItemsForCategory($watchlistByCategory, selectedCategory);
   $: myMovies = buildWatchlistMovieItems(selectedWatchlistItems, watchedPostIDs, postWatchlistCounts);
   $: allMovies = sortMovies(
-    filterMoviesBySearch(buildAllMovieItems($posts, watchedPostIDs, postWatchlistCounts), searchTerm),
+    filterMoviesBySearch(buildAllMovieItems(allMoviePosts, watchedPostIDs, postWatchlistCounts), searchTerm),
     sortKey
   );
+  $: if (activeTab === 'all' && !allMoviesLoaded && !allMoviesLoading) {
+    void loadAllMovies(true);
+  }
 
   function buildCategoryCounts(map: Map<string, WatchlistItem[]>): Map<string, number> {
     const counts = new Map<string, number>();
@@ -342,6 +352,47 @@
           createdAt: new Date(post.createdAt).getTime(),
         };
       });
+  }
+
+  function mergeMovies(existing: Post[], incoming: Post[]): Post[] {
+    const byID = new Map<string, Post>();
+    for (const post of existing) {
+      byID.set(post.id, post);
+    }
+    for (const post of incoming) {
+      byID.set(post.id, post);
+    }
+    return Array.from(byID.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  }
+
+  async function loadAllMovies(reset = false): Promise<void> {
+    if (allMoviesLoading) {
+      return;
+    }
+
+    allMoviesLoading = true;
+    allMoviesError = null;
+
+    try {
+      const response = await api.getMoviePosts(
+        ALL_MOVIES_PAGE_SIZE,
+        reset ? undefined : (allMoviesNextCursor ?? undefined)
+      );
+
+      allMoviePosts = reset
+        ? response.posts
+        : mergeMovies(allMoviePosts, response.posts);
+      allMoviesHasMore = response.hasMore;
+      allMoviesNextCursor = response.nextCursor ?? null;
+      allMoviesLoaded = true;
+      allMoviesError = null;
+    } catch (error) {
+      allMoviesError = error instanceof Error ? error.message : 'Failed to load movies';
+    } finally {
+      allMoviesLoading = false;
+    }
   }
 
   function filterMoviesBySearch(items: MovieListItem[], search: string): MovieListItem[] {
@@ -583,7 +634,21 @@
           </div>
         </div>
 
-        {#if allMovies.length === 0}
+        {#if allMoviesLoading && allMovies.length === 0}
+          <div
+            class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+            data-testid="watchlist-all-loading"
+          >
+            Loading movies...
+          </div>
+        {:else if allMoviesError && allMovies.length === 0}
+          <div
+            class="mt-3 rounded-xl border border-dashed border-red-200 bg-red-50 px-4 py-6 text-sm text-red-700"
+            data-testid="watchlist-all-error"
+          >
+            {allMoviesError}
+          </div>
+        {:else if allMovies.length === 0}
           <div
             class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
             data-testid="watchlist-all-empty"
@@ -637,6 +702,26 @@
               </button>
             {/each}
           </div>
+        {/if}
+
+        {#if allMoviesHasMore}
+          <div class="mt-4 flex justify-center">
+            <button
+              type="button"
+              class="rounded-lg border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+              on:click={() => void loadAllMovies(false)}
+              disabled={allMoviesLoading}
+              data-testid="watchlist-all-load-more"
+            >
+              {allMoviesLoading ? 'Loading...' : 'Load more'}
+            </button>
+          </div>
+        {/if}
+
+        {#if allMoviesError && allMovies.length > 0}
+          <p class="mt-3 text-center text-xs text-red-600" data-testid="watchlist-all-error-inline">
+            {allMoviesError}
+          </p>
         {/if}
       </div>
     {/if}

--- a/frontend/src/components/movies/Watchlist.svelte
+++ b/frontend/src/components/movies/Watchlist.svelte
@@ -69,7 +69,7 @@
   let allMoviesHasMore = false;
   let allMoviesNextCursor: string | null = null;
   let allMoviesLoading = false;
-  let allMoviesLoaded = false;
+  let allMoviesAutoLoadAttempted = false;
   let allMoviesError: string | null = null;
 
   const tabOptions: Array<{ key: TabKey; label: string }> = [
@@ -121,7 +121,8 @@
     filterMoviesBySearch(buildAllMovieItems(allMoviePosts, watchedPostIDs, postWatchlistCounts), searchTerm),
     sortKey
   );
-  $: if (activeTab === 'all' && !allMoviesLoaded && !allMoviesLoading) {
+  $: if (activeTab === 'all' && !allMoviesAutoLoadAttempted && !allMoviesLoading) {
+    allMoviesAutoLoadAttempted = true;
     void loadAllMovies(true);
   }
 
@@ -386,7 +387,6 @@
         : mergeMovies(allMoviePosts, response.posts);
       allMoviesHasMore = response.hasMore;
       allMoviesNextCursor = response.nextCursor ?? null;
-      allMoviesLoaded = true;
       allMoviesError = null;
     } catch (error) {
       allMoviesError = error instanceof Error ? error.message : 'Failed to load movies';
@@ -646,7 +646,18 @@
             class="mt-3 rounded-xl border border-dashed border-red-200 bg-red-50 px-4 py-6 text-sm text-red-700"
             data-testid="watchlist-all-error"
           >
-            {allMoviesError}
+            <p>{allMoviesError}</p>
+            <div class="mt-3">
+              <button
+                type="button"
+                class="rounded-lg border border-red-300 bg-white px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100"
+                on:click={() => void loadAllMovies(true)}
+                disabled={allMoviesLoading}
+                data-testid="watchlist-all-retry"
+              >
+                Retry
+              </button>
+            </div>
           </div>
         {:else if allMovies.length === 0}
           <div

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -191,6 +191,45 @@ describe('api client', () => {
     expect(url).toContain('cursor=cursor-1');
   });
 
+  it('getMoviePosts builds query params and maps response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        posts: [
+          {
+            id: 'post-1',
+            user_id: 'user-1',
+            section_id: 'section-movie',
+            content: 'The Matrix',
+            created_at: '2026-01-02T00:00:00Z',
+            movie_stats: {
+              avg_rating: 4.8,
+              watch_count: 10,
+              watchlist_count: 3,
+            },
+          },
+        ],
+        has_more: true,
+        next_cursor: 'cursor-next',
+      }),
+    });
+
+    const response = await api.getMoviePosts(15, 'cursor-1');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/posts/movies');
+    expect(url).toContain('limit=15');
+    expect(url).toContain('cursor=cursor-1');
+    expect(response.hasMore).toBe(true);
+    expect(response.nextCursor).toBe('cursor-next');
+    expect(response.posts).toHaveLength(1);
+    expect(response.posts[0]?.id).toBe('post-1');
+    expect(response.posts[0]?.movieStats?.averageRating).toBe(4.8);
+    expect(response.posts[0]?.movieStats?.watchCount).toBe(10);
+    expect(response.posts[0]?.movieStats?.watchlistCount).toBe(3);
+  });
+
   it('getThreadComments builds query params', async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -713,6 +713,24 @@ class ApiClient {
     return this.get(`/sections/${sectionId}/feed?${params}`);
   }
 
+  async getMoviePosts(
+    limit = 20,
+    cursor?: string
+  ): Promise<{ posts: Post[]; hasMore: boolean; nextCursor?: string }> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (cursor) params.set('cursor', cursor);
+    const response = await this.get<{
+      posts: ApiPost[];
+      has_more?: boolean;
+      next_cursor?: string | null;
+    }>(`/posts/movies?${params}`);
+    return {
+      posts: (response.posts ?? []).map(mapApiPost),
+      hasMore: response.has_more ?? false,
+      nextCursor: response.next_cursor ?? undefined,
+    };
+  }
+
   async getSectionLinks(
     sectionId: string,
     limit = 20,


### PR DESCRIPTION
## Summary
- add `GET /api/v1/posts/movies` to return paginated posts across movie and series sections, including `movie_stats`
- wire the endpoint in backend routing and add backend handler/service coverage for the new movie feed path
- add frontend API client support for `/posts/movies` with response mapping (`posts`, `has_more`, `next_cursor`)
- update `Watchlist.svelte` All Movies tab to load from backend data (lazy load on tab open), support cursor pagination (`Load more`), and preserve search/sort behavior across loaded results
- update watchlist and API client frontend tests to validate endpoint-backed loading, filtering, sorting, and pagination

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./...`
- `cd frontend && npm run check`
- `cd frontend && npm run test`

Closes #836