### PR TITLE
[Movies] Add Rotten Tomatoes score via OMDb API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ CLUBHOUSE_UPLOAD_MAX_BYTES=10485760
 # Movies metadata (TMDB)
 # Set a TMDB v3 API key to enable enriched metadata for IMDB/TMDB/Letterboxd links.
 TMDB_API_KEY=
+# Set an OMDb API key to enrich movie/series metadata with Rotten Tomatoes and Metacritic scores.
+OMDB_API_KEY=
 
 # Proxy (optional, comma-separated IPs/CIDRs)
 TRUSTED_PROXY_IPS=

--- a/.env.production.example
+++ b/.env.production.example
@@ -45,6 +45,8 @@ CLUBHOUSE_TOTP_ENCRYPTION_KEY=__REPLACE_WITH_BASE64_KEY__
 
 # Movies metadata (TMDB)
 TMDB_API_KEY=
+# Movies metadata (OMDb - optional RT/Metacritic enrichment)
+OMDB_API_KEY=
 
 # Proxy (optional, comma-separated IPs/CIDRs)
 TRUSTED_PROXY_IPS=

--- a/backend/internal/models/movie.go
+++ b/backend/internal/models/movie.go
@@ -24,20 +24,22 @@ type Season struct {
 
 // MovieData represents normalized movie metadata.
 type MovieData struct {
-	Title         string       `json:"title"`
-	Overview      string       `json:"overview"`
-	Poster        string       `json:"poster"`
-	Backdrop      string       `json:"backdrop"`
-	Runtime       int          `json:"runtime"`
-	Genres        []string     `json:"genres"`
-	ReleaseDate   string       `json:"release_date"`
-	Cast          []CastMember `json:"cast"`
-	Seasons       []Season     `json:"seasons,omitempty"`
-	Director      string       `json:"director"`
-	TMDBRating    float64      `json:"tmdb_rating"`
-	TrailerKey    string       `json:"trailer_key"`
-	TMDBID        int          `json:"tmdb_id,omitempty"`
-	TMDBMediaType string       `json:"tmdb_media_type,omitempty"`
+	Title               string       `json:"title"`
+	Overview            string       `json:"overview"`
+	Poster              string       `json:"poster"`
+	Backdrop            string       `json:"backdrop"`
+	Runtime             int          `json:"runtime"`
+	Genres              []string     `json:"genres"`
+	ReleaseDate         string       `json:"release_date"`
+	Cast                []CastMember `json:"cast"`
+	Seasons             []Season     `json:"seasons,omitempty"`
+	Director            string       `json:"director"`
+	TMDBRating          float64      `json:"tmdb_rating"`
+	RottenTomatoesScore *int         `json:"rotten_tomatoes_score,omitempty"`
+	MetacriticScore     *int         `json:"metacritic_score,omitempty"`
+	TrailerKey          string       `json:"trailer_key"`
+	TMDBID              int          `json:"tmdb_id,omitempty"`
+	TMDBMediaType       string       `json:"tmdb_media_type,omitempty"`
 }
 
 type WatchlistItem struct {

--- a/backend/internal/services/links/metadata.go
+++ b/backend/internal/services/links/metadata.go
@@ -32,6 +32,7 @@ const metadataSectionTypeContextKey metadataContextKey = "link_metadata_section_
 
 var (
 	newTMDBClientFromEnvFunc = NewTMDBClientFromEnv
+	newOMDBClientFromEnvFunc = NewOMDBClientFromEnv
 	parseMovieMetadataFunc   = ParseMovieMetadata
 )
 
@@ -201,7 +202,12 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (map[string]interfac
 	}
 	if shouldExtractMovieMetadata(ctx) {
 		if tmdbClient, err := newTMDBClientFromEnvFunc(); err == nil {
-			if movie, movieErr := parseMovieMetadataFunc(ctx, rawURL, tmdbClient); movieErr == nil && movie != nil {
+			var omdbClient *OMDBClient
+			if omdb, omdbErr := newOMDBClientFromEnvFunc(); omdbErr == nil {
+				omdbClient = omdb
+			}
+
+			if movie, movieErr := parseMovieMetadataFunc(ctx, rawURL, tmdbClient, omdbClient); movieErr == nil && movie != nil {
 				metadata["movie"] = movie
 			}
 		}

--- a/backend/internal/services/links/omdb.go
+++ b/backend/internal/services/links/omdb.go
@@ -1,0 +1,331 @@
+package links
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sanderginn/clubhouse/internal/observability"
+)
+
+const (
+	omdbAPIKeyEnv            = "OMDB_API_KEY"
+	omdbDefaultBaseURL       = "https://www.omdbapi.com"
+	omdbUserAgent            = "ClubhouseOMDBClient/1.0"
+	omdbRequestTimeout       = 10 * time.Second
+	omdbDefaultDailyLimit    = 1000
+	omdbDefaultDailyWindow   = 24 * time.Hour
+	omdbErrorBodyMaxBytes    = 4096
+	omdbRatingSourceRT       = "rotten tomatoes"
+	omdbRatingSourceMetaCrit = "metacritic"
+)
+
+var (
+	ErrOMDBAPIKeyMissing = errors.New("omdb api key is required")
+	ErrOMDBRateLimited   = errors.New("omdb rate limited")
+	ErrOMDBNotFound      = errors.New("omdb resource not found")
+)
+
+// OMDBClient provides methods for interacting with the OMDb API.
+type OMDBClient struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+	limiter    *omdbRateLimiter
+}
+
+// OMDBRatings contains normalized ratings from OMDb.
+type OMDBRatings struct {
+	RottenTomatoesScore *int
+	MetacriticScore     *int
+}
+
+type omdbRating struct {
+	Source string `json:"Source"`
+	Value  string `json:"Value"`
+}
+
+type omdbTitleResponse struct {
+	Response  string       `json:"Response"`
+	Error     string       `json:"Error"`
+	Ratings   []omdbRating `json:"Ratings"`
+	Metascore string       `json:"Metascore"`
+}
+
+// OMDBAPIError captures non-success responses from OMDb.
+type OMDBAPIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *OMDBAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("omdb api error (%d): %s", e.StatusCode, e.Message)
+}
+
+func (e *OMDBAPIError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	if e.StatusCode == http.StatusTooManyRequests || strings.Contains(strings.ToLower(e.Message), "request limit reached") {
+		return ErrOMDBRateLimited
+	}
+
+	message := strings.ToLower(e.Message)
+	if strings.Contains(message, "movie not found") ||
+		strings.Contains(message, "series not found") ||
+		strings.Contains(message, "incorrect imdb id") {
+		return ErrOMDBNotFound
+	}
+
+	return nil
+}
+
+// NewOMDBClientFromEnv creates an OMDb client using OMDB_API_KEY.
+func NewOMDBClientFromEnv() (*OMDBClient, error) {
+	apiKey := strings.TrimSpace(os.Getenv(omdbAPIKeyEnv))
+	return NewOMDBClient(apiKey, nil)
+}
+
+// NewOMDBClient creates an OMDb client with an optional custom HTTP client.
+func NewOMDBClient(apiKey string, httpClient *http.Client) (*OMDBClient, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, ErrOMDBAPIKeyMissing
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: omdbRequestTimeout}
+	}
+
+	return &OMDBClient{
+		apiKey:     apiKey,
+		baseURL:    omdbDefaultBaseURL,
+		httpClient: httpClient,
+		limiter:    newOMDBRateLimiter(omdbDefaultDailyLimit, omdbDefaultDailyWindow),
+	}, nil
+}
+
+// GetRatingsByIMDBID fetches Rotten Tomatoes and Metacritic scores for an IMDB ID.
+func (c *OMDBClient) GetRatingsByIMDBID(ctx context.Context, imdbID string) (*OMDBRatings, error) {
+	if ctx == nil {
+		return nil, errors.New("context is required")
+	}
+	if c == nil {
+		return nil, errors.New("omdb client is required")
+	}
+
+	imdbID = strings.ToLower(strings.TrimSpace(imdbID))
+	if !imdbIDPattern.MatchString(imdbID) {
+		return nil, errors.New("valid imdb id is required")
+	}
+
+	if c.limiter != nil && !c.limiter.Allow() {
+		observability.LogWarn(ctx, "omdb daily quota reached", "imdb_id", imdbID)
+		return nil, ErrOMDBRateLimited
+	}
+
+	values := url.Values{}
+	values.Set("apikey", c.apiKey)
+	values.Set("i", imdbID)
+
+	requestURL := strings.TrimSuffix(c.baseURL, "/")
+	requestURL = requestURL + "/?" + values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build omdb request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", omdbUserAgent)
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		observability.LogWarn(ctx, "omdb request failed", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return nil, fmt.Errorf("omdb request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		apiErr := parseOMDBAPIError(resp)
+		observability.LogWarn(ctx, "omdb request failed", "status_code", strconv.Itoa(resp.StatusCode), "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", apiErr.Error())
+		return nil, apiErr
+	}
+
+	var payload omdbTitleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		observability.LogWarn(ctx, "omdb response decode failed", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "error", err.Error())
+		return nil, fmt.Errorf("decode omdb response: %w", err)
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(payload.Response), "true") {
+		message := strings.TrimSpace(payload.Error)
+		if message == "" {
+			message = "unknown omdb error"
+		}
+		return nil, &OMDBAPIError{StatusCode: http.StatusBadGateway, Message: message}
+	}
+
+	ratings := extractOMDBRatings(payload)
+	if ratings.RottenTomatoesScore == nil && ratings.MetacriticScore == nil {
+		return nil, nil
+	}
+
+	observability.LogDebug(ctx, "omdb request completed", "duration_ms", strconv.FormatInt(duration.Milliseconds(), 10), "status_code", strconv.Itoa(resp.StatusCode))
+
+	return &ratings, nil
+}
+
+func extractOMDBRatings(payload omdbTitleResponse) OMDBRatings {
+	var ratings OMDBRatings
+
+	for _, entry := range payload.Ratings {
+		source := strings.ToLower(strings.TrimSpace(entry.Source))
+		switch source {
+		case omdbRatingSourceRT:
+			if score, ok := parseOMDBPercent(entry.Value); ok {
+				ratings.RottenTomatoesScore = intPtr(score)
+			}
+		case omdbRatingSourceMetaCrit:
+			if score, ok := parseOMDBScoreOutOf100(entry.Value); ok {
+				ratings.MetacriticScore = intPtr(score)
+			}
+		}
+	}
+
+	if ratings.MetacriticScore == nil {
+		if score, ok := parseOMDBInteger(payload.Metascore); ok {
+			ratings.MetacriticScore = intPtr(score)
+		}
+	}
+
+	return ratings
+}
+
+func parseOMDBAPIError(resp *http.Response) error {
+	message := strings.TrimSpace(resp.Status)
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, omdbErrorBodyMaxBytes))
+	if err == nil && len(body) > 0 {
+		var payload omdbTitleResponse
+		if decodeErr := json.Unmarshal(body, &payload); decodeErr == nil {
+			if strings.TrimSpace(payload.Error) != "" {
+				message = strings.TrimSpace(payload.Error)
+			}
+		}
+	}
+
+	if message == "" {
+		message = http.StatusText(resp.StatusCode)
+	}
+
+	return &OMDBAPIError{
+		StatusCode: resp.StatusCode,
+		Message:    message,
+	}
+}
+
+func parseOMDBPercent(raw string) (int, bool) {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimSuffix(value, "%")
+	score, err := strconv.Atoi(value)
+	if err != nil || score < 0 || score > 100 {
+		return 0, false
+	}
+	return score, true
+}
+
+func parseOMDBScoreOutOf100(raw string) (int, bool) {
+	value := strings.TrimSpace(raw)
+	parts := strings.SplitN(value, "/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) != "100" {
+		return 0, false
+	}
+
+	score, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || score < 0 || score > 100 {
+		return 0, false
+	}
+	return score, true
+}
+
+func parseOMDBInteger(raw string) (int, bool) {
+	value := strings.TrimSpace(raw)
+	if value == "" || strings.EqualFold(value, "N/A") {
+		return 0, false
+	}
+	score, err := strconv.Atoi(value)
+	if err != nil || score < 0 || score > 100 {
+		return 0, false
+	}
+	return score, true
+}
+
+func intPtr(value int) *int {
+	v := value
+	return &v
+}
+
+type omdbRateLimiter struct {
+	limit      int
+	window     time.Duration
+	mu         sync.Mutex
+	requestLog []time.Time
+}
+
+func newOMDBRateLimiter(limit int, window time.Duration) *omdbRateLimiter {
+	return &omdbRateLimiter{limit: limit, window: window}
+}
+
+func (r *omdbRateLimiter) Allow() bool {
+	if r == nil || r.limit <= 0 || r.window <= 0 {
+		return true
+	}
+
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.prune(now)
+	if len(r.requestLog) >= r.limit {
+		return false
+	}
+
+	r.requestLog = append(r.requestLog, now)
+	return true
+}
+
+func (r *omdbRateLimiter) prune(now time.Time) {
+	if len(r.requestLog) == 0 {
+		return
+	}
+
+	cutoff := now.Add(-r.window)
+	firstKept := 0
+	for ; firstKept < len(r.requestLog); firstKept++ {
+		if r.requestLog[firstKept].After(cutoff) {
+			break
+		}
+	}
+
+	if firstKept == 0 {
+		return
+	}
+
+	copy(r.requestLog, r.requestLog[firstKept:])
+	r.requestLog = r.requestLog[:len(r.requestLog)-firstKept]
+}

--- a/backend/internal/services/links/omdb_test.go
+++ b/backend/internal/services/links/omdb_test.go
@@ -1,0 +1,233 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewOMDBClientFromEnv(t *testing.T) {
+	t.Setenv(omdbAPIKeyEnv, "test-omdb-key")
+
+	client, err := NewOMDBClientFromEnv()
+	if err != nil {
+		t.Fatalf("NewOMDBClientFromEnv error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+	if client.apiKey != "test-omdb-key" {
+		t.Fatalf("api key = %q, want test-omdb-key", client.apiKey)
+	}
+}
+
+func TestNewOMDBClientFromEnvMissingAPIKey(t *testing.T) {
+	t.Setenv(omdbAPIKeyEnv, "")
+
+	_, err := NewOMDBClientFromEnv()
+	if !errors.Is(err, ErrOMDBAPIKeyMissing) {
+		t.Fatalf("expected ErrOMDBAPIKeyMissing, got %v", err)
+	}
+}
+
+func TestOMDBClientGetRatingsByIMDBID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Fatalf("path = %q, want /", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("apikey"); got != "test-omdb-key" {
+			t.Fatalf("apikey = %q, want test-omdb-key", got)
+		}
+		if got := r.URL.Query().Get("i"); got != "tt0133093" {
+			t.Fatalf("imdb id = %q, want tt0133093", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != omdbUserAgent {
+			t.Fatalf("user-agent = %q, want %q", got, omdbUserAgent)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Response":"True",
+			"Ratings":[
+				{"Source":"Internet Movie Database","Value":"8.7/10"},
+				{"Source":"Rotten Tomatoes","Value":"83%"},
+				{"Source":"Metacritic","Value":"73/100"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestOMDBClient(t, server.URL)
+
+	ratings, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093")
+	if err != nil {
+		t.Fatalf("GetRatingsByIMDBID error: %v", err)
+	}
+	if ratings == nil {
+		t.Fatal("expected ratings")
+	}
+	if ratings.RottenTomatoesScore == nil || *ratings.RottenTomatoesScore != 83 {
+		t.Fatalf("rotten tomatoes = %+v, want 83", ratings.RottenTomatoesScore)
+	}
+	if ratings.MetacriticScore == nil || *ratings.MetacriticScore != 73 {
+		t.Fatalf("metacritic = %+v, want 73", ratings.MetacriticScore)
+	}
+}
+
+func TestOMDBClientGetRatingsByIMDBIDUsesMetascoreFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Response":"True",
+			"Metascore":"64",
+			"Ratings":[
+				{"Source":"Rotten Tomatoes","Value":"91%"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestOMDBClient(t, server.URL)
+
+	ratings, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093")
+	if err != nil {
+		t.Fatalf("GetRatingsByIMDBID error: %v", err)
+	}
+	if ratings == nil {
+		t.Fatal("expected ratings")
+	}
+	if ratings.RottenTomatoesScore == nil || *ratings.RottenTomatoesScore != 91 {
+		t.Fatalf("rotten tomatoes = %+v, want 91", ratings.RottenTomatoesScore)
+	}
+	if ratings.MetacriticScore == nil || *ratings.MetacriticScore != 64 {
+		t.Fatalf("metacritic = %+v, want 64", ratings.MetacriticScore)
+	}
+}
+
+func TestOMDBClientGetRatingsByIMDBIDNoSupportedRatings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Response":"True",
+			"Metascore":"N/A",
+			"Ratings":[{"Source":"Internet Movie Database","Value":"8.8/10"}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestOMDBClient(t, server.URL)
+
+	ratings, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093")
+	if err != nil {
+		t.Fatalf("GetRatingsByIMDBID error: %v", err)
+	}
+	if ratings != nil {
+		t.Fatalf("expected nil ratings, got %+v", ratings)
+	}
+}
+
+func TestOMDBClientAPIErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		check      func(t *testing.T, err error)
+	}{
+		{
+			name:       "http rate limit",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"Error":"Request limit reached!"}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrOMDBRateLimited) {
+					t.Fatalf("expected ErrOMDBRateLimited, got %v", err)
+				}
+			},
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusOK,
+			body:       `{"Response":"False","Error":"Movie not found!"}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				if !errors.Is(err, ErrOMDBNotFound) {
+					t.Fatalf("expected ErrOMDBNotFound, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := newTestOMDBClient(t, server.URL)
+			_, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			tt.check(t, err)
+		})
+	}
+}
+
+func TestOMDBClientGetRatingsByIMDBIDRespectsDailyLimit(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Response":"True","Ratings":[{"Source":"Rotten Tomatoes","Value":"90%"}]}`))
+	}))
+	defer server.Close()
+
+	client := newTestOMDBClient(t, server.URL)
+	client.limiter = newOMDBRateLimiter(1, time.Hour)
+
+	if _, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093"); err != nil {
+		t.Fatalf("first request error: %v", err)
+	}
+
+	_, err := client.GetRatingsByIMDBID(context.Background(), "tt0133093")
+	if !errors.Is(err, ErrOMDBRateLimited) {
+		t.Fatalf("expected ErrOMDBRateLimited, got %v", err)
+	}
+
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}
+
+func TestOMDBClientGetRatingsByIMDBIDInvalidIMDBID(t *testing.T) {
+	client := newTestOMDBClient(t, "https://example.invalid")
+	_, err := client.GetRatingsByIMDBID(context.Background(), "tt-bad")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "valid imdb id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func newTestOMDBClient(t *testing.T, baseURL string) *OMDBClient {
+	t.Helper()
+
+	client, err := NewOMDBClient("test-omdb-key", &http.Client{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewOMDBClient error: %v", err)
+	}
+
+	client.baseURL = baseURL
+	client.limiter = newOMDBRateLimiter(1000, time.Second)
+
+	return client
+}

--- a/backend/internal/services/links/tmdb.go
+++ b/backend/internal/services/links/tmdb.go
@@ -150,38 +150,46 @@ type TMDBVideos struct {
 	Results []TMDBVideo `json:"results"`
 }
 
+// TMDBExternalIDs contains external IDs (such as IMDB ID).
+type TMDBExternalIDs struct {
+	IMDBID string `json:"imdb_id"`
+}
+
 // MovieDetails is the detailed movie response payload.
 type MovieDetails struct {
-	ID           int         `json:"id"`
-	Title        string      `json:"title"`
-	Overview     string      `json:"overview"`
-	PosterPath   string      `json:"poster_path"`
-	BackdropPath string      `json:"backdrop_path"`
-	Runtime      int         `json:"runtime"`
-	Genres       []TMDBGenre `json:"genres"`
-	ReleaseDate  string      `json:"release_date"`
-	Credits      TMDBCredits `json:"credits"`
-	Director     string      `json:"director"`
-	VoteAverage  float64     `json:"vote_average"`
-	Videos       TMDBVideos  `json:"videos"`
+	ID           int             `json:"id"`
+	Title        string          `json:"title"`
+	Overview     string          `json:"overview"`
+	PosterPath   string          `json:"poster_path"`
+	BackdropPath string          `json:"backdrop_path"`
+	Runtime      int             `json:"runtime"`
+	Genres       []TMDBGenre     `json:"genres"`
+	ReleaseDate  string          `json:"release_date"`
+	Credits      TMDBCredits     `json:"credits"`
+	Director     string          `json:"director"`
+	VoteAverage  float64         `json:"vote_average"`
+	Videos       TMDBVideos      `json:"videos"`
+	IMDBID       string          `json:"imdb_id"`
+	ExternalIDs  TMDBExternalIDs `json:"external_ids"`
 }
 
 // TVDetails is the detailed TV response payload.
 type TVDetails struct {
-	ID             int          `json:"id"`
-	Name           string       `json:"name"`
-	Overview       string       `json:"overview"`
-	PosterPath     string       `json:"poster_path"`
-	BackdropPath   string       `json:"backdrop_path"`
-	EpisodeRunTime []int        `json:"episode_run_time"`
-	Runtime        int          `json:"runtime"`
-	Genres         []TMDBGenre  `json:"genres"`
-	FirstAirDate   string       `json:"first_air_date"`
-	Seasons        []TMDBSeason `json:"seasons"`
-	Credits        TMDBCredits  `json:"credits"`
-	Director       string       `json:"director"`
-	VoteAverage    float64      `json:"vote_average"`
-	Videos         TMDBVideos   `json:"videos"`
+	ID             int             `json:"id"`
+	Name           string          `json:"name"`
+	Overview       string          `json:"overview"`
+	PosterPath     string          `json:"poster_path"`
+	BackdropPath   string          `json:"backdrop_path"`
+	EpisodeRunTime []int           `json:"episode_run_time"`
+	Runtime        int             `json:"runtime"`
+	Genres         []TMDBGenre     `json:"genres"`
+	FirstAirDate   string          `json:"first_air_date"`
+	Seasons        []TMDBSeason    `json:"seasons"`
+	Credits        TMDBCredits     `json:"credits"`
+	Director       string          `json:"director"`
+	VoteAverage    float64         `json:"vote_average"`
+	Videos         TMDBVideos      `json:"videos"`
+	ExternalIDs    TMDBExternalIDs `json:"external_ids"`
 }
 
 // FindResult is the TMDB /find response scoped for IMDB lookups.
@@ -264,7 +272,7 @@ func (c *TMDBClient) GetMovieDetails(ctx context.Context, tmdbID int) (*MovieDet
 	}
 
 	values := url.Values{}
-	values.Set("append_to_response", "credits,videos")
+	values.Set("append_to_response", "credits,videos,external_ids")
 
 	var details MovieDetails
 	if err := c.get(ctx, fmt.Sprintf("/movie/%d", tmdbID), values, &details); err != nil {
@@ -283,7 +291,7 @@ func (c *TMDBClient) GetTVDetails(ctx context.Context, tmdbID int) (*TVDetails, 
 	}
 
 	values := url.Values{}
-	values.Set("append_to_response", "credits,videos")
+	values.Set("append_to_response", "credits,videos,external_ids")
 
 	var details TVDetails
 	if err := c.get(ctx, fmt.Sprintf("/tv/%d", tmdbID), values, &details); err != nil {

--- a/backend/internal/services/links/tmdb_test.go
+++ b/backend/internal/services/links/tmdb_test.go
@@ -96,7 +96,7 @@ func TestTMDBClientGetMovieDetails(t *testing.T) {
 		if r.URL.Path != "/movie/550" {
 			t.Fatalf("path = %q, want /movie/550", r.URL.Path)
 		}
-		if r.URL.Query().Get("append_to_response") != "credits,videos" {
+		if r.URL.Query().Get("append_to_response") != "credits,videos,external_ids" {
 			t.Fatalf("append_to_response = %q", r.URL.Query().Get("append_to_response"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -110,6 +110,7 @@ func TestTMDBClientGetMovieDetails(t *testing.T) {
 			"genres":[{"id":18,"name":"Drama"}],
 			"release_date":"1999-10-15",
 			"vote_average":8.4,
+			"imdb_id":"tt0137523",
 			"credits":{
 				"cast":[{"id":287,"name":"Brad Pitt","character":"Tyler Durden","order":0}],
 				"crew":[{"id":7467,"name":"David Fincher","job":"Director","department":"Directing"}]
@@ -132,6 +133,9 @@ func TestTMDBClientGetMovieDetails(t *testing.T) {
 	}
 	if details.Director != "David Fincher" {
 		t.Fatalf("director = %q, want David Fincher", details.Director)
+	}
+	if details.IMDBID != "tt0137523" {
+		t.Fatalf("imdb_id = %q, want tt0137523", details.IMDBID)
 	}
 	if len(details.Videos.Results) != 1 || details.Videos.Results[0].Key != "SUXWAEX2jlg" {
 		t.Fatalf("unexpected videos payload: %+v", details.Videos.Results)
@@ -158,6 +162,7 @@ func TestTMDBClientGetTVDetails(t *testing.T) {
 				{"season_number":0,"episode_count":3,"air_date":"2010-12-05","name":"Specials","overview":"Bonus episodes.","poster_path":"/specials.jpg"}
 			],
 			"vote_average":8.5,
+			"external_ids":{"imdb_id":"tt0944947"},
 			"credits":{
 				"cast":[{"id":239019,"name":"Emilia Clarke","character":"Daenerys Targaryen","order":1}],
 				"crew":[{"id":9813,"name":"Miguel Sapochnik","job":"Director","department":"Directing"}]
@@ -192,6 +197,9 @@ func TestTMDBClientGetTVDetails(t *testing.T) {
 	}
 	if details.Director != "Miguel Sapochnik" {
 		t.Fatalf("director = %q, want Miguel Sapochnik", details.Director)
+	}
+	if details.ExternalIDs.IMDBID != "tt0944947" {
+		t.Fatalf("external imdb_id = %q, want tt0944947", details.ExternalIDs.IMDBID)
 	}
 }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,7 @@ services:
       CLUBHOUSE_UPLOAD_DIR: /data/uploads
       CLUBHOUSE_UPLOAD_MAX_BYTES: ${CLUBHOUSE_UPLOAD_MAX_BYTES:-10485760}
       TMDB_API_KEY: ${TMDB_API_KEY:-}
+      OMDB_API_KEY: ${OMDB_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
       CLUBHOUSE_UPLOAD_DIR: /data/uploads
       CLUBHOUSE_UPLOAD_MAX_BYTES: ${CLUBHOUSE_UPLOAD_MAX_BYTES:-10485760}
       TMDB_API_KEY: ${TMDB_API_KEY:-}
+      OMDB_API_KEY: ${OMDB_API_KEY:-}
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- add a new OMDb client (`OMDB_API_KEY`) with normalized rating extraction for Rotten Tomatoes (`%`) and Metacritic (`/100` or `Metascore` fallback)
- enrich movie/series metadata after TMDB resolution by looking up OMDb via IMDB ID and storing `rotten_tomatoes_score` / `metacritic_score` in `MovieData`
- keep OMDb enrichment fail-safe: missing OMDb key, no OMDb data, API errors, or rate limits do not block metadata parsing or post creation
- update TMDB detail fetches to include `external_ids` so TV metadata can resolve IMDB IDs for OMDb lookups
- add backend config wiring for `OMDB_API_KEY` in compose/env templates

## Tests
- `go build ./...` (backend)
- `go test ./internal/services/links -v`
- `task backend:test`

Closes #849