### PR TITLE
[Movies] Fix movie stats not updating after save/rate actions until reload

### DIFF
--- a/frontend/src/components/movies/WatchButton.svelte
+++ b/frontend/src/components/movies/WatchButton.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, tick } from 'svelte';
   import { get } from 'svelte/store';
   import { movieStore, type WatchLog } from '../../stores/movieStore';
+  import { postStore } from '../../stores/postStore';
   import RatingStars from '../recipes/RatingStars.svelte';
 
   export let postId: string;
@@ -124,9 +125,12 @@
     formError = '';
 
     const previous = activeWatchLog;
+    const previousWatched = Boolean(previous);
+    const previousRating = previous?.rating ?? null;
     const notes = notesValue.trim();
 
     optimisticWatchLog = buildOptimisticLog();
+    postStore.setMovieWatchState(postId, true, ratingValue);
     movieStore.setError(null);
 
     try {
@@ -139,6 +143,7 @@
       const { error } = get(movieStore);
       if (error) {
         optimisticWatchLog = previous ?? null;
+        postStore.setMovieWatchState(postId, previousWatched, previousRating);
         formError = error;
         showToast(error);
       } else {
@@ -160,7 +165,9 @@
     formError = '';
 
     const previous = activeWatchLog;
+    const previousRating = previous.rating ?? null;
     optimisticWatchLog = null;
+    postStore.setMovieWatchState(postId, false, null);
     movieStore.setError(null);
 
     try {
@@ -169,6 +176,7 @@
       const { error } = get(movieStore);
       if (error) {
         optimisticWatchLog = previous;
+        postStore.setMovieWatchState(postId, true, previousRating);
         formError = error;
         showToast(error);
       } else {

--- a/frontend/src/components/movies/WatchlistSaveButton.svelte
+++ b/frontend/src/components/movies/WatchlistSaveButton.svelte
@@ -13,6 +13,7 @@
     type WatchlistCategory as StoreWatchlistCategory,
     type WatchlistItem as StoreWatchlistItem,
   } from '../../stores/movieStore';
+  import { postStore } from '../../stores/postStore';
   import { currentUser } from '../../stores/authStore';
 
   export let postId: string;
@@ -249,6 +250,7 @@
       localSaveCount = Math.max(0, localSaveCount - 1);
     }
 
+    postStore.setMovieWatchlistState(postId, willBeSaved, setToArray(next));
     updateFallbackState(next);
   }
 
@@ -272,6 +274,7 @@
       localSaveCount = Math.max(0, localSaveCount + 1);
     }
 
+    postStore.setMovieWatchlistState(postId, previous.size > 0, setToArray(previous));
     updateFallbackState(previous);
   }
 

--- a/frontend/src/stores/__tests__/movieStore.test.ts
+++ b/frontend/src/stores/__tests__/movieStore.test.ts
@@ -12,6 +12,8 @@ const apiGetMyWatchLogs = vi.hoisted(() => vi.fn());
 const apiLogWatch = vi.hoisted(() => vi.fn());
 const apiUpdateWatchLog = vi.hoisted(() => vi.fn());
 const apiRemoveWatchLog = vi.hoisted(() => vi.fn());
