### PR TITLE
[Books] Create read_logs table migration

### DIFF
--- a/backend/migrations/039_create_read_logs_table.down.sql
+++ b/backend/migrations/039_create_read_logs_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS read_logs;

--- a/backend/migrations/039_create_read_logs_table.up.sql
+++ b/backend/migrations/039_create_read_logs_table.up.sql
@@ -1,0 +1,18 @@
+-- Create read_logs table
+CREATE TABLE read_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  rating INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ,
+
+  CONSTRAINT read_logs_rating_check CHECK (rating >= 1 AND rating <= 5)
+);
+
+CREATE UNIQUE INDEX read_logs_user_post_unique
+  ON read_logs(user_id, post_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_read_logs_user_id ON read_logs(user_id);
+CREATE INDEX idx_read_logs_post_id ON read_logs(post_id);


### PR DESCRIPTION
## Summary
- add `039_create_read_logs_table.up.sql` to create `read_logs` with required columns and constraints
- add partial unique index on `(user_id, post_id)` where `deleted_at IS NULL`
- add `idx_read_logs_user_id` and `idx_read_logs_post_id`
- add down migration to drop `read_logs`

## Validation
- pre-commit hooks executed during commit and passed for applicable checks

Closes #856