### PR TITLE
[Books] Create book_quotes table migration

### DIFF
--- a/backend/migrations/040_create_book_quotes_table.down.sql
+++ b/backend/migrations/040_create_book_quotes_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS book_quotes;

--- a/backend/migrations/040_create_book_quotes_table.up.sql
+++ b/backend/migrations/040_create_book_quotes_table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE book_quotes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  quote_text TEXT NOT NULL,
+  page_number INT,
+  chapter VARCHAR(200),
+  note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_book_quotes_post_id ON book_quotes(post_id);
+CREATE INDEX idx_book_quotes_user_id ON book_quotes(user_id);


### PR DESCRIPTION
## Summary
- add migration `040_create_book_quotes_table.up.sql` creating `book_quotes` with UUID PK, `post_id`/`user_id` FKs, quote metadata fields, timestamps, and soft-delete column
- add required indexes `idx_book_quotes_post_id` and `idx_book_quotes_user_id`
- add rollback migration `040_create_book_quotes_table.down.sql` to drop `book_quotes`

## Validation
- `cd backend && go test ./...`

Closes #876