### PR TITLE
[Movies] Display season information in MovieCard for series posts

### DIFF
--- a/frontend/src/components/movies/MovieCard.svelte
+++ b/frontend/src/components/movies/MovieCard.svelte
@@ -8,6 +8,29 @@
     character: string;
   };
 
+  type SeasonMetadata = {
+    seasonNumber?: number;
+    season_number?: number;
+    episodeCount?: number;
+    episode_count?: number;
+    airDate?: string;
+    air_date?: string;
+    name?: string;
+    overview?: string;
+    poster?: string;
+    poster_url?: string;
+    posterUrl?: string;
+  };
+
+  type NormalizedSeason = {
+    seasonNumber: number;
+    episodeCount?: number;
+    airDate?: string;
+    name?: string;
+    overview?: string;
+    poster?: string;
+  };
+
   type MovieMetadata = {
     title: string;
     overview?: string;
@@ -24,6 +47,7 @@
     tmdb_id?: number;
     tmdbMediaType?: string;
     tmdb_media_type?: string;
+    seasons?: SeasonMetadata[];
   };
 
   export let movie: MovieMetadata = { title: '' };
@@ -38,6 +62,9 @@
   let trailerDialog: HTMLDivElement | null = null;
   let trailerCloseButton: HTMLButtonElement | null = null;
   let previousFocusedElement: HTMLElement | null = null;
