### PR TITLE
[Movies] Add link to TMDB page in MovieCard

### DIFF
--- a/backend/internal/models/movie.go
+++ b/backend/internal/models/movie.go
@@ -24,18 +24,20 @@ type Season struct {
 
 // MovieData represents normalized movie metadata.
 type MovieData struct {
-	Title       string       `json:"title"`
-	Overview    string       `json:"overview"`
-	Poster      string       `json:"poster"`
-	Backdrop    string       `json:"backdrop"`
-	Runtime     int          `json:"runtime"`
-	Genres      []string     `json:"genres"`
-	ReleaseDate string       `json:"release_date"`
-	Cast        []CastMember `json:"cast"`
-	Seasons     []Season     `json:"seasons,omitempty"`
-	Director    string       `json:"director"`
-	TMDBRating  float64      `json:"tmdb_rating"`
-	TrailerKey  string       `json:"trailer_key"`
+	Title         string       `json:"title"`
+	Overview      string       `json:"overview"`
+	Poster        string       `json:"poster"`
+	Backdrop      string       `json:"backdrop"`
+	Runtime       int          `json:"runtime"`
+	Genres        []string     `json:"genres"`
+	ReleaseDate   string       `json:"release_date"`
+	Cast          []CastMember `json:"cast"`
+	Seasons       []Season     `json:"seasons,omitempty"`
+	Director      string       `json:"director"`
+	TMDBRating    float64      `json:"tmdb_rating"`
+	TrailerKey    string       `json:"trailer_key"`
+	TMDBID        int          `json:"tmdb_id,omitempty"`
+	TMDBMediaType string       `json:"tmdb_media_type,omitempty"`
 }
 
 type WatchlistItem struct {

--- a/backend/internal/services/links/movie_parser.go
+++ b/backend/internal/services/links/movie_parser.go
@@ -173,13 +173,13 @@ func parseTMDBMovieMetadata(ctx context.Context, client *TMDBClient, mediaType s
 		if err != nil {
 			return nil, fmt.Errorf("get tmdb movie details for id %d: %w", tmdbID, err)
 		}
-		return movieDataFromMovieDetails(details), nil
+		return movieDataFromMovieDetails(details, mediaType), nil
 	case "tv":
 		details, err := client.GetTVDetails(ctx, tmdbID)
 		if err != nil {
 			return nil, fmt.Errorf("get tmdb tv details for id %d: %w", tmdbID, err)
 		}
-		return movieDataFromTVDetails(details), nil
+		return movieDataFromTVDetails(details, mediaType), nil
 	default:
 		return nil, nil
 	}
@@ -213,44 +213,48 @@ func letterboxdSlugToTitle(slug string) string {
 	return strings.Join(strings.Fields(title), " ")
 }
 
-func movieDataFromMovieDetails(details *MovieDetails) *MovieData {
+func movieDataFromMovieDetails(details *MovieDetails, mediaType string) *MovieData {
 	if details == nil {
 		return nil
 	}
 
 	return &MovieData{
-		Title:       strings.TrimSpace(details.Title),
-		Overview:    strings.TrimSpace(details.Overview),
-		Poster:      tmdbImageURL(details.PosterPath, tmdbPosterSize),
-		Backdrop:    tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
-		Runtime:     details.Runtime,
-		Genres:      tmdbGenreNames(details.Genres),
-		ReleaseDate: strings.TrimSpace(details.ReleaseDate),
-		Cast:        tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
-		Director:    strings.TrimSpace(details.Director),
-		TMDBRating:  details.VoteAverage,
-		TrailerKey:  tmdbTrailerKey(details.Videos.Results),
+		Title:         strings.TrimSpace(details.Title),
+		Overview:      strings.TrimSpace(details.Overview),
+		Poster:        tmdbImageURL(details.PosterPath, tmdbPosterSize),
+		Backdrop:      tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
+		Runtime:       details.Runtime,
+		Genres:        tmdbGenreNames(details.Genres),
+		ReleaseDate:   strings.TrimSpace(details.ReleaseDate),
+		Cast:          tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
+		Director:      strings.TrimSpace(details.Director),
+		TMDBRating:    details.VoteAverage,
+		TrailerKey:    tmdbTrailerKey(details.Videos.Results),
+		TMDBID:        details.ID,
+		TMDBMediaType: strings.TrimSpace(mediaType),
 	}
 }
 
-func movieDataFromTVDetails(details *TVDetails) *MovieData {
+func movieDataFromTVDetails(details *TVDetails, mediaType string) *MovieData {
 	if details == nil {
 		return nil
 	}
 
 	return &MovieData{
-		Title:       strings.TrimSpace(details.Name),
-		Overview:    strings.TrimSpace(details.Overview),
-		Poster:      tmdbImageURL(details.PosterPath, tmdbPosterSize),
-		Backdrop:    tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
-		Runtime:     details.Runtime,
-		Genres:      tmdbGenreNames(details.Genres),
-		ReleaseDate: strings.TrimSpace(details.FirstAirDate),
-		Cast:        tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
-		Seasons:     tmdbSeasons(details.Seasons),
-		Director:    strings.TrimSpace(details.Director),
-		TMDBRating:  details.VoteAverage,
-		TrailerKey:  tmdbTrailerKey(details.Videos.Results),
+		Title:         strings.TrimSpace(details.Name),
+		Overview:      strings.TrimSpace(details.Overview),
+		Poster:        tmdbImageURL(details.PosterPath, tmdbPosterSize),
+		Backdrop:      tmdbImageURL(details.BackdropPath, tmdbBackdropSize),
+		Runtime:       details.Runtime,
+		Genres:        tmdbGenreNames(details.Genres),
+		ReleaseDate:   strings.TrimSpace(details.FirstAirDate),
+		Cast:          tmdbCastMembers(details.Credits.Cast, movieMetadataCastMaxSize),
+		Seasons:       tmdbSeasons(details.Seasons),
+		Director:      strings.TrimSpace(details.Director),
+		TMDBRating:    details.VoteAverage,
+		TrailerKey:    tmdbTrailerKey(details.Videos.Results),
+		TMDBID:        details.ID,
+		TMDBMediaType: strings.TrimSpace(mediaType),
 	}
 }
 

--- a/backend/internal/services/links/movie_parser_test.go
+++ b/backend/internal/services/links/movie_parser_test.go
@@ -77,6 +77,12 @@ func TestParseMovieMetadataIMDbURL(t *testing.T) {
 	if metadata.Director != "Lana Wachowski" {
 		t.Fatalf("Director = %q, want Lana Wachowski", metadata.Director)
 	}
+	if metadata.TMDBID != 603 {
+		t.Fatalf("TMDBID = %d, want 603", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "movie" {
+		t.Fatalf("TMDBMediaType = %q, want movie", metadata.TMDBMediaType)
+	}
 	if metadata.TrailerKey != "trailer-key" {
 		t.Fatalf("TrailerKey = %q, want trailer-key", metadata.TrailerKey)
 	}
@@ -126,6 +132,12 @@ func TestParseMovieMetadataTMDBMovieURL(t *testing.T) {
 	}
 	if metadata.Director != "David Fincher" {
 		t.Fatalf("Director = %q, want David Fincher", metadata.Director)
+	}
+	if metadata.TMDBID != 550 {
+		t.Fatalf("TMDBID = %d, want 550", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "movie" {
+		t.Fatalf("TMDBMediaType = %q, want movie", metadata.TMDBMediaType)
 	}
 }
 
@@ -188,6 +200,12 @@ func TestParseMovieMetadataTMDBTVURL(t *testing.T) {
 	if metadata.Seasons[2].SeasonNumber != 2 {
 		t.Fatalf("season[2] = %+v, want season_number=2", metadata.Seasons[2])
 	}
+	if metadata.TMDBID != 1399 {
+		t.Fatalf("TMDBID = %d, want 1399", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "tv" {
+		t.Fatalf("TMDBMediaType = %q, want tv", metadata.TMDBMediaType)
+	}
 }
 
 func TestParseMovieMetadataTMDBTVURLWithoutSeasons(t *testing.T) {
@@ -225,6 +243,12 @@ func TestParseMovieMetadataTMDBTVURLWithoutSeasons(t *testing.T) {
 	}
 	if len(metadata.Seasons) != 0 {
 		t.Fatalf("Seasons len = %d, want 0", len(metadata.Seasons))
+	}
+	if metadata.TMDBID != 3036 {
+		t.Fatalf("TMDBID = %d, want 3036", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "tv" {
+		t.Fatalf("TMDBMediaType = %q, want tv", metadata.TMDBMediaType)
 	}
 }
 
@@ -268,6 +292,12 @@ func TestParseMovieMetadataLetterboxdURL(t *testing.T) {
 	}
 	if metadata.Title != "The Matrix" {
 		t.Fatalf("Title = %q, want The Matrix", metadata.Title)
+	}
+	if metadata.TMDBID != 603 {
+		t.Fatalf("TMDBID = %d, want 603", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "movie" {
+		t.Fatalf("TMDBMediaType = %q, want movie", metadata.TMDBMediaType)
 	}
 }
 

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -69,6 +69,10 @@
     tmdb_rating?: number;
     trailerKey?: string;
     trailer_key?: string;
+    tmdbId?: number;
+    tmdb_id?: number;
+    tmdbMediaType?: string;
+    tmdb_media_type?: string;
   };
   type MovieCardMetadata = {
     title: string;
@@ -82,6 +86,8 @@
     director?: string;
     tmdbRating?: number;
     trailerKey?: string;
+    tmdbId?: number;
+    tmdbMediaType?: 'movie' | 'tv';
   };
   type LinkMetadataWithMovie = LinkMetadata & {
     movie?: MovieMetadata;
@@ -635,6 +641,22 @@
               character: typeof member.character === 'string' ? member.character : '',
             }))
         : undefined;
+    const normalizedTMDBID =
+      typeof movie.tmdbId === 'number'
+        ? movie.tmdbId
+        : typeof movie.tmdb_id === 'number'
+          ? movie.tmdb_id
+          : undefined;
+    const rawTMDBMediaType =
+      (typeof movie.tmdbMediaType === 'string' ? movie.tmdbMediaType : undefined) ??
+      (typeof movie.tmdb_media_type === 'string' ? movie.tmdb_media_type : undefined);
+    const normalizedTMDBMediaType =
+      rawTMDBMediaType?.trim().toLowerCase() === 'movie'
+        ? 'movie'
+        : rawTMDBMediaType?.trim().toLowerCase() === 'tv' ||
+            rawTMDBMediaType?.trim().toLowerCase() === 'series'
+          ? 'tv'
+          : undefined;
 
     return {
       title,
@@ -648,6 +670,8 @@
       ...(normalizedDirector ? { director: normalizedDirector } : {}),
       ...(typeof normalizedRating === 'number' ? { tmdbRating: normalizedRating } : {}),
       ...(normalizedTrailerKey ? { trailerKey: normalizedTrailerKey } : {}),
+      ...(typeof normalizedTMDBID === 'number' ? { tmdbId: normalizedTMDBID } : {}),
+      ...(normalizedTMDBMediaType ? { tmdbMediaType: normalizedTMDBMediaType } : {}),
     };
   }
 

--- a/frontend/src/components/__tests__/MovieCard.test.ts
+++ b/frontend/src/components/__tests__/MovieCard.test.ts
@@ -15,6 +15,8 @@ type MovieMetadata = {
   director?: string;
   tmdbRating?: number;
   trailerKey?: string;
+  tmdbId?: number;
+  tmdbMediaType?: 'movie' | 'tv';
 };
 
 const fullMovie: MovieMetadata = {
@@ -36,6 +38,8 @@ const fullMovie: MovieMetadata = {
   director: 'Christopher Nolan',
   tmdbRating: 8.6,
   trailerKey: 'zSWdZVtXT7E',
+  tmdbId: 157336,
+  tmdbMediaType: 'movie',
 };
 
 afterEach(() => {
@@ -53,7 +57,37 @@ describe('MovieCard', () => {
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('Drama');
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('Adventure');
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('+1');
+    expect(screen.getByTestId('movie-tmdb-link')).toHaveAttribute(
+      'href',
+      'https://www.themoviedb.org/movie/157336'
+    );
     expect(screen.queryByTestId('movie-expanded-content')).not.toBeInTheDocument();
+  });
+
+  it('renders a secure TMDB link for TV metadata', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        tmdbId: 1399,
+        tmdbMediaType: 'tv',
+      },
+    });
+
+    const tmdbLink = screen.getByTestId('movie-tmdb-link');
+    expect(tmdbLink).toHaveAttribute('href', 'https://www.themoviedb.org/tv/1399');
+    expect(tmdbLink).toHaveAttribute('target', '_blank');
+    expect(tmdbLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render TMDB link when tmdb id is missing', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        tmdbId: undefined,
+      },
+    });
+
+    expect(screen.queryByTestId('movie-tmdb-link')).not.toBeInTheDocument();
   });
 
   it('renders fallback content for minimal metadata', () => {

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -162,6 +162,8 @@ describe('mapApiPost', () => {
               director: 'Christopher Nolan',
               tmdb_rating: 8.6,
               trailer_key: 'zSWdZVtXT7E',
+              tmdb_id: '157336',
+              tmdb_media_type: 'movie',
               cast: [
                 { name: 'Matthew McConaughey', character: 'Cooper' },
                 { name: 'Anne Hathaway', character: 'Brand' },
@@ -183,6 +185,8 @@ describe('mapApiPost', () => {
     expect(movie?.director).toBe('Christopher Nolan');
     expect(movie?.tmdbRating).toBe(8.6);
     expect(movie?.trailerKey).toBe('zSWdZVtXT7E');
+    expect(movie?.tmdbId).toBe(157336);
+    expect(movie?.tmdbMediaType).toBe('movie');
     expect(movie?.cast).toEqual([
       { name: 'Matthew McConaughey', character: 'Cooper' },
       { name: 'Anne Hathaway', character: 'Brand' },

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -120,6 +120,17 @@ function normalizeStringArray(value: unknown): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeTMDBMediaType(value: unknown): 'movie' | 'tv' | undefined {
+  const normalized = normalizeString(value)?.toLowerCase();
+  if (normalized === 'movie') {
+    return 'movie';
+  }
+  if (normalized === 'tv' || normalized === 'series') {
+    return 'tv';
+  }
+  return undefined;
+}
+
 function normalizeRecipeMetadata(rawRecipe: unknown): RecipeMetadata | undefined {
   if (!rawRecipe) {
     return undefined;
@@ -259,6 +270,10 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
   const director = normalizeString(movie.director);
   const tmdbRating = normalizeNumber(movie.tmdb_rating ?? movie.tmdbRating);
   const trailerKey = normalizeString(movie.trailer_key ?? movie.trailerKey);
+  const tmdbId = normalizeNumber(movie.tmdb_id ?? movie.tmdbId);
+  const tmdbMediaType = normalizeTMDBMediaType(
+    movie.tmdb_media_type ?? movie.tmdbMediaType
+  );
 
   const cast = Array.isArray(movie.cast)
     ? movie.cast
@@ -294,6 +309,8 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
     !!director ||
     typeof tmdbRating === 'number' ||
     !!trailerKey ||
+    typeof tmdbId === 'number' ||
+    !!tmdbMediaType ||
     !!(cast && cast.length > 0);
 
   if (!hasMovieMetadata) {
@@ -312,6 +329,8 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
     ...(director ? { director } : {}),
     ...(typeof tmdbRating === 'number' ? { tmdbRating } : {}),
     ...(trailerKey ? { trailerKey } : {}),
+    ...(typeof tmdbId === 'number' ? { tmdbId } : {}),
+    ...(tmdbMediaType ? { tmdbMediaType } : {}),
   };
 }
 

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -77,6 +77,8 @@ export interface MovieMetadata {
   director?: string;
   tmdbRating?: number;
   trailerKey?: string;
+  tmdbId?: number;
+  tmdbMediaType?: 'movie' | 'tv';
 }
 
 export interface PostImage {


### PR DESCRIPTION
## Summary
- include `tmdb_id` and `tmdb_media_type` in backend movie metadata payloads for both movie and TV TMDB lookups
- carry TMDB ID/media type through frontend movie metadata normalization and `PostCard` mapping
- add a subtle `View on TMDB` link in `MovieCard` that renders only when metadata is complete and opens in a new tab with `rel="noopener noreferrer"`
- add coverage for TMDB metadata parsing and MovieCard TMDB link rendering/security behavior

## Tests
- `cd backend && go build ./... && go test ./internal/services/links -run 'TestParseMovieMetadata' -v`
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/MovieCard.test.ts src/stores/__tests__/postMapper.test.ts`
- `cd frontend && npm run test -- src/components/__tests__/PostCard.test.ts`

Closes #845