### PR TITLE
[Movies] Move Watchlist from standalone nav to Movies section header

### DIFF
--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -13,7 +13,6 @@
   import {
     buildAdminHref,
     buildSectionHref,
-    buildWatchlistHref,
     pushPath,
   } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
@@ -32,11 +31,6 @@
     pushPath(buildAdminHref());
   }
 
-  function handleWatchlistClick() {
-    uiStore.setActiveView('watchlist');
-    threadRouteStore.clearTarget();
-    pushPath(buildWatchlistHref());
-  }
 </script>
 
 <nav class="flex flex-col h-full" aria-label="Main navigation">
@@ -62,21 +56,6 @@
       {/each}
     </ul>
 
-    {#if $isAuthenticated}
-      <div class="mt-4 border-t border-gray-200 px-2 pt-4">
-        <button
-          on:click={handleWatchlistClick}
-          class="w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
-            {$activeView === 'watchlist'
-            ? 'bg-indigo-600 text-white'
-            : 'text-gray-700 hover:bg-indigo-50'}"
-          aria-current={$activeView === 'watchlist' ? 'page' : undefined}
-        >
-          <span class="text-lg" aria-hidden="true">🎬</span>
-          <span>My Movies</span>
-        </button>
-      </div>
-    {/if}
   </div>
 
   {#if $isAuthenticated}

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -71,19 +71,7 @@ describe('Nav', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
-  it('shows and activates the watchlist navigation item', async () => {
-    const pushStateSpy = vi.spyOn(window.history, 'pushState');
-    render(Nav);
-
-    const watchlistButton = screen.getByRole('button', { name: 'My Movies' });
-    await fireEvent.click(watchlistButton);
-
-    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/watchlist');
-    expect(watchlistButton).toHaveAttribute('aria-current', 'page');
-  });
-
-  it('hides watchlist navigation when logged out', () => {
-    authStore.setUser(null);
+  it('does not render a standalone My Movies navigation entry', () => {
     render(Nav);
 
     expect(screen.queryByRole('button', { name: 'My Movies' })).not.toBeInTheDocument();

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAdminHref,
   buildFeedHref,
+  buildSectionWatchlistHref,
   buildSectionHref,
   buildStandaloneThreadHref,
   buildSettingsHref,
@@ -10,6 +11,7 @@ import {
   isAdminPath,
   isSettingsPath,
   isWatchlistPath,
+  parseSectionWatchlistSlug,
   parseStandaloneThreadPostId,
   parseSectionSlug,
   parseThreadCommentId,
@@ -70,6 +72,13 @@ describe('routeNavigation', () => {
     expect(isWatchlistPath('/watchlist')).toBe(true);
     expect(isWatchlistPath('/watchlist/favorites')).toBe(true);
     expect(isWatchlistPath('/sections/movies')).toBe(false);
+  });
+
+  it('builds and parses section watchlist hrefs', () => {
+    expect(buildSectionWatchlistHref('movies')).toBe('/sections/movies/watchlist');
+    expect(parseSectionWatchlistSlug('/sections/movies/watchlist')).toBe('movies');
+    expect(parseSectionWatchlistSlug('/sections/movies')).toBeNull();
+    expect(parseSectionWatchlistSlug('/watchlist')).toBeNull();
   });
 
   it('builds feed hrefs from section slugs', () => {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -4,6 +4,7 @@ const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
 const WATCHLIST_PATH = '/watchlist';
+const WATCHLIST_SEGMENT = WATCHLIST_PATH.slice(1);
 
 export type SearchHistoryState = {
   query: string;
@@ -25,6 +26,10 @@ export function buildThreadHref(sectionSlug: string, postId: string): string {
 
 export function buildStandaloneThreadHref(postId: string): string {
   return `${THREAD_ROOT_PATH}${postId}`;
+}
+
+export function buildSectionWatchlistHref(sectionSlug: string): string {
+  return `${buildSectionHref(sectionSlug)}/${WATCHLIST_SEGMENT}`;
 }
 
 export function parseSectionSlug(pathname: string): string | null {
@@ -63,6 +68,22 @@ export function parseStandaloneThreadPostId(pathname: string): string | null {
   const [postId] = remainder.split('/');
   const trimmed = postId?.trim();
   return trimmed ? trimmed : null;
+}
+
+export function parseSectionWatchlistSlug(pathname: string): string | null {
+  if (!pathname.startsWith(SECTION_PATH_PREFIX)) {
+    return null;
+  }
+  const remainder = pathname.slice(SECTION_PATH_PREFIX.length);
+  const [sectionSlug, segment] = remainder.split('/');
+  if (!sectionSlug || segment !== WATCHLIST_SEGMENT) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(sectionSlug);
+  } catch {
+    return sectionSlug;
+  }
 }
 
 export function parseThreadCommentId(search: string): string | null {

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -3,7 +3,7 @@ import { writable, derived } from 'svelte/store';
 interface UIState {
   sidebarOpen: boolean;
   isMobile: boolean;
-  activeView: 'feed' | 'watchlist' | 'admin' | 'profile' | 'settings' | 'thread';
+  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread';
   activeProfileUserId: string | null;
 }
 
@@ -25,7 +25,7 @@ function createUIStore() {
         isMobile,
         sidebarOpen: isMobile ? false : state.sidebarOpen,
       })),
-    setActiveView: (activeView: 'feed' | 'watchlist' | 'admin' | 'profile' | 'settings' | 'thread') =>
+    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread') =>
       update((state) => ({
         ...state,
         activeView,


### PR DESCRIPTION
## Summary
- remove the standalone `My Movies` entry from the sidebar navigation
- add section-level `Feed` and `Watchlist` tabs for movie and series sections in `App.svelte`
- render `Watchlist` inline within the active movie/series section context instead of as a dedicated global page
- support section watchlist URLs via `/sections/:slug/watchlist` route helpers while preserving legacy `/watchlist` deep links
- update frontend tests for the new navigation flow and route helper behavior

## Validation
- task frontend:check
- task frontend:test

Closes #846