### PR TITLE
[Movies] Separate Watchlist by section type and display in Series section

### DIFF
--- a/backend/internal/handlers/post.go
+++ b/backend/internal/handlers/post.go
@@ -360,6 +360,11 @@ func (h *PostHandler) GetMovieFeed(w http.ResponseWriter, r *http.Request) {
 
 	cursor := r.URL.Query().Get("cursor")
 	limitStr := r.URL.Query().Get("limit")
+	sectionType, err := parseMovieOrSeriesSectionType(r.URL.Query().Get("section_type"))
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_SECTION_TYPE", "section_type must be either movie or series")
+		return
+	}
 
 	limit := 20
 	if limitStr != "" {
@@ -377,7 +382,7 @@ func (h *PostHandler) GetMovieFeed(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID, _ := middleware.GetUserIDFromContext(r.Context())
-	feed, err := h.postService.GetMovieFeed(r.Context(), cursorPtr, limit, userID)
+	feed, err := h.postService.GetMovieFeed(r.Context(), cursorPtr, limit, userID, sectionType)
 	if err != nil {
 		writeError(r.Context(), w, http.StatusInternalServerError, "GET_MOVIE_FEED_FAILED", "Failed to get movie feed")
 		return

--- a/backend/internal/handlers/post_test.go
+++ b/backend/internal/handlers/post_test.go
@@ -537,6 +537,32 @@ func TestGetMovieFeedMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestGetMovieFeedRejectsInvalidSectionType(t *testing.T) {
+	db, _, err := setupMockDB(t)
+	if err != nil {
+		t.Fatalf("failed to setup mock db: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewPostHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/movies?section_type=invalid", nil)
+	rr := httptest.NewRecorder()
+
+	handler.GetMovieFeed(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "INVALID_SECTION_TYPE" {
+		t.Fatalf("expected code INVALID_SECTION_TYPE, got %s", response.Code)
+	}
+}
+
 // TestGetFeedInvalidSectionID tests with invalid section ID format
 func TestGetFeedInvalidSectionID(t *testing.T) {
 	db, _, err := setupMockDB(t)

--- a/backend/internal/handlers/section_type.go
+++ b/backend/internal/handlers/section_type.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+)
+
+var errInvalidSectionType = errors.New("invalid section type")
+
+func parseMovieOrSeriesSectionType(raw string) (*string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" {
+		return nil, nil
+	}
+	if normalized != "movie" && normalized != "series" {
+		return nil, errInvalidSectionType
+	}
+	return &normalized, nil
+}

--- a/backend/internal/handlers/watchlist.go
+++ b/backend/internal/handlers/watchlist.go
@@ -237,7 +237,13 @@ func (h *WatchlistHandler) ListWatchlist(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	grouped, err := h.watchlistService.GetUserWatchlist(r.Context(), userID)
+	sectionType, err := parseMovieOrSeriesSectionType(r.URL.Query().Get("section_type"))
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_SECTION_TYPE", "section_type must be either movie or series")
+		return
+	}
+
+	grouped, err := h.watchlistService.GetUserWatchlist(r.Context(), userID, sectionType)
 	if err != nil {
 		writeError(r.Context(), w, http.StatusInternalServerError, "GET_WATCHLIST_FAILED", "Failed to get watchlist")
 		return

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -540,7 +540,7 @@
           </div>
 
           {#if supportsWatchlist && sectionSubview === 'watchlist'}
-            <Watchlist />
+            <Watchlist sectionType={$activeSection.type === 'series' ? 'series' : 'movie'} />
           {:else}
             <!-- Section-specific components should render above PostForm for consistency. -->
             {#if $activeSection.type === 'recipe'}

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -215,12 +215,13 @@ describe('api client', () => {
       }),
     });
 
-    const response = await api.getMoviePosts(15, 'cursor-1');
+    const response = await api.getMoviePosts(15, 'cursor-1', 'series');
 
     const [url] = fetchMock.mock.calls[0];
     expect(url).toContain('/posts/movies');
     expect(url).toContain('limit=15');
     expect(url).toContain('cursor=cursor-1');
+    expect(url).toContain('section_type=series');
     expect(response.hasMore).toBe(true);
     expect(response.nextCursor).toBe('cursor-next');
     expect(response.posts).toHaveLength(1);
@@ -228,6 +229,20 @@ describe('api client', () => {
     expect(response.posts[0]?.movieStats?.averageRating).toBe(4.8);
     expect(response.posts[0]?.movieStats?.watchCount).toBe(10);
     expect(response.posts[0]?.movieStats?.watchlistCount).toBe(3);
+  });
+
+  it('getMyWatchlist passes optional section_type filter', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ categories: [] }),
+    });
+
+    await api.getMyWatchlist('movie');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/me/watchlist');
+    expect(url).toContain('section_type=movie');
   });
 
   it('getThreadComments builds query params', async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -715,10 +715,12 @@ class ApiClient {
 
   async getMoviePosts(
     limit = 20,
-    cursor?: string
+    cursor?: string,
+    sectionType?: 'movie' | 'series'
   ): Promise<{ posts: Post[]; hasMore: boolean; nextCursor?: string }> {
     const params = new URLSearchParams({ limit: String(limit) });
     if (cursor) params.set('cursor', cursor);
+    if (sectionType) params.set('section_type', sectionType);
     const response = await this.get<{
       posts: ApiPost[];
       has_more?: boolean;
@@ -987,10 +989,17 @@ class ApiClient {
     };
   }
 
-  async getMyWatchlist(): Promise<{ categories: { name: string; items: WatchlistItemWithPost[] }[] }> {
+  async getMyWatchlist(
+    sectionType?: 'movie' | 'series'
+  ): Promise<{ categories: { name: string; items: WatchlistItemWithPost[] }[] }> {
+    const params = new URLSearchParams();
+    if (sectionType) {
+      params.set('section_type', sectionType);
+    }
+    const query = params.toString();
     const response = await this.get<{
       categories: { name: string; items: ApiWatchlistItem[] }[];
-    }>('/me/watchlist');
+    }>(query ? `/me/watchlist?${query}` : '/me/watchlist');
     return {
       categories: (response.categories ?? []).map((category) => ({
         name: category.name,

--- a/frontend/src/stores/__tests__/movieStore.test.ts
+++ b/frontend/src/stores/__tests__/movieStore.test.ts
@@ -118,6 +118,11 @@ describe('movieStore', () => {
     expect(favorites[0].post?.id).toBe('post-1');
   });
 
+  it('loadWatchlist forwards optional section type', async () => {
+    await movieStore.loadWatchlist('series');
+    expect(apiGetMyWatchlist).toHaveBeenCalledWith('series');
+  });
+
   it('addToWatchlist and removeFromWatchlist update state', async () => {
     apiAddToWatchlist.mockResolvedValue({
       watchlistItems: [

--- a/frontend/src/stores/movieStore.ts
+++ b/frontend/src/stores/movieStore.ts
@@ -375,6 +375,7 @@ const initialState: MovieStoreState = {
 
 function createMovieStore() {
   const { subscribe, update, set } = writable<MovieStoreState>({ ...initialState });
+  let latestWatchlistRequestID = 0;
 
   return {
     subscribe,
@@ -496,11 +497,18 @@ function createMovieStore() {
         watchlist: moveCategoryWatchlistItems(state.watchlist, fromCategory, toCategory),
       })),
     loadWatchlist: async (sectionType?: 'movie' | 'series'): Promise<void> => {
+      const requestID = ++latestWatchlistRequestID;
       movieStore.setLoadingWatchlist(true);
       try {
         const response = await api.getMyWatchlist(sectionType);
+        if (requestID !== latestWatchlistRequestID) {
+          return;
+        }
         movieStore.setWatchlist(buildWatchlistMap(response.categories ?? []));
       } catch (error) {
+        if (requestID !== latestWatchlistRequestID) {
+          return;
+        }
         movieStore.setError(error instanceof Error ? error.message : 'Failed to load watchlist');
       }
     },

--- a/frontend/src/stores/movieStore.ts
+++ b/frontend/src/stores/movieStore.ts
@@ -495,10 +495,10 @@ function createMovieStore() {
         ...state,
         watchlist: moveCategoryWatchlistItems(state.watchlist, fromCategory, toCategory),
       })),
-    loadWatchlist: async (): Promise<void> => {
+    loadWatchlist: async (sectionType?: 'movie' | 'series'): Promise<void> => {
       movieStore.setLoadingWatchlist(true);
       try {
-        const response = await api.getMyWatchlist();
+        const response = await api.getMyWatchlist(sectionType);
         movieStore.setWatchlist(buildWatchlistMap(response.categories ?? []));
       } catch (error) {
         movieStore.setError(error instanceof Error ? error.message : 'Failed to load watchlist');


### PR DESCRIPTION
## Summary
- add `sectionType` context to the Watchlist UI and pass it from `App.svelte` based on the active section (`movie` or `series`)
- filter both `My List` and `All` watchlist tabs by section type, including dynamic labels and empty states (`All Movies`/`All Series`, `No movies...`/`No series...`)
- add backend support for `section_type` filtering on watchlist and movie-feed endpoints (`GET /api/v1/me/watchlist` and `GET /api/v1/posts/movies`)
- update frontend API and movie store methods to pass `section_type` to backend endpoints
- add/extend backend and frontend tests for section-type filtering and validation behavior

## Testing
- `task backend:test`
- `task frontend:test`
- `task frontend:check`

Closes #851