### PR TITLE
[Movies] Fetch and store season data from TMDB for series

### DIFF
--- a/backend/internal/models/movie.go
+++ b/backend/internal/models/movie.go
@@ -12,6 +12,16 @@ type CastMember struct {
 	Character string `json:"character,omitempty"`
 }
 
+// Season represents TV season metadata.
+type Season struct {
+	SeasonNumber int    `json:"season_number"`
+	EpisodeCount int    `json:"episode_count"`
+	AirDate      string `json:"air_date"`
+	Name         string `json:"name"`
+	Overview     string `json:"overview"`
+	Poster       string `json:"poster"`
+}
+
 // MovieData represents normalized movie metadata.
 type MovieData struct {
 	Title       string       `json:"title"`
@@ -22,6 +32,7 @@ type MovieData struct {
 	Genres      []string     `json:"genres"`
 	ReleaseDate string       `json:"release_date"`
 	Cast        []CastMember `json:"cast"`
+	Seasons     []Season     `json:"seasons,omitempty"`
 	Director    string       `json:"director"`
 	TMDBRating  float64      `json:"tmdb_rating"`
 	TrailerKey  string       `json:"trailer_key"`

--- a/backend/internal/services/links/movie_parser.go
+++ b/backend/internal/services/links/movie_parser.go
@@ -247,6 +247,7 @@ func movieDataFromTVDetails(details *TVDetails) *MovieData {
 		Genres:      tmdbGenreNames(details.Genres),
 		ReleaseDate: strings.TrimSpace(details.FirstAirDate),
 		Cast:        tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
+		Seasons:     tmdbSeasons(details.Seasons),
 		Director:    strings.TrimSpace(details.Director),
 		TMDBRating:  details.VoteAverage,
 		TrailerKey:  tmdbTrailerKey(details.Videos.Results),
@@ -319,6 +320,36 @@ func tmdbCastMembers(cast []TMDBCastMember, limit int) []models.CastMember {
 	if len(result) == 0 {
 		return nil
 	}
+	return result
+}
+
+func tmdbSeasons(seasons []TMDBSeason) []models.Season {
+	if len(seasons) == 0 {
+		return nil
+	}
+
+	orderedSeasons := make([]TMDBSeason, len(seasons))
+	copy(orderedSeasons, seasons)
+	sort.SliceStable(orderedSeasons, func(i, j int) bool {
+		return orderedSeasons[i].SeasonNumber < orderedSeasons[j].SeasonNumber
+	})
+
+	result := make([]models.Season, 0, len(orderedSeasons))
+	for _, season := range orderedSeasons {
+		result = append(result, models.Season{
+			SeasonNumber: season.SeasonNumber,
+			EpisodeCount: season.EpisodeCount,
+			AirDate:      strings.TrimSpace(season.AirDate),
+			Name:         strings.TrimSpace(season.Name),
+			Overview:     strings.TrimSpace(season.Overview),
+			Poster:       tmdbImageURL(season.PosterPath, tmdbPosterSize),
+		})
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
 	return result
 }
 

--- a/backend/internal/services/links/tmdb.go
+++ b/backend/internal/services/links/tmdb.go
@@ -103,6 +103,16 @@ type TMDBGenre struct {
 	Name string `json:"name"`
 }
 
+// TMDBSeason represents season details returned by TMDB TV endpoints.
+type TMDBSeason struct {
+	SeasonNumber int    `json:"season_number"`
+	EpisodeCount int    `json:"episode_count"`
+	AirDate      string `json:"air_date"`
+	Name         string `json:"name"`
+	Overview     string `json:"overview"`
+	PosterPath   string `json:"poster_path"`
+}
+
 // TMDBCastMember represents a credited cast member.
 type TMDBCastMember struct {
 	ID        int    `json:"id"`
@@ -158,19 +168,20 @@ type MovieDetails struct {
 
 // TVDetails is the detailed TV response payload.
 type TVDetails struct {
-	ID             int         `json:"id"`
-	Name           string      `json:"name"`
-	Overview       string      `json:"overview"`
-	PosterPath     string      `json:"poster_path"`
-	BackdropPath   string      `json:"backdrop_path"`
-	EpisodeRunTime []int       `json:"episode_run_time"`
-	Runtime        int         `json:"runtime"`
-	Genres         []TMDBGenre `json:"genres"`
-	FirstAirDate   string      `json:"first_air_date"`
-	Credits        TMDBCredits `json:"credits"`
-	Director       string      `json:"director"`
-	VoteAverage    float64     `json:"vote_average"`
-	Videos         TMDBVideos  `json:"videos"`
+	ID             int          `json:"id"`
+	Name           string       `json:"name"`
+	Overview       string       `json:"overview"`
+	PosterPath     string       `json:"poster_path"`
+	BackdropPath   string       `json:"backdrop_path"`
+	EpisodeRunTime []int        `json:"episode_run_time"`
+	Runtime        int          `json:"runtime"`
+	Genres         []TMDBGenre  `json:"genres"`
+	FirstAirDate   string       `json:"first_air_date"`
+	Seasons        []TMDBSeason `json:"seasons"`
+	Credits        TMDBCredits  `json:"credits"`
+	Director       string       `json:"director"`
+	VoteAverage    float64      `json:"vote_average"`
+	Videos         TMDBVideos   `json:"videos"`
 }
 
 // FindResult is the TMDB /find response scoped for IMDB lookups.

--- a/backend/internal/services/links/tmdb_test.go
+++ b/backend/internal/services/links/tmdb_test.go
@@ -153,6 +153,10 @@ func TestTMDBClientGetTVDetails(t *testing.T) {
 			"episode_run_time":[57],
 			"genres":[{"id":18,"name":"Drama"}],
 			"first_air_date":"2011-04-17",
+			"seasons":[
+				{"season_number":1,"episode_count":10,"air_date":"2011-04-17","name":"Season 1","overview":"Houses rise.","poster_path":"/season1.jpg"},
+				{"season_number":0,"episode_count":3,"air_date":"2010-12-05","name":"Specials","overview":"Bonus episodes.","poster_path":"/specials.jpg"}
+			],
 			"vote_average":8.5,
 			"credits":{
 				"cast":[{"id":239019,"name":"Emilia Clarke","character":"Daenerys Targaryen","order":1}],
@@ -176,6 +180,15 @@ func TestTMDBClientGetTVDetails(t *testing.T) {
 	}
 	if details.Runtime != 57 {
 		t.Fatalf("runtime = %d, want 57", details.Runtime)
+	}
+	if len(details.Seasons) != 2 {
+		t.Fatalf("seasons len = %d, want 2", len(details.Seasons))
+	}
+	if details.Seasons[0].SeasonNumber != 1 {
+		t.Fatalf("seasons[0].season_number = %d, want 1", details.Seasons[0].SeasonNumber)
+	}
+	if details.Seasons[1].SeasonNumber != 0 {
+		t.Fatalf("seasons[1].season_number = %d, want 0", details.Seasons[1].SeasonNumber)
 	}
 	if details.Director != "Miguel Sapochnik" {
 		t.Fatalf("director = %q, want Miguel Sapochnik", details.Director)


### PR DESCRIPTION
## Summary
- add `TMDBSeason` and wire `TVDetails.Seasons` so `/tv/{id}` season data is decoded from TMDB responses
- extend normalized movie metadata with `seasons` (`season_number`, `episode_count`, `air_date`, `name`, `overview`, `poster`)
- map and sort seasons by `season_number` in `movieDataFromTVDetails`, including season `0` specials
- keep backward compatibility by making `seasons` optional and validating TV payloads that omit the field
- add/extend TMDB and movie parser tests for season extraction, ordering, poster URL normalization, and no-seasons fallback

## Testing
- `go build ./...` (from `backend/`)
- `go test ./internal/services/links -run 'TestTMDBClientGetTVDetails|TestParseMovieMetadataTMDBTVURL|TestParseMovieMetadataTMDBTVURLWithoutSeasons' -v` (from `backend/`)
- `task backend:test`

Closes #847