+  let seasonListExpanded = true;
+  let seasonPosterLoadFailures: Record<number, boolean> = {};
+  let previousSeasonPosterState = '';
 
   $: posterUrl = movie.poster || movie.backdrop || null;
   $: if (posterUrl !== previousPosterUrl) {
@@ -51,7 +78,6 @@
     typeof movie.tmdbRating === 'number' && Number.isFinite(movie.tmdbRating)
       ? movie.tmdbRating.toFixed(1)
       : 'N/A';
-  $: metaLine = runtimeLabel ? `★ ${ratingLabel} · ${runtimeLabel}` : `★ ${ratingLabel}`;
   $: visibleGenres = (movie.genres ?? []).filter(Boolean).slice(0, 3);
   $: remainingGenres = Math.max((movie.genres?.length ?? 0) - visibleGenres.length, 0);
   $: directorLabel = movie.director?.trim() || 'Unknown';
@@ -60,6 +86,24 @@
   $: trailerEmbedUrl = buildTrailerUrl(movie.trailerKey);
   $: tmdbId = resolveTMDBID(movie.tmdbId ?? movie.tmdb_id);
   $: tmdbMediaType = normalizeTMDBMediaType(movie.tmdbMediaType ?? movie.tmdb_media_type);
+  $: seasons = normalizeSeasons(movie.seasons);
+  $: seasonCount = seasons.length;
+  $: isSeriesContent = tmdbMediaType === 'tv' || (tmdbMediaType !== 'movie' && seasonCount > 0);
+  $: seasonCountLabel = seasonCount > 0 ? formatSeasonCount(seasonCount) : null;
+  $: metaLineParts = [
+    `★ ${ratingLabel}`,
+    runtimeLabel,
+    isSeriesContent && seasonCountLabel ? seasonCountLabel : null,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+  $: metaLine = metaLineParts.join(' · ');
+  $: seasonPosterState = seasons
+    .map((season) => `${season.seasonNumber}:${season.poster ?? ''}`)
+    .join('|');
+  $: if (seasonPosterState !== previousSeasonPosterState) {
+    previousSeasonPosterState = seasonPosterState;
+    seasonPosterLoadFailures = {};
+    seasonListExpanded = true;
+  }
   $: tmdbUrl =
     typeof tmdbId === 'number' && tmdbMediaType
       ? `https://www.themoviedb.org/${tmdbMediaType}/${tmdbId}`
@@ -133,8 +177,111 @@
     return null;
   }
 
+  function normalizeSeasons(rawSeasons?: SeasonMetadata[]): NormalizedSeason[] {
+    if (!Array.isArray(rawSeasons)) {
+      return [];
+    }
+
+    return rawSeasons
+      .map((season): NormalizedSeason | null => {
+        if (!season || typeof season !== 'object') {
+          return null;
+        }
+
+        const seasonNumberRaw =
+          typeof season.seasonNumber === 'number'
+            ? season.seasonNumber
+            : typeof season.season_number === 'number'
+              ? season.season_number
+              : null;
+        if (seasonNumberRaw === null || !Number.isFinite(seasonNumberRaw)) {
+          return null;
+        }
+
+        const episodeCountRaw =
+          typeof season.episodeCount === 'number'
+            ? season.episodeCount
+            : typeof season.episode_count === 'number'
+              ? season.episode_count
+              : undefined;
+        const airDateRaw =
+          typeof season.airDate === 'string'
+            ? season.airDate
+            : typeof season.air_date === 'string'
+              ? season.air_date
+              : undefined;
+        const posterRaw =
+          typeof season.poster === 'string'
+            ? season.poster
+            : typeof season.poster_url === 'string'
+              ? season.poster_url
+              : typeof season.posterUrl === 'string'
+                ? season.posterUrl
+                : undefined;
+        const nameRaw = typeof season.name === 'string' ? season.name.trim() : '';
+        const overviewRaw = typeof season.overview === 'string' ? season.overview.trim() : '';
+        const airDate = airDateRaw?.trim();
+        const poster = posterRaw?.trim();
+
+        return {
+          seasonNumber: Math.trunc(seasonNumberRaw),
+          ...(typeof episodeCountRaw === 'number' && Number.isFinite(episodeCountRaw)
+            ? { episodeCount: Math.trunc(episodeCountRaw) }
+            : {}),
+          ...(airDate ? { airDate } : {}),
+          ...(nameRaw ? { name: nameRaw } : {}),
+          ...(overviewRaw ? { overview: overviewRaw } : {}),
+          ...(poster ? { poster } : {}),
+        };
+      })
+      .filter((season): season is NormalizedSeason => season !== null)
+      .sort((a, b) => a.seasonNumber - b.seasonNumber);
+  }
+
+  function formatSeasonCount(count: number): string {
+    return count === 1 ? '1 Season' : `${count} Seasons`;
+  }
+
+  function formatSeasonName(season: NormalizedSeason): string {
+    if (season.name) {
+      return season.name;
+    }
+    if (season.seasonNumber === 0) {
+      return 'Specials';
+    }
+    return `Season ${season.seasonNumber}`;
+  }
+
+  function formatSeasonYear(airDate?: string): string | null {
+    return formatReleaseYear(airDate);
+  }
+
+  function formatEpisodeCount(episodeCount?: number): string | null {
+    if (typeof episodeCount !== 'number' || !Number.isFinite(episodeCount) || episodeCount <= 0) {
+      return null;
+    }
+    return episodeCount === 1 ? '1 episode' : `${episodeCount} episodes`;
+  }
+
+  function formatSeasonDetails(season: NormalizedSeason): string {
+    const details: string[] = [];
+    const episodeCount = formatEpisodeCount(season.episodeCount);
+    const year = formatSeasonYear(season.airDate);
+    if (episodeCount) {
+      details.push(episodeCount);
+    }
+    if (year) {
+      details.push(year);
+    }
+    return details.length > 0 ? details.join(' · ') : 'Season details unavailable';
+  }
+
   function toggleExpanded() {
     expanded = !expanded;
+  }
+
+  function toggleSeasonList() {
+    seasonListExpanded = !seasonListExpanded;
   }
 
   function openTrailerModal() {
@@ -222,6 +369,13 @@
 
   function handlePosterError() {
     posterLoadFailed = true;
+  }
+
+  function handleSeasonPosterError(seasonNumber: number) {
+    seasonPosterLoadFailures = {
+      ...seasonPosterLoadFailures,
+      [seasonNumber]: true,
+    };
   }
 
   onDestroy(() => {
@@ -341,6 +495,84 @@
                 {/each}
               </ul>
             </div>
+          {/if}
+
+          {#if isSeriesContent && seasonCount > 0}
+            <section data-testid="movie-seasons-section">
+              <div class="flex items-center justify-between gap-2">
+                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Seasons
+                </p>
+                <button
+                  type="button"
+                  class="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:border-slate-300 hover:bg-slate-100"
+                  on:click={toggleSeasonList}
+                  data-testid="movie-seasons-toggle"
+                >
+                  {#if seasonListExpanded}
+                    Hide seasons
+                  {:else}
+                    Show {seasonCountLabel}
+                  {/if}
+                </button>
+              </div>
+
+              {#if seasonListExpanded}
+                <ul
+                  class="mt-3 max-h-72 space-y-2 overflow-y-auto pr-1"
+                  data-testid="movie-seasons-list"
+                >
+                  {#each seasons as season (season.seasonNumber)}
+                    <li
+                      class="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:flex-row sm:items-center"
+                      data-testid={`movie-season-${season.seasonNumber}`}
+                    >
+                      <div class="h-24 w-full shrink-0 overflow-hidden rounded-md bg-slate-200 sm:w-16">
+                        {#if season.poster && !seasonPosterLoadFailures[season.seasonNumber]}
+                          <img
+                            src={season.poster}
+                            alt={`${formatSeasonName(season)} poster`}
+                            class="h-full w-full object-cover"
+                            loading="lazy"
+                            on:error={() => handleSeasonPosterError(season.seasonNumber)}
+                            data-testid={`movie-season-poster-${season.seasonNumber}`}
+                          />
+                        {:else}
+                          <div
+                            class="flex h-full w-full items-center justify-center px-2 text-center text-[11px] font-medium text-slate-600"
+                            data-testid={`movie-season-poster-fallback-${season.seasonNumber}`}
+                          >
+                            No poster
+                          </div>
+                        {/if}
+                      </div>
+                      <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                          <span
+                            class="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold uppercase text-slate-700"
+                            data-testid={`movie-season-number-${season.seasonNumber}`}
+                          >
+                            S{season.seasonNumber}
+                          </span>
+                          <p
+                            class="truncate text-sm font-semibold text-slate-900"
+                            data-testid={`movie-season-name-${season.seasonNumber}`}
+                          >
+                            {formatSeasonName(season)}
+                          </p>
+                        </div>
+                        <p
+                          class="mt-1 text-xs text-slate-600"
+                          data-testid={`movie-season-details-${season.seasonNumber}`}
+                        >
+                          {formatSeasonDetails(season)}
+                        </p>
+                      </div>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </section>
           {/if}
 
           {#if trailerEmbedUrl}

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -164,6 +164,22 @@ describe('mapApiPost', () => {
               trailer_key: 'zSWdZVtXT7E',
               tmdb_id: '157336',
               tmdb_media_type: 'movie',
+              seasons: [
+                {
+                  season_number: 0,
+                  episode_count: 2,
+                  air_date: '2014-01-01',
+                  name: 'Specials',
+                  poster_url: 'https://example.com/specials.jpg',
+                },
+                {
+                  season_number: 1,
+                  episode_count: '10',
+                  air_date: '2015-01-01',
+                  name: 'Season 1',
+                  poster: 'https://example.com/season-1.jpg',
+                },
+              ],
               cast: [
                 { name: 'Matthew McConaughey', character: 'Cooper' },
                 { name: 'Anne Hathaway', character: 'Brand' },
@@ -187,6 +203,22 @@ describe('mapApiPost', () => {
     expect(movie?.trailerKey).toBe('zSWdZVtXT7E');
     expect(movie?.tmdbId).toBe(157336);
     expect(movie?.tmdbMediaType).toBe('movie');
+    expect(movie?.seasons).toEqual([
+      {
+        seasonNumber: 0,
+        episodeCount: 2,
+        airDate: '2014-01-01',
+        name: 'Specials',
+        poster: 'https://example.com/specials.jpg',
+      },
+      {
+        seasonNumber: 1,
+        episodeCount: 10,
+        airDate: '2015-01-01',
+        name: 'Season 1',
+        poster: 'https://example.com/season-1.jpg',
+      },
+    ]);
     expect(movie?.cast).toEqual([
       { name: 'Matthew McConaughey', character: 'Cooper' },
       { name: 'Anne Hathaway', character: 'Brand' },

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -65,6 +65,15 @@ export interface MovieCastMember {
   character?: string;
 }
 
+export interface MovieSeason {
+  seasonNumber: number;
+  episodeCount?: number;
+  airDate?: string;
+  name?: string;
+  overview?: string;
+  poster?: string;
+}
+
 export interface MovieMetadata {
   title?: string;
   overview?: string;
@@ -79,6 +88,7 @@ export interface MovieMetadata {
   trailerKey?: string;
   tmdbId?: number;
   tmdbMediaType?: 'movie' | 'tv';
+  seasons?: MovieSeason[];
 }
 
 export interface PostImage {


### PR DESCRIPTION
## Summary
- add season-aware rendering to `MovieCard` for series metadata, including collapsed `N Seasons` summary
- add an expanded/collapsible, scrollable season list with season number/name, episode count, air year, and lazy-loaded poster thumbnails with fallback
- preserve and normalize `movie.seasons` through frontend metadata mapping (`postStore`, `postMapper`, and `PostCard`) so season data reaches `MovieCard`
- add tests for season rendering and season normalization/fallback behavior

## Validation
- `npm run test -- src/components/__tests__/MovieCard.test.ts src/stores/__tests__/postMapper.test.ts`
- `npm run check`
- `task frontend:test`
- `npm run lint`

Closes #848