+const apiGetPostWatchlistInfo = vi.hoisted(() => vi.fn());
+const apiGetPostWatchLogs = vi.hoisted(() => vi.fn());
 
 vi.mock('../../services/api', () => ({
   api: {
@@ -26,6 +28,8 @@ vi.mock('../../services/api', () => ({
     logWatch: apiLogWatch,
     updateWatchLog: apiUpdateWatchLog,
     removeWatchLog: apiRemoveWatchLog,
+    getPostWatchlistInfo: apiGetPostWatchlistInfo,
+    getPostWatchLogs: apiGetPostWatchLogs,
   },
 }));
 
@@ -39,6 +43,7 @@ const {
   handleMovieWatchRemovedEvent,
 } = await import('../movieStore');
 const { authStore } = await import('../authStore');
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 beforeEach(() => {
   movieStore.reset();
@@ -60,6 +65,21 @@ beforeEach(() => {
   apiLogWatch.mockReset();
   apiUpdateWatchLog.mockReset();
   apiRemoveWatchLog.mockReset();
+  apiGetPostWatchlistInfo.mockReset();
+  apiGetPostWatchLogs.mockReset();
+  apiGetPostWatchlistInfo.mockResolvedValue({
+    saveCount: 1,
+    users: [],
+    viewerSaved: false,
+    viewerCategories: [],
+  });
+  apiGetPostWatchLogs.mockResolvedValue({
+    watchCount: 1,
+    avgRating: 4.2,
+    logs: [],
+    viewerWatched: false,
+    viewerRating: undefined,
+  });
 });
 
 describe('movieStore', () => {
@@ -220,7 +240,7 @@ describe('movieStore', () => {
     expect(sorted[0].name).toBe('Alpha');
   });
 
-  it('websocket handlers apply movie events to local state', () => {
+  it('websocket handlers apply movie events to local state', async () => {
     handleMovieWatchlistedEvent({
       user_id: 'user-1',
       watchlist_item: {
@@ -249,12 +269,16 @@ describe('movieStore', () => {
     handleMovieUnwatchlistedEvent({ post_id: 'post-ws', user_id: 'user-1', category: 'Favorites' });
     handleMovieWatchRemovedEvent({ post_id: 'post-ws', user_id: 'user-1' });
 
+    await flushPromises();
+
     state = get(movieStore);
     expect(state.watchlist.get('Favorites')).toBeUndefined();
     expect(state.watchLogs).toHaveLength(0);
+    expect(apiGetPostWatchlistInfo).toHaveBeenCalledWith('post-ws');
+    expect(apiGetPostWatchLogs).toHaveBeenCalledWith('post-ws');
   });
 
-  it('websocket handlers ignore events from other users and sparse self payloads', () => {
+  it('websocket handlers ignore payload writes for other users but handle sparse self payloads', async () => {
     movieStore.applyWatchlistItems([
       {
         id: 'watch-own',
@@ -313,11 +337,19 @@ describe('movieStore', () => {
       rating: 5,
     });
 
+    await flushPromises();
+
     const state = get(movieStore);
     const favorites = state.watchlist.get('Favorites') ?? [];
-    expect(favorites).toHaveLength(1);
-    expect(favorites[0].postId).toBe('post-own');
-    expect(state.watchLogs).toHaveLength(1);
-    expect(state.watchLogs[0].postId).toBe('post-own');
+    expect(favorites).toHaveLength(2);
+    expect(favorites.some((item) => item.postId === 'post-own')).toBe(true);
+    expect(favorites.some((item) => item.postId === 'post-sparse')).toBe(true);
+    expect(state.watchLogs).toHaveLength(2);
+    expect(state.watchLogs.some((item) => item.postId === 'post-own')).toBe(true);
+    expect(state.watchLogs.some((item) => item.postId === 'post-sparse')).toBe(true);
+    expect(apiGetPostWatchlistInfo).toHaveBeenCalledWith('post-own');
+    expect(apiGetPostWatchlistInfo).toHaveBeenCalledWith('post-sparse');
+    expect(apiGetPostWatchLogs).toHaveBeenCalledWith('post-own');
+    expect(apiGetPostWatchLogs).toHaveBeenCalledWith('post-sparse');
   });
 });

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -182,6 +182,105 @@ describe('postStore', () => {
     expect(state.posts[0].links?.[0].metadata).toBeUndefined();
   });
 
+  it('setMovieWatchlistState updates viewer flags and watchlist count', () => {
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          movieStats: {
+            watchlistCount: 3,
+            watchCount: 1,
+            averageRating: 4,
+            viewerWatchlisted: false,
+            viewerWatched: false,
+            viewerRating: null,
+            viewerCategories: [],
+          },
+        },
+      ],
+      null,
+      true
+    );
+
+    postStore.setMovieWatchlistState('post-1', true, ['Favorites']);
+    let state = get(postStore);
+    expect(state.posts[0].movieStats?.watchlistCount).toBe(4);
+    expect(state.posts[0].movieStats?.viewerWatchlisted).toBe(true);
+    expect(state.posts[0].movieStats?.viewerCategories).toEqual(['Favorites']);
+
+    postStore.setMovieWatchlistState('post-1', false, []);
+    state = get(postStore);
+    expect(state.posts[0].movieStats?.watchlistCount).toBe(3);
+    expect(state.posts[0].movieStats?.viewerWatchlisted).toBe(false);
+    expect(state.posts[0].movieStats?.viewerCategories).toEqual([]);
+  });
+
+  it('setMovieWatchState updates watch count and average rating', () => {
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          movieStats: {
+            watchlistCount: 2,
+            watchCount: 2,
+            averageRating: 4,
+            viewerWatchlisted: false,
+            viewerWatched: false,
+            viewerRating: null,
+            viewerCategories: [],
+          },
+        },
+      ],
+      null,
+      true
+    );
+
+    postStore.setMovieWatchState('post-1', true, 5);
+    let state = get(postStore);
+    expect(state.posts[0].movieStats?.watchCount).toBe(3);
+    expect(state.posts[0].movieStats?.averageRating).toBeCloseTo(4.333, 3);
+    expect(state.posts[0].movieStats?.viewerWatched).toBe(true);
+    expect(state.posts[0].movieStats?.viewerRating).toBe(5);
+
+    postStore.setMovieWatchState('post-1', true, 3);
+    state = get(postStore);
+    expect(state.posts[0].movieStats?.watchCount).toBe(3);
+    expect(state.posts[0].movieStats?.averageRating).toBeCloseTo(3.667, 3);
+    expect(state.posts[0].movieStats?.viewerRating).toBe(3);
+
+    postStore.setMovieWatchState('post-1', false, null);
+    state = get(postStore);
+    expect(state.posts[0].movieStats?.watchCount).toBe(2);
+    expect(state.posts[0].movieStats?.averageRating).toBe(4);
+    expect(state.posts[0].movieStats?.viewerWatched).toBe(false);
+    expect(state.posts[0].movieStats?.viewerRating).toBeNull();
+  });
+
+  it('setMovieStats overwrites reconciled movie aggregate fields', () => {
+    postStore.setPosts([basePost], null, true);
+
+    postStore.setMovieStats('post-1', {
+      watchlistCount: 6,
+      watchCount: 4,
+      averageRating: 4.5,
+      viewerWatchlisted: true,
+      viewerWatched: true,
+      viewerRating: 5,
+      viewerCategories: ['Top Picks'],
+    });
+
+    const state = get(postStore);
+    expect(state.posts[0].movieStats).toMatchObject({
+      watchlistCount: 6,
+      watchCount: 4,
+      averageRating: 4.5,
+      viewerWatchlisted: true,
+      viewerWatched: true,
+      viewerRating: 5,
+      viewerCategories: ['Top Picks'],
+    });
+  });
+
   it('reset restores defaults', () => {
     postStore.setPosts([basePost], 'cursor-1', false);
     postStore.reset();

--- a/frontend/src/stores/movieStore.ts
+++ b/frontend/src/stores/movieStore.ts
@@ -642,8 +642,14 @@ export function handleMovieUnwatchlistedEvent(payload: unknown): void {
   }
 
   if (shouldHandleCurrentUserEvent(payload)) {
-    const category = extractCategoryName(payload) ?? undefined;
-    movieStore.applyUnwatchlist(postId, category);
+    const category = extractCategoryName(payload);
+    if (category) {
+      movieStore.applyUnwatchlist(postId, category);
+    } else {
+      // Backend movie_unwatchlisted events currently omit category.
+      // Reload the watchlist to avoid clearing all categories locally for this post.
+      void movieStore.loadWatchlist();
+    }
   }
 
   void refreshPostMovieStats(postId);

--- a/frontend/src/stores/movieStore.ts
+++ b/frontend/src/stores/movieStore.ts
@@ -9,7 +9,7 @@ import {
 } from '../services/api';
 import { currentUser } from './authStore';
 import { mapApiPost, type ApiPost } from './postMapper';
-import type { Post } from './postStore';
+import { postStore, type Post } from './postStore';
 
 const DEFAULT_WATCHLIST_CATEGORY = 'Uncategorized';
 
@@ -222,7 +222,21 @@ function extractPostId(payload: unknown): string | null {
 
   const record = payload as Record<string, unknown>;
   const postId = record.post_id ?? record.postId;
-  return typeof postId === 'string' && postId.length > 0 ? postId : null;
+  if (typeof postId === 'string' && postId.length > 0) {
+    return postId;
+  }
+
+  const nestedWatchlistItem =
+    record.watchlist_item ?? record.watchlistItem ?? record.watch_log ?? record.watchLog ?? record.log;
+  if (nestedWatchlistItem && typeof nestedWatchlistItem === 'object') {
+    const nestedRecord = nestedWatchlistItem as Record<string, unknown>;
+    const nestedPostID = nestedRecord.post_id ?? nestedRecord.postId;
+    if (typeof nestedPostID === 'string' && nestedPostID.length > 0) {
+      return nestedPostID;
+    }
+  }
+
+  return null;
 }
 
 function extractUserId(payload: unknown): string | null {
@@ -245,10 +259,108 @@ function extractCategoryName(payload: unknown): string | null {
   return typeof category === 'string' && category.length > 0 ? category : null;
 }
 
+function extractCategories(payload: unknown): string[] {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (Array.isArray(record.categories)) {
+    return record.categories
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+  }
+
+  const category = extractCategoryName(payload);
+  return category ? [category] : [];
+}
+
+function extractRating(payload: unknown): number | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const rating = record.rating;
+  return typeof rating === 'number' && Number.isFinite(rating) ? rating : null;
+}
+
 function shouldHandleCurrentUserEvent(payload: unknown): boolean {
   const actingUserID = extractUserId(payload);
   const currentUserID = get(currentUser)?.id;
   return !!actingUserID && !!currentUserID && actingUserID === currentUserID;
+}
+
+function buildWatchlistItemsFromCategories(payload: unknown): WatchlistItem[] {
+  const postId = extractPostId(payload);
+  const actingUserID = extractUserId(payload);
+  const currentUserID = get(currentUser)?.id;
+  if (!postId || !actingUserID || !currentUserID || actingUserID !== currentUserID) {
+    return [];
+  }
+
+  const categories = extractCategories(payload);
+  if (categories.length === 0) {
+    return [];
+  }
+
+  const createdAt = new Date().toISOString();
+  return categories.map((category) => ({
+    id: `ws-${postId}-${category}-${Date.now()}`,
+    userId: currentUserID,
+    postId,
+    category,
+    createdAt,
+  }));
+}
+
+function buildWatchLogFromPayload(payload: unknown): WatchLog | null {
+  const postId = extractPostId(payload);
+  const actingUserID = extractUserId(payload);
+  const currentUserID = get(currentUser)?.id;
+  const rating = extractRating(payload);
+  if (!postId || !actingUserID || !currentUserID || actingUserID !== currentUserID) {
+    return null;
+  }
+  if (rating === null) {
+    return null;
+  }
+
+  return {
+    id: `ws-watch-${postId}-${Date.now()}`,
+    userId: currentUserID,
+    postId,
+    rating,
+    watchedAt: new Date().toISOString(),
+  };
+}
+
+async function refreshPostMovieStats(postId: string): Promise<void> {
+  try {
+    const [watchlistInfo, watchLogInfo] = await Promise.all([
+      api.getPostWatchlistInfo(postId),
+      api.getPostWatchLogs(postId),
+    ]);
+
+    postStore.setMovieStats(postId, {
+      watchlistCount: watchlistInfo.saveCount ?? 0,
+      watchCount: watchLogInfo.watchCount ?? 0,
+      averageRating:
+        typeof watchLogInfo.avgRating === 'number' && Number.isFinite(watchLogInfo.avgRating)
+          ? watchLogInfo.avgRating
+          : null,
+      viewerWatchlisted: watchlistInfo.viewerSaved ?? false,
+      viewerWatched: watchLogInfo.viewerWatched ?? false,
+      viewerRating:
+        typeof watchLogInfo.viewerRating === 'number' && Number.isFinite(watchLogInfo.viewerRating)
+          ? watchLogInfo.viewerRating
+          : null,
+      viewerCategories: watchlistInfo.viewerCategories ?? [],
+    });
+  } catch {
+    // Ignore transient refresh errors; future events or feed refresh will reconcile.
+  }
 }
 
 const initialState: MovieStoreState = {
@@ -407,6 +519,7 @@ function createMovieStore() {
       try {
         const response = await api.addToWatchlist(postId, categories);
         movieStore.applyWatchlistItems((response.watchlistItems ?? []).map(mapApiWatchlistItem));
+        void refreshPostMovieStats(postId);
       } catch (error) {
         movieStore.setError(error instanceof Error ? error.message : 'Failed to add to watchlist');
       }
@@ -415,6 +528,7 @@ function createMovieStore() {
       try {
         await api.removeFromWatchlist(postId, category);
         movieStore.applyUnwatchlist(postId, category);
+        void refreshPostMovieStats(postId);
       } catch (error) {
         movieStore.setError(
           error instanceof Error ? error.message : 'Failed to remove from watchlist'
@@ -464,6 +578,7 @@ function createMovieStore() {
       try {
         const response = await api.logWatch(postId, rating, notes);
         movieStore.applyWatchLog(mapApiWatchLog(response.watchLog));
+        void refreshPostMovieStats(postId);
       } catch (error) {
         movieStore.setError(error instanceof Error ? error.message : 'Failed to log watch');
       }
@@ -472,6 +587,7 @@ function createMovieStore() {
       try {
         const response = await api.updateWatchLog(postId, { rating, notes });
         movieStore.applyWatchLog(mapApiWatchLog(response.watchLog));
+        void refreshPostMovieStats(postId);
       } catch (error) {
         movieStore.setError(error instanceof Error ? error.message : 'Failed to update watch log');
       }
@@ -480,6 +596,7 @@ function createMovieStore() {
       try {
         await api.removeWatchLog(postId);
         movieStore.applyWatchLogRemoval(postId);
+        void refreshPostMovieStats(postId);
       } catch (error) {
         movieStore.setError(error instanceof Error ? error.message : 'Failed to remove watch log');
       }
@@ -501,50 +618,63 @@ export const sortedCategories = derived(movieStore, ($store) =>
 );
 
 export function handleMovieWatchlistedEvent(payload: unknown): void {
-  if (!shouldHandleCurrentUserEvent(payload)) {
+  const postId = extractPostId(payload);
+  if (!postId) {
     return;
   }
 
-  const watchlistItems = extractWatchlistItems(payload).map(mapApiWatchlistItem);
-  if (watchlistItems.length === 0) {
-    return;
+  if (shouldHandleCurrentUserEvent(payload)) {
+    const watchlistItems = extractWatchlistItems(payload).map(mapApiWatchlistItem);
+    const fallbackItems =
+      watchlistItems.length > 0 ? watchlistItems : buildWatchlistItemsFromCategories(payload);
+    if (fallbackItems.length > 0) {
+      movieStore.applyWatchlistItems(fallbackItems);
+    }
   }
-  movieStore.applyWatchlistItems(watchlistItems);
+
+  void refreshPostMovieStats(postId);
 }
 
 export function handleMovieUnwatchlistedEvent(payload: unknown): void {
-  if (!shouldHandleCurrentUserEvent(payload)) {
-    return;
-  }
-
   const postId = extractPostId(payload);
   if (!postId) {
     return;
   }
-  const category = extractCategoryName(payload) ?? undefined;
-  movieStore.applyUnwatchlist(postId, category);
+
+  if (shouldHandleCurrentUserEvent(payload)) {
+    const category = extractCategoryName(payload) ?? undefined;
+    movieStore.applyUnwatchlist(postId, category);
+  }
+
+  void refreshPostMovieStats(postId);
 }
 
 export function handleMovieWatchedEvent(payload: unknown): void {
-  if (!shouldHandleCurrentUserEvent(payload)) {
-    return;
-  }
-
-  const watchLog = extractWatchLog(payload);
-  if (!watchLog) {
-    return;
-  }
-  movieStore.applyWatchLog(mapApiWatchLog(watchLog));
-}
-
-export function handleMovieWatchRemovedEvent(payload: unknown): void {
-  if (!shouldHandleCurrentUserEvent(payload)) {
-    return;
-  }
-
   const postId = extractPostId(payload);
   if (!postId) {
     return;
   }
-  movieStore.applyWatchLogRemoval(postId);
+
+  if (shouldHandleCurrentUserEvent(payload)) {
+    const watchLog = extractWatchLog(payload);
+    const mappedWatchLog = watchLog ? mapApiWatchLog(watchLog) : buildWatchLogFromPayload(payload);
+    if (mappedWatchLog) {
+      movieStore.applyWatchLog(mappedWatchLog);
+    }
+  }
+
+  void refreshPostMovieStats(postId);
+}
+
+export function handleMovieWatchRemovedEvent(payload: unknown): void {
+  const postId = extractPostId(payload);
+  if (!postId) {
+    return;
+  }
+
+  if (shouldHandleCurrentUserEvent(payload)) {
+    movieStore.applyWatchLogRemoval(postId);
+  }
+
+  void refreshPostMovieStats(postId);
 }

--- a/frontend/src/stores/websocketStore.ts
+++ b/frontend/src/stores/websocketStore.ts
@@ -14,6 +14,12 @@ import {
   handleRecipeSavedEvent,
   handleRecipeUnsavedEvent,
 } from './recipeStore';
+import {
+  handleMovieWatchedEvent,
+  handleMovieWatchlistedEvent,
+  handleMovieWatchRemovedEvent,
+  handleMovieUnwatchlistedEvent,
+} from './movieStore';
 import { api } from '../services/api';
 import { mapApiComment } from './commentMapper';
 import { mapApiPost, normalizeLinkMetadata, type ApiPost } from './postMapper';
@@ -378,6 +384,22 @@ function connect() {
       }
       case 'recipe_category_deleted': {
         handleRecipeCategoryDeletedEvent(parsed.data);
+        break;
+      }
+      case 'movie_watchlisted': {
+        handleMovieWatchlistedEvent(parsed.data);
+        break;
+      }
+      case 'movie_unwatchlisted': {
+        handleMovieUnwatchlistedEvent(parsed.data);
+        break;
+      }
+      case 'movie_watched': {
+        handleMovieWatchedEvent(parsed.data);
+        break;
+      }
+      case 'movie_watch_removed': {
+        handleMovieWatchRemovedEvent(parsed.data);
         break;
       }
       default:


### PR DESCRIPTION
## Summary
- add dedicated movie stat mutators in `postStore` for optimistic viewer save/watch updates and server-side stat reconciliation
- update `WatchlistSaveButton` and `WatchButton` to immediately update movie aggregate stats (saved/watched/avg) and rollback on API error
- wire movie websocket event types in `websocketStore` and extend movie event handlers to refresh post stats from API so other users' actions update counts in real time
- add/expand frontend tests for movie stat math, movie websocket handling, and websocket routing

## Testing
- `task frontend:test`
- `task frontend:check`
- `task frontend:lint`

Closes #844