### PR TITLE
[Books] Create bookshelf service

### DIFF
--- a/backend/internal/services/bookshelf.go
+++ b/backend/internal/services/bookshelf.go
@@ -1,0 +1,1102 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	defaultBookshelfCategoryName  = "Uncategorized"
+	maxBookshelfCategoryNameLimit = 100
+	defaultBookshelfPageSize      = 20
+	maxBookshelfPageSize          = 100
+	bookshelfCursorSeparator      = "|"
+)
+
+// BookshelfService handles book bookshelf operations.
+type BookshelfService struct {
+	db    *sql.DB
+	audit *AuditService
+}
+
+// NewBookshelfService creates a bookshelf service.
+func NewBookshelfService(db *sql.DB) *BookshelfService {
+	return &BookshelfService{
+		db:    db,
+		audit: NewAuditService(db),
+	}
+}
+
+// CreateCategory creates a new bookshelf category for a user.
+func (s *BookshelfService) CreateCategory(ctx context.Context, userID uuid.UUID, name string) (*models.BookshelfCategory, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.CreateCategory")
+	span.SetAttributes(attribute.String("user_id", userID.String()))
+	defer span.End()
+
+	normalized, err := normalizeBookshelfCategoryName(name)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	span.SetAttributes(attribute.String("category_name", normalized))
+
+	position, err := s.nextBookshelfCategoryPosition(ctx, s.db, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	query := `
+		INSERT INTO bookshelf_categories (id, user_id, name, position, created_at)
+		VALUES ($1, $2, $3, $4, now())
+		RETURNING id, user_id, name, position, created_at
+	`
+
+	categoryID := uuid.New()
+	var category models.BookshelfCategory
+	if err := s.db.QueryRowContext(ctx, query, categoryID, userID, normalized, position).Scan(
+		&category.ID,
+		&category.UserID,
+		&category.Name,
+		&category.Position,
+		&category.CreatedAt,
+	); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to create bookshelf category: %w", err)
+	}
+
+	if err := s.logBookshelfAudit(ctx, "create_bookshelf_category", userID, map[string]interface{}{
+		"category_id":   category.ID.String(),
+		"category_name": category.Name,
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return &category, nil
+}
+
+// GetCategories returns all bookshelf categories for a user in display order.
+func (s *BookshelfService) GetCategories(ctx context.Context, userID uuid.UUID) ([]models.BookshelfCategory, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.GetCategories")
+	span.SetAttributes(attribute.String("user_id", userID.String()))
+	defer span.End()
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, name, position, created_at
+		FROM bookshelf_categories
+		WHERE user_id = $1
+		ORDER BY position ASC, created_at ASC
+	`, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query bookshelf categories: %w", err)
+	}
+	defer rows.Close()
+
+	categories := make([]models.BookshelfCategory, 0)
+	for rows.Next() {
+		var category models.BookshelfCategory
+		if err := rows.Scan(&category.ID, &category.UserID, &category.Name, &category.Position, &category.CreatedAt); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		categories = append(categories, category)
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate bookshelf categories: %w", err)
+	}
+
+	return categories, nil
+}
+
+// UpdateCategory updates a bookshelf category's name and position.
+func (s *BookshelfService) UpdateCategory(
+	ctx context.Context,
+	userID, categoryID uuid.UUID,
+	req models.UpdateBookshelfCategoryRequest,
+) (*models.BookshelfCategory, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.UpdateCategory")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("category_id", categoryID.String()),
+		attribute.Int("position", req.Position),
+	)
+	defer span.End()
+
+	normalized, err := normalizeBookshelfCategoryName(req.Name)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	if req.Position < 0 {
+		err := errors.New("position must be greater than or equal to 0")
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	query := `
+		UPDATE bookshelf_categories
+		SET name = $1, position = $2
+		WHERE id = $3 AND user_id = $4
+		RETURNING id, user_id, name, position, created_at
+	`
+
+	var category models.BookshelfCategory
+	if err := s.db.QueryRowContext(ctx, query, normalized, req.Position, categoryID, userID).Scan(
+		&category.ID,
+		&category.UserID,
+		&category.Name,
+		&category.Position,
+		&category.CreatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			notFoundErr := errors.New("category not found")
+			recordSpanError(span, notFoundErr)
+			return nil, notFoundErr
+		}
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to update bookshelf category: %w", err)
+	}
+
+	if err := s.logBookshelfAudit(ctx, "update_bookshelf_category", userID, map[string]interface{}{
+		"category_id": category.ID.String(),
+		"changes": map[string]interface{}{
+			"name":     category.Name,
+			"position": category.Position,
+		},
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return &category, nil
+}
+
+// DeleteCategory deletes a category and moves its active items to uncategorized (NULL category_id).
+func (s *BookshelfService) DeleteCategory(ctx context.Context, userID, categoryID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.DeleteCategory")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("category_id", categoryID.String()),
+	)
+	defer span.End()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to begin delete bookshelf category transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var categoryName string
+	if err := tx.QueryRowContext(
+		ctx,
+		"SELECT name FROM bookshelf_categories WHERE id = $1 AND user_id = $2",
+		categoryID,
+		userID,
+	).Scan(&categoryName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			notFoundErr := errors.New("category not found")
+			recordSpanError(span, notFoundErr)
+			return notFoundErr
+		}
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to load bookshelf category: %w", err)
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`UPDATE bookshelf_items
+		SET category_id = NULL
+		WHERE user_id = $1 AND category_id = $2 AND deleted_at IS NULL`,
+		userID,
+		categoryID,
+	); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to move bookshelf items to uncategorized: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM bookshelf_categories WHERE id = $1 AND user_id = $2", categoryID, userID); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to delete bookshelf category: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to commit delete bookshelf category transaction: %w", err)
+	}
+
+	if err := s.logBookshelfAudit(ctx, "delete_bookshelf_category", userID, map[string]interface{}{
+		"category_id":   categoryID.String(),
+		"category_name": categoryName,
+	}); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	return nil
+}
+
+// ReorderCategories updates category positions in the provided order.
+func (s *BookshelfService) ReorderCategories(ctx context.Context, userID uuid.UUID, categoryIDs []uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.ReorderCategories")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.Int("category_count", len(categoryIDs)),
+	)
+	defer span.End()
+
+	if len(categoryIDs) == 0 {
+		err := errors.New("category_ids must not be empty")
+		recordSpanError(span, err)
+		return err
+	}
+
+	seen := make(map[uuid.UUID]struct{}, len(categoryIDs))
+	for _, categoryID := range categoryIDs {
+		if _, exists := seen[categoryID]; exists {
+			err := errors.New("duplicate category id")
+			recordSpanError(span, err)
+			return err
+		}
+		seen[categoryID] = struct{}{}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to begin reorder bookshelf categories transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	rows, err := tx.QueryContext(ctx, "SELECT id FROM bookshelf_categories WHERE user_id = $1", userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to query user bookshelf categories: %w", err)
+	}
+	existing := make(map[uuid.UUID]struct{})
+	for rows.Next() {
+		var categoryID uuid.UUID
+		if err := rows.Scan(&categoryID); err != nil {
+			_ = rows.Close()
+			recordSpanError(span, err)
+			return err
+		}
+		existing[categoryID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to iterate user bookshelf categories: %w", err)
+	}
+	_ = rows.Close()
+
+	if len(existing) != len(categoryIDs) {
+		err := errors.New("category_ids must include all user categories")
+		recordSpanError(span, err)
+		return err
+	}
+	for _, categoryID := range categoryIDs {
+		if _, ok := existing[categoryID]; !ok {
+			err := errors.New("category not found")
+			recordSpanError(span, err)
+			return err
+		}
+	}
+
+	for position, categoryID := range categoryIDs {
+		if _, err := tx.ExecContext(
+			ctx,
+			"UPDATE bookshelf_categories SET position = $1 WHERE id = $2 AND user_id = $3",
+			position,
+			categoryID,
+			userID,
+		); err != nil {
+			recordSpanError(span, err)
+			return fmt.Errorf("failed to update category position: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to commit reorder bookshelf categories transaction: %w", err)
+	}
+
+	reordered := make([]string, 0, len(categoryIDs))
+	for _, categoryID := range categoryIDs {
+		reordered = append(reordered, categoryID.String())
+	}
+	if err := s.logBookshelfAudit(ctx, "update_bookshelf_category", userID, map[string]interface{}{
+		"reordered_category_ids": reordered,
+	}); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	return nil
+}
+
+// AddToBookshelf adds or restores a bookshelf item.
+func (s *BookshelfService) AddToBookshelf(ctx context.Context, userID, postID uuid.UUID, categories []string) error {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.AddToBookshelf")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+		attribute.Int("category_count", len(categories)),
+	)
+	defer span.End()
+
+	if err := s.verifyBookPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	normalizedCategories, err := normalizeBookshelfCategoriesForAdd(categories)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	span.SetAttributes(attribute.StringSlice("categories", normalizedCategories))
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to begin add bookshelf transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	selectedCategoryID, selectedCategoryName, autoCreatedCategories, err := s.resolveBookshelfCategories(ctx, tx, userID, normalizedCategories)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	query := `
+		SELECT id, category_id, deleted_at
+		FROM bookshelf_items
+		WHERE user_id = $1 AND post_id = $2
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+	`
+
+	var (
+		existingID         uuid.UUID
+		existingCategoryID uuid.NullUUID
+		existingDeletedAt  sql.NullTime
+	)
+	err = tx.QueryRowContext(ctx, query, userID, postID).Scan(&existingID, &existingCategoryID, &existingDeletedAt)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to query existing bookshelf item: %w", err)
+	}
+
+	changed := false
+	if errors.Is(err, sql.ErrNoRows) {
+		if _, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO bookshelf_items (id, user_id, post_id, category_id, created_at)
+			VALUES ($1, $2, $3, $4, now())`,
+			uuid.New(),
+			userID,
+			postID,
+			uuidPointerValue(selectedCategoryID),
+		); err != nil {
+			recordSpanError(span, err)
+			return fmt.Errorf("failed to create bookshelf item: %w", err)
+		}
+		changed = true
+	} else {
+		var existingCategoryPointer *uuid.UUID
+		if existingCategoryID.Valid {
+			existingCategoryPointer = &existingCategoryID.UUID
+		}
+
+		if existingDeletedAt.Valid {
+			if _, err := tx.ExecContext(
+				ctx,
+				`UPDATE bookshelf_items
+				SET category_id = $2, deleted_at = NULL
+				WHERE id = $1`,
+				existingID,
+				uuidPointerValue(selectedCategoryID),
+			); err != nil {
+				recordSpanError(span, err)
+				return fmt.Errorf("failed to restore bookshelf item: %w", err)
+			}
+			changed = true
+		} else if !equalUUIDPointers(existingCategoryPointer, selectedCategoryID) {
+			if _, err := tx.ExecContext(
+				ctx,
+				`UPDATE bookshelf_items
+				SET category_id = $2
+				WHERE id = $1`,
+				existingID,
+				uuidPointerValue(selectedCategoryID),
+			); err != nil {
+				recordSpanError(span, err)
+				return fmt.Errorf("failed to update bookshelf item category: %w", err)
+			}
+			changed = true
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to commit add bookshelf transaction: %w", err)
+	}
+
+	if changed {
+		metadata := map[string]interface{}{
+			"post_id":    postID.String(),
+			"categories": normalizedCategories,
+		}
+		if selectedCategoryName != "" {
+			metadata["selected_category"] = selectedCategoryName
+		} else {
+			metadata["selected_category"] = nil
+		}
+		if len(autoCreatedCategories) > 0 {
+			metadata["auto_created_categories"] = autoCreatedCategories
+		}
+
+		if err := s.logBookshelfAudit(ctx, "add_to_bookshelf", userID, metadata); err != nil {
+			recordSpanError(span, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RemoveFromBookshelf soft deletes an active bookshelf item.
+func (s *BookshelfService) RemoveFromBookshelf(ctx context.Context, userID, postID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.RemoveFromBookshelf")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+	)
+	defer span.End()
+
+	if err := s.verifyBookPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE bookshelf_items
+		SET deleted_at = now()
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to remove bookshelf item: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	if rowsAffected == 0 {
+		notFoundErr := errors.New("bookshelf item not found")
+		recordSpanError(span, notFoundErr)
+		return notFoundErr
+	}
+
+	if err := s.logBookshelfAudit(ctx, "remove_from_bookshelf", userID, map[string]interface{}{
+		"post_id": postID.String(),
+	}); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	return nil
+}
+
+// GetUserBookshelf lists a user's bookshelf items with optional category filter and cursor pagination.
+func (s *BookshelfService) GetUserBookshelf(
+	ctx context.Context,
+	userID uuid.UUID,
+	category *string,
+	cursor *string,
+	limit int,
+) ([]models.BookshelfItem, *string, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.GetUserBookshelf")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+		attribute.Bool("has_category", category != nil && strings.TrimSpace(*category) != ""),
+	)
+	defer span.End()
+
+	items, nextCursor, err := s.getBookshelfItems(ctx, &userID, category, cursor, limit)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, nil, err
+	}
+	return items, nextCursor, nil
+}
+
+// GetAllBookshelfItems lists all members' bookshelf items with optional category filter and cursor pagination.
+func (s *BookshelfService) GetAllBookshelfItems(
+	ctx context.Context,
+	category *string,
+	cursor *string,
+	limit int,
+) ([]models.BookshelfItem, *string, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.GetAllBookshelfItems")
+	span.SetAttributes(
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+		attribute.Bool("has_category", category != nil && strings.TrimSpace(*category) != ""),
+	)
+	defer span.End()
+
+	items, nextCursor, err := s.getBookshelfItems(ctx, nil, category, cursor, limit)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, nil, err
+	}
+	return items, nextCursor, nil
+}
+
+// GetPostBookshelfInfo returns save count, users, and viewer bookshelf state for one post.
+func (s *BookshelfService) GetPostBookshelfInfo(ctx context.Context, postID uuid.UUID, viewerID *uuid.UUID) (*models.PostBookshelfInfo, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.GetPostBookshelfInfo")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.Bool("has_viewer", viewerID != nil),
+	)
+	if viewerID != nil {
+		span.SetAttributes(attribute.String("viewer_id", viewerID.String()))
+	}
+	defer span.End()
+
+	if err := s.verifyBookPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	var saveCount int
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT user_id)
+		FROM bookshelf_items
+		WHERE post_id = $1 AND deleted_at IS NULL
+	`, postID).Scan(&saveCount); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query bookshelf save count: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT u.id, u.username, u.profile_picture_url, MIN(bi.created_at) AS first_saved
+		FROM bookshelf_items bi
+		JOIN users u ON bi.user_id = u.id
+		WHERE bi.post_id = $1 AND bi.deleted_at IS NULL
+		GROUP BY u.id, u.username, u.profile_picture_url
+		ORDER BY first_saved ASC
+	`, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query bookshelf users: %w", err)
+	}
+	defer rows.Close()
+
+	users := make([]models.BookshelfUserInfo, 0)
+	for rows.Next() {
+		var user models.BookshelfUserInfo
+		var firstSaved sql.NullTime
+		if err := rows.Scan(&user.ID, &user.Username, &user.ProfilePictureUrl, &firstSaved); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		users = append(users, user)
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate bookshelf users: %w", err)
+	}
+
+	info := &models.PostBookshelfInfo{
+		SaveCount: saveCount,
+		Users:     users,
+	}
+
+	if viewerID != nil {
+		viewerRows, err := s.db.QueryContext(ctx, `
+			SELECT bc.name
+			FROM bookshelf_items bi
+			LEFT JOIN bookshelf_categories bc ON bc.id = bi.category_id
+			WHERE bi.post_id = $1 AND bi.user_id = $2 AND bi.deleted_at IS NULL
+			ORDER BY bi.created_at ASC, bi.id ASC
+		`, postID, *viewerID)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, fmt.Errorf("failed to query viewer bookshelf categories: %w", err)
+		}
+		defer viewerRows.Close()
+
+		for viewerRows.Next() {
+			var category sql.NullString
+			if err := viewerRows.Scan(&category); err != nil {
+				recordSpanError(span, err)
+				return nil, err
+			}
+			info.ViewerCategories = append(info.ViewerCategories, bookshelfDisplayCategoryName(category))
+		}
+		if err := viewerRows.Err(); err != nil {
+			recordSpanError(span, err)
+			return nil, fmt.Errorf("failed to iterate viewer bookshelf categories: %w", err)
+		}
+		if len(info.ViewerCategories) > 0 {
+			info.ViewerSaved = true
+		}
+	}
+
+	return info, nil
+}
+
+// GetBookshelfStatsForPosts returns bookshelf aggregation for multiple posts.
+func (s *BookshelfService) GetBookshelfStatsForPosts(
+	ctx context.Context,
+	postIDs []uuid.UUID,
+	viewerID *uuid.UUID,
+) (map[uuid.UUID]*models.PostBookshelfInfo, error) {
+	ctx, span := otel.Tracer("clubhouse.bookshelf").Start(ctx, "BookshelfService.GetBookshelfStatsForPosts")
+	span.SetAttributes(
+		attribute.Int("post_count", len(postIDs)),
+		attribute.Bool("has_viewer", viewerID != nil),
+	)
+	if viewerID != nil {
+		span.SetAttributes(attribute.String("viewer_id", viewerID.String()))
+	}
+	defer span.End()
+
+	stats := make(map[uuid.UUID]*models.PostBookshelfInfo, len(postIDs))
+	for _, postID := range postIDs {
+		stats[postID] = &models.PostBookshelfInfo{}
+	}
+	if len(postIDs) == 0 {
+		return stats, nil
+	}
+
+	viewerIDValue := uuid.Nil
+	if viewerID != nil {
+		viewerIDValue = *viewerID
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			bi.post_id,
+			COUNT(DISTINCT bi.user_id) AS save_count,
+			bool_or(bi.user_id = $2) AS viewer_saved
+		FROM bookshelf_items bi
+		WHERE bi.post_id = ANY($1) AND bi.deleted_at IS NULL
+		GROUP BY bi.post_id
+	`, pq.Array(postIDs), viewerIDValue)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query bookshelf stats: %w", err)
+	}
+	for rows.Next() {
+		var postID uuid.UUID
+		var saveCount int
+		var viewerSaved bool
+		if err := rows.Scan(&postID, &saveCount, &viewerSaved); err != nil {
+			_ = rows.Close()
+			recordSpanError(span, err)
+			return nil, err
+		}
+		if stat, ok := stats[postID]; ok {
+			stat.SaveCount = saveCount
+			stat.ViewerSaved = viewerSaved
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate bookshelf stats: %w", err)
+	}
+	_ = rows.Close()
+
+	if viewerID != nil {
+		categoryRows, err := s.db.QueryContext(ctx, `
+			SELECT bi.post_id, bc.name
+			FROM bookshelf_items bi
+			LEFT JOIN bookshelf_categories bc ON bc.id = bi.category_id
+			WHERE bi.post_id = ANY($1) AND bi.user_id = $2 AND bi.deleted_at IS NULL
+			ORDER BY bi.post_id, bi.created_at ASC, bi.id ASC
+		`, pq.Array(postIDs), *viewerID)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, fmt.Errorf("failed to query viewer bookshelf categories for stats: %w", err)
+		}
+		for categoryRows.Next() {
+			var postID uuid.UUID
+			var category sql.NullString
+			if err := categoryRows.Scan(&postID, &category); err != nil {
+				_ = categoryRows.Close()
+				recordSpanError(span, err)
+				return nil, err
+			}
+			if stat, ok := stats[postID]; ok {
+				stat.ViewerCategories = append(stat.ViewerCategories, bookshelfDisplayCategoryName(category))
+			}
+		}
+		if err := categoryRows.Err(); err != nil {
+			_ = categoryRows.Close()
+			recordSpanError(span, err)
+			return nil, fmt.Errorf("failed to iterate viewer bookshelf categories for stats: %w", err)
+		}
+		_ = categoryRows.Close()
+	}
+
+	return stats, nil
+}
+
+func (s *BookshelfService) getBookshelfItems(
+	ctx context.Context,
+	userID *uuid.UUID,
+	category *string,
+	cursor *string,
+	limit int,
+) ([]models.BookshelfItem, *string, error) {
+	if limit <= 0 || limit > maxBookshelfPageSize {
+		limit = defaultBookshelfPageSize
+	}
+
+	query := `
+		SELECT bi.id, bi.user_id, bi.post_id, bi.category_id, bi.created_at, bi.deleted_at
+		FROM bookshelf_items bi
+		JOIN posts p ON p.id = bi.post_id AND p.deleted_at IS NULL
+		LEFT JOIN bookshelf_categories bc ON bc.id = bi.category_id
+		WHERE bi.deleted_at IS NULL
+	`
+
+	args := make([]interface{}, 0, 5)
+	argIndex := 1
+
+	if userID != nil {
+		query += fmt.Sprintf(" AND bi.user_id = $%d", argIndex)
+		args = append(args, *userID)
+		argIndex++
+	}
+
+	if category != nil {
+		trimmed := strings.TrimSpace(*category)
+		if trimmed != "" {
+			if strings.EqualFold(trimmed, defaultBookshelfCategoryName) {
+				query += " AND bi.category_id IS NULL"
+			} else {
+				query += fmt.Sprintf(" AND bc.name = $%d", argIndex)
+				args = append(args, trimmed)
+				argIndex++
+			}
+		}
+	}
+
+	if cursor != nil && strings.TrimSpace(*cursor) != "" {
+		cursorCreatedAt, cursorID, hasID, err := parseBookshelfCursor(strings.TrimSpace(*cursor))
+		if err != nil {
+			return nil, nil, err
+		}
+		if hasID {
+			query += fmt.Sprintf(" AND (bi.created_at < $%d OR (bi.created_at = $%d AND bi.id < $%d))", argIndex, argIndex, argIndex+1)
+			args = append(args, cursorCreatedAt, cursorID)
+			argIndex += 2
+		} else {
+			query += fmt.Sprintf(" AND bi.created_at < $%d", argIndex)
+			args = append(args, cursorCreatedAt)
+			argIndex++
+		}
+	}
+
+	query += fmt.Sprintf(" ORDER BY bi.created_at DESC, bi.id DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query bookshelf items: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]models.BookshelfItem, 0, limit)
+	for rows.Next() {
+		item, err := scanBookshelfItem(rows)
+		if err != nil {
+			return nil, nil, err
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("failed to iterate bookshelf items: %w", err)
+	}
+
+	hasMore := len(items) > limit
+	if hasMore {
+		items = items[:limit]
+	}
+
+	var nextCursor *string
+	if hasMore && len(items) > 0 {
+		cursorValue := buildBookshelfCursor(items[len(items)-1].CreatedAt, items[len(items)-1].ID)
+		nextCursor = &cursorValue
+	}
+
+	return items, nextCursor, nil
+}
+
+func (s *BookshelfService) resolveBookshelfCategories(
+	ctx context.Context,
+	tx *sql.Tx,
+	userID uuid.UUID,
+	categories []string,
+) (*uuid.UUID, string, []string, error) {
+	if len(categories) == 0 {
+		return nil, "", nil, nil
+	}
+
+	createdNames := make([]string, 0)
+	resolvedIDs := make(map[string]uuid.UUID, len(categories))
+	for _, categoryName := range categories {
+		var categoryID uuid.UUID
+		err := tx.QueryRowContext(
+			ctx,
+			"SELECT id FROM bookshelf_categories WHERE user_id = $1 AND name = $2",
+			userID,
+			categoryName,
+		).Scan(&categoryID)
+		if err == nil {
+			resolvedIDs[categoryName] = categoryID
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, "", nil, fmt.Errorf("failed to query bookshelf category: %w", err)
+		}
+
+		position, err := s.nextBookshelfCategoryPosition(ctx, tx, userID)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		categoryID = uuid.New()
+		_, err = tx.ExecContext(
+			ctx,
+			`INSERT INTO bookshelf_categories (id, user_id, name, position, created_at)
+			VALUES ($1, $2, $3, $4, now())`,
+			categoryID,
+			userID,
+			categoryName,
+			position,
+		)
+		if err != nil {
+			var pqErr *pq.Error
+			if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+				if selectErr := tx.QueryRowContext(
+					ctx,
+					"SELECT id FROM bookshelf_categories WHERE user_id = $1 AND name = $2",
+					userID,
+					categoryName,
+				).Scan(&categoryID); selectErr != nil {
+					return nil, "", nil, fmt.Errorf("failed to resolve concurrent bookshelf category create: %w", selectErr)
+				}
+			} else {
+				return nil, "", nil, fmt.Errorf("failed to auto-create bookshelf category: %w", err)
+			}
+		} else {
+			createdNames = append(createdNames, categoryName)
+		}
+
+		resolvedIDs[categoryName] = categoryID
+	}
+
+	selected := categories[0]
+	selectedID := resolvedIDs[selected]
+	return &selectedID, selected, createdNames, nil
+}
+
+func (s *BookshelfService) nextBookshelfCategoryPosition(ctx context.Context, queryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+}, userID uuid.UUID) (int, error) {
+	var next int
+	if err := queryer.QueryRowContext(
+		ctx,
+		"SELECT COALESCE(MAX(position), -1) + 1 FROM bookshelf_categories WHERE user_id = $1",
+		userID,
+	).Scan(&next); err != nil {
+		return 0, fmt.Errorf("failed to fetch next bookshelf category position: %w", err)
+	}
+	return next, nil
+}
+
+func (s *BookshelfService) verifyBookPost(ctx context.Context, postID uuid.UUID) error {
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM posts p
+			JOIN sections s ON p.section_id = s.id
+			WHERE p.id = $1 AND p.deleted_at IS NULL AND s.type = 'book'
+		)
+	`, postID).Scan(&exists); err != nil {
+		return fmt.Errorf("failed to verify book post: %w", err)
+	}
+	if !exists {
+		return errors.New("book post not found")
+	}
+	return nil
+}
+
+func (s *BookshelfService) logBookshelfAudit(ctx context.Context, action string, userID uuid.UUID, metadata map[string]interface{}) error {
+	if err := s.audit.LogAuditWithMetadata(ctx, action, uuid.Nil, userID, metadata); err != nil {
+		return fmt.Errorf("failed to create bookshelf audit log: %w", err)
+	}
+	return nil
+}
+
+func scanBookshelfItem(scanner interface {
+	Scan(dest ...interface{}) error
+}) (*models.BookshelfItem, error) {
+	var (
+		item           models.BookshelfItem
+		categoryID     uuid.NullUUID
+		deletedAtValue sql.NullTime
+	)
+	if err := scanner.Scan(
+		&item.ID,
+		&item.UserID,
+		&item.PostID,
+		&categoryID,
+		&item.CreatedAt,
+		&deletedAtValue,
+	); err != nil {
+		return nil, err
+	}
+
+	if categoryID.Valid {
+		item.CategoryID = &categoryID.UUID
+	}
+	if deletedAtValue.Valid {
+		deletedAt := deletedAtValue.Time
+		item.DeletedAt = &deletedAt
+	}
+
+	return &item, nil
+}
+
+func normalizeBookshelfCategoryName(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", errors.New("category name is required")
+	}
+	if strings.EqualFold(trimmed, defaultBookshelfCategoryName) {
+		return "", errors.New("category name is reserved")
+	}
+	if len(trimmed) > maxBookshelfCategoryNameLimit {
+		return "", fmt.Errorf("category name must be %d characters or less", maxBookshelfCategoryNameLimit)
+	}
+	return trimmed, nil
+}
+
+func normalizeBookshelfCategoriesForAdd(categories []string) ([]string, error) {
+	if len(categories) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(categories))
+	normalized := make([]string, 0, len(categories))
+	for _, category := range categories {
+		trimmed := strings.TrimSpace(category)
+		if trimmed == "" || strings.EqualFold(trimmed, defaultBookshelfCategoryName) {
+			continue
+		}
+		if len(trimmed) > maxBookshelfCategoryNameLimit {
+			return nil, fmt.Errorf("category name must be %d characters or less", maxBookshelfCategoryNameLimit)
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+
+	return normalized, nil
+}
+
+func equalUUIDPointers(left *uuid.UUID, right *uuid.UUID) bool {
+	if left == nil && right == nil {
+		return true
+	}
+	if left == nil || right == nil {
+		return false
+	}
+	return *left == *right
+}
+
+func uuidPointerValue(value *uuid.UUID) interface{} {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func bookshelfDisplayCategoryName(name sql.NullString) string {
+	if name.Valid && strings.TrimSpace(name.String) != "" {
+		return name.String
+	}
+	return defaultBookshelfCategoryName
+}
+
+func parseBookshelfCursor(cursor string) (time.Time, uuid.UUID, bool, error) {
+	parts := strings.Split(cursor, bookshelfCursorSeparator)
+	switch len(parts) {
+	case 1:
+		createdAt, err := parseBookshelfCursorTime(parts[0])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		return createdAt, uuid.Nil, false, nil
+	case 2:
+		createdAt, err := parseBookshelfCursorTime(parts[0])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		cursorID, err := uuid.Parse(parts[1])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		return createdAt, cursorID, true, nil
+	default:
+		return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+	}
+}
+
+func parseBookshelfCursorTime(raw string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err == nil {
+		return parsed, nil
+	}
+	return time.Parse("2006-01-02T15:04:05.000Z07:00", raw)
+}
+
+func buildBookshelfCursor(createdAt time.Time, itemID uuid.UUID) string {
+	return fmt.Sprintf("%s%s%s", createdAt.UTC().Format(time.RFC3339Nano), bookshelfCursorSeparator, itemID.String())
+}

--- a/backend/internal/services/bookshelf_test.go
+++ b/backend/internal/services/bookshelf_test.go
@@ -1,0 +1,407 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestBookshelfAddRemoveAndAudit(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfaddremove", "bookshelfaddremove@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book post"))
+
+	service := NewBookshelfService(db)
+	if err := service.AddToBookshelf(context.Background(), userID, postID, []string{"Favorites"}); err != nil {
+		t.Fatalf("AddToBookshelf failed: %v", err)
+	}
+
+	if err := service.RemoveFromBookshelf(context.Background(), userID, postID); err != nil {
+		t.Fatalf("RemoveFromBookshelf failed: %v", err)
+	}
+
+	var activeCount int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM bookshelf_items
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`, userID, postID).Scan(&activeCount); err != nil {
+		t.Fatalf("failed to query active bookshelf items: %v", err)
+	}
+	if activeCount != 0 {
+		t.Fatalf("expected 0 active bookshelf items, got %d", activeCount)
+	}
+
+	addMetadata := mustQueryAuditMetadata(t, db, "add_to_bookshelf", userID)
+	if addMetadata["post_id"] != postID.String() {
+		t.Fatalf("expected add_to_bookshelf post_id %s, got %v", postID.String(), addMetadata["post_id"])
+	}
+
+	removeMetadata := mustQueryAuditMetadata(t, db, "remove_from_bookshelf", userID)
+	if removeMetadata["post_id"] != postID.String() {
+		t.Fatalf("expected remove_from_bookshelf post_id %s, got %v", postID.String(), removeMetadata["post_id"])
+	}
+}
+
+func TestBookshelfCategoryCRUDWithDeleteRecategorization(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfcategory", "bookshelfcategory@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book post"))
+
+	service := NewBookshelfService(db)
+	category, err := service.CreateCategory(context.Background(), userID, "To Read")
+	if err != nil {
+		t.Fatalf("CreateCategory failed: %v", err)
+	}
+
+	updated, err := service.UpdateCategory(context.Background(), userID, category.ID, models.UpdateBookshelfCategoryRequest{
+		Name:     "Shelf A",
+		Position: 3,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCategory failed: %v", err)
+	}
+	if updated.Name != "Shelf A" || updated.Position != 3 {
+		t.Fatalf("unexpected updated category: %+v", updated)
+	}
+
+	if err := service.AddToBookshelf(context.Background(), userID, postID, []string{"Shelf A"}); err != nil {
+		t.Fatalf("AddToBookshelf failed: %v", err)
+	}
+
+	if err := service.DeleteCategory(context.Background(), userID, category.ID); err != nil {
+		t.Fatalf("DeleteCategory failed: %v", err)
+	}
+
+	var categoryID uuid.NullUUID
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT category_id
+		FROM bookshelf_items
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`, userID, postID).Scan(&categoryID); err != nil {
+		t.Fatalf("failed to query bookshelf item category: %v", err)
+	}
+	if categoryID.Valid {
+		t.Fatalf("expected category_id NULL after delete, got %s", categoryID.UUID.String())
+	}
+
+	createMetadata := mustQueryAuditMetadata(t, db, "create_bookshelf_category", userID)
+	if createMetadata["category_name"] != "To Read" {
+		t.Fatalf("expected create category_name To Read, got %v", createMetadata["category_name"])
+	}
+
+	updateMetadata := mustQueryAuditMetadata(t, db, "update_bookshelf_category", userID)
+	changesRaw, ok := updateMetadata["changes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected update changes object, got %T", updateMetadata["changes"])
+	}
+	if changesRaw["name"] != "Shelf A" {
+		t.Fatalf("expected updated name Shelf A, got %v", changesRaw["name"])
+	}
+
+	deleteMetadata := mustQueryAuditMetadata(t, db, "delete_bookshelf_category", userID)
+	if deleteMetadata["category_id"] != category.ID.String() {
+		t.Fatalf("expected delete category_id %s, got %v", category.ID.String(), deleteMetadata["category_id"])
+	}
+	if deleteMetadata["category_name"] != "Shelf A" {
+		t.Fatalf("expected delete category_name Shelf A, got %v", deleteMetadata["category_name"])
+	}
+}
+
+func TestBookshelfReorderCategories(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfreorder", "bookshelfreorder@test.com", false, true))
+	service := NewBookshelfService(db)
+
+	categoryOne, err := service.CreateCategory(context.Background(), userID, "One")
+	if err != nil {
+		t.Fatalf("CreateCategory One failed: %v", err)
+	}
+	categoryTwo, err := service.CreateCategory(context.Background(), userID, "Two")
+	if err != nil {
+		t.Fatalf("CreateCategory Two failed: %v", err)
+	}
+	categoryThree, err := service.CreateCategory(context.Background(), userID, "Three")
+	if err != nil {
+		t.Fatalf("CreateCategory Three failed: %v", err)
+	}
+
+	if err := service.ReorderCategories(context.Background(), userID, []uuid.UUID{
+		categoryThree.ID,
+		categoryOne.ID,
+		categoryTwo.ID,
+	}); err != nil {
+		t.Fatalf("ReorderCategories failed: %v", err)
+	}
+
+	categories, err := service.GetCategories(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("GetCategories failed: %v", err)
+	}
+	if len(categories) != 3 {
+		t.Fatalf("expected 3 categories, got %d", len(categories))
+	}
+	if categories[0].ID != categoryThree.ID || categories[0].Position != 0 {
+		t.Fatalf("unexpected first category after reorder: %+v", categories[0])
+	}
+	if categories[1].ID != categoryOne.ID || categories[1].Position != 1 {
+		t.Fatalf("unexpected second category after reorder: %+v", categories[1])
+	}
+	if categories[2].ID != categoryTwo.ID || categories[2].Position != 2 {
+		t.Fatalf("unexpected third category after reorder: %+v", categories[2])
+	}
+}
+
+func TestBookshelfAutoCreateCategoriesOnAdd(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfautocreate", "bookshelfautocreate@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book post"))
+
+	service := NewBookshelfService(db)
+	if err := service.AddToBookshelf(context.Background(), userID, postID, []string{"Auto Shelf"}); err != nil {
+		t.Fatalf("AddToBookshelf failed: %v", err)
+	}
+
+	var (
+		categoryID   uuid.UUID
+		categoryName string
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT bc.id, bc.name
+		FROM bookshelf_items bi
+		JOIN bookshelf_categories bc ON bc.id = bi.category_id
+		WHERE bi.user_id = $1 AND bi.post_id = $2 AND bi.deleted_at IS NULL
+	`, userID, postID).Scan(&categoryID, &categoryName); err != nil {
+		t.Fatalf("failed to query auto-created category mapping: %v", err)
+	}
+	if categoryName != "Auto Shelf" {
+		t.Fatalf("expected Auto Shelf category, got %s", categoryName)
+	}
+
+	var categoryCount int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*) FROM bookshelf_categories WHERE user_id = $1
+	`, userID).Scan(&categoryCount); err != nil {
+		t.Fatalf("failed to query category count: %v", err)
+	}
+	if categoryCount != 1 {
+		t.Fatalf("expected 1 auto-created category, got %d", categoryCount)
+	}
+
+	metadata := mustQueryAuditMetadata(t, db, "add_to_bookshelf", userID)
+	autoCreated, ok := metadata["auto_created_categories"].([]interface{})
+	if !ok || len(autoCreated) != 1 || autoCreated[0] != "Auto Shelf" {
+		t.Fatalf("expected auto_created_categories [Auto Shelf], got %v", metadata["auto_created_categories"])
+	}
+}
+
+func TestBookshelfSoftDeleteAndReAddRestoresItem(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfrestore", "bookshelfrestore@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book post"))
+
+	service := NewBookshelfService(db)
+	if err := service.AddToBookshelf(context.Background(), userID, postID, nil); err != nil {
+		t.Fatalf("initial AddToBookshelf failed: %v", err)
+	}
+	if err := service.RemoveFromBookshelf(context.Background(), userID, postID); err != nil {
+		t.Fatalf("RemoveFromBookshelf failed: %v", err)
+	}
+
+	var deletedItemID uuid.UUID
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT id
+		FROM bookshelf_items
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NOT NULL
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+	`, userID, postID).Scan(&deletedItemID); err != nil {
+		t.Fatalf("failed to query deleted bookshelf item: %v", err)
+	}
+
+	if err := service.AddToBookshelf(context.Background(), userID, postID, []string{"Restored Shelf"}); err != nil {
+		t.Fatalf("re-add AddToBookshelf failed: %v", err)
+	}
+
+	var (
+		activeItemID    uuid.UUID
+		activeDeletedAt sql.NullTime
+	)
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT id, deleted_at
+		FROM bookshelf_items
+		WHERE user_id = $1 AND post_id = $2
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+	`, userID, postID).Scan(&activeItemID, &activeDeletedAt); err != nil {
+		t.Fatalf("failed to query restored bookshelf item: %v", err)
+	}
+	if activeItemID != deletedItemID {
+		t.Fatalf("expected restored item ID %s, got %s", deletedItemID, activeItemID)
+	}
+	if activeDeletedAt.Valid {
+		t.Fatalf("expected restored item deleted_at to be NULL")
+	}
+}
+
+func TestGetBookshelfStatsForPostsAggregation(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfstatsa", "bookshelfstatsa@test.com", false, true))
+	userB := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelfstatsb", "bookshelfstatsb@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postOne := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Book one"))
+	postTwo := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Book two"))
+
+	service := NewBookshelfService(db)
+	if err := service.AddToBookshelf(context.Background(), userA, postOne, []string{"Favorites"}); err != nil {
+		t.Fatalf("AddToBookshelf userA postOne failed: %v", err)
+	}
+	if err := service.AddToBookshelf(context.Background(), userB, postOne, nil); err != nil {
+		t.Fatalf("AddToBookshelf userB postOne failed: %v", err)
+	}
+	if err := service.AddToBookshelf(context.Background(), userA, postTwo, nil); err != nil {
+		t.Fatalf("AddToBookshelf userA postTwo failed: %v", err)
+	}
+
+	stats, err := service.GetBookshelfStatsForPosts(context.Background(), []uuid.UUID{postOne, postTwo}, &userA)
+	if err != nil {
+		t.Fatalf("GetBookshelfStatsForPosts failed: %v", err)
+	}
+
+	postOneStats := stats[postOne]
+	if postOneStats == nil {
+		t.Fatalf("expected stats for post one")
+	}
+	if postOneStats.SaveCount != 2 {
+		t.Fatalf("expected post one save_count 2, got %d", postOneStats.SaveCount)
+	}
+	if !postOneStats.ViewerSaved {
+		t.Fatalf("expected post one ViewerSaved true")
+	}
+	if len(postOneStats.ViewerCategories) != 1 || postOneStats.ViewerCategories[0] != "Favorites" {
+		t.Fatalf("expected post one viewer categories [Favorites], got %v", postOneStats.ViewerCategories)
+	}
+
+	postTwoStats := stats[postTwo]
+	if postTwoStats == nil {
+		t.Fatalf("expected stats for post two")
+	}
+	if postTwoStats.SaveCount != 1 {
+		t.Fatalf("expected post two save_count 1, got %d", postTwoStats.SaveCount)
+	}
+	if !postTwoStats.ViewerSaved {
+		t.Fatalf("expected post two ViewerSaved true")
+	}
+	if len(postTwoStats.ViewerCategories) != 1 || postTwoStats.ViewerCategories[0] != defaultBookshelfCategoryName {
+		t.Fatalf("expected post two viewer categories [%s], got %v", defaultBookshelfCategoryName, postTwoStats.ViewerCategories)
+	}
+}
+
+func TestGetUserAndAllBookshelfItemsPagination(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelflista", "bookshelflista@test.com", false, true))
+	userB := uuid.MustParse(testutil.CreateTestUser(t, db, "bookshelflistb", "bookshelflistb@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postOne := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Book one"))
+	postTwo := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Book two"))
+	postThree := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Book three"))
+
+	service := NewBookshelfService(db)
+	if err := service.AddToBookshelf(context.Background(), userA, postOne, []string{"Favorites"}); err != nil {
+		t.Fatalf("AddToBookshelf postOne failed: %v", err)
+	}
+	if err := service.AddToBookshelf(context.Background(), userA, postTwo, nil); err != nil {
+		t.Fatalf("AddToBookshelf postTwo failed: %v", err)
+	}
+	if err := service.AddToBookshelf(context.Background(), userB, postThree, []string{"Favorites"}); err != nil {
+		t.Fatalf("AddToBookshelf postThree failed: %v", err)
+	}
+
+	pageOne, nextCursor, err := service.GetUserBookshelf(context.Background(), userA, nil, nil, 1)
+	if err != nil {
+		t.Fatalf("GetUserBookshelf page one failed: %v", err)
+	}
+	if len(pageOne) != 1 {
+		t.Fatalf("expected 1 item on page one, got %d", len(pageOne))
+	}
+	if nextCursor == nil || *nextCursor == "" {
+		t.Fatalf("expected next cursor on page one")
+	}
+
+	pageTwo, finalCursor, err := service.GetUserBookshelf(context.Background(), userA, nil, nextCursor, 1)
+	if err != nil {
+		t.Fatalf("GetUserBookshelf page two failed: %v", err)
+	}
+	if len(pageTwo) != 1 {
+		t.Fatalf("expected 1 item on page two, got %d", len(pageTwo))
+	}
+	if finalCursor != nil {
+		t.Fatalf("expected no cursor on final page")
+	}
+
+	favorites := "Favorites"
+	allFavorites, allCursor, err := service.GetAllBookshelfItems(context.Background(), &favorites, nil, 10)
+	if err != nil {
+		t.Fatalf("GetAllBookshelfItems failed: %v", err)
+	}
+	if len(allFavorites) != 2 {
+		t.Fatalf("expected 2 favorites entries across users, got %d", len(allFavorites))
+	}
+	if allCursor != nil {
+		t.Fatalf("expected no next cursor for full favorites page")
+	}
+
+	uncategorized := defaultBookshelfCategoryName
+	userUncategorized, _, err := service.GetUserBookshelf(context.Background(), userA, &uncategorized, nil, 10)
+	if err != nil {
+		t.Fatalf("GetUserBookshelf uncategorized filter failed: %v", err)
+	}
+	if len(userUncategorized) != 1 || userUncategorized[0].PostID != postTwo {
+		t.Fatalf("expected uncategorized result for post %s, got %+v", postTwo.String(), userUncategorized)
+	}
+}
+
+func mustQueryAuditMetadata(t *testing.T, db *sql.DB, action string, userID uuid.UUID) map[string]interface{} {
+	t.Helper()
+
+	var raw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = $1 AND target_user_id = $2
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, action, userID).Scan(&raw); err != nil {
+		t.Fatalf("failed to query audit log for action %s: %v", action, err)
+	}
+
+	metadata := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal audit metadata for action %s: %v", action, err)
+	}
+
+	return metadata
+}


### PR DESCRIPTION
## Summary
- add `BookshelfService` in `backend/internal/services/bookshelf.go` with category CRUD + reorder, item add/remove, user/all listing with cursor pagination, post bookshelf info, and multi-post bookshelf stats aggregation
- implement bookshelf business rules: auto-create missing categories on add, soft-delete + restore behavior, and category deletion recategorization to uncategorized (`NULL category_id`)
- add audit logging for required actions: `add_to_bookshelf`, `remove_from_bookshelf`, `create_bookshelf_category`, `update_bookshelf_category`, and `delete_bookshelf_category`
- add OpenTelemetry spans/attributes and consistent error recording for all service operations
- add `backend/internal/services/bookshelf_test.go` covering add/remove, category CRUD, reorder, auto-create, soft-delete/re-add restore, pagination/filtering, stats aggregation, and audit metadata assertions

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run 'Bookshelf' -v`
- `cd backend && go test ./...`

Closes #860