### PR TITLE
[Books] Add spoiler flag to comments migration

### DIFF
--- a/backend/migrations/041_add_spoiler_flag_to_comments.down.sql
+++ b/backend/migrations/041_add_spoiler_flag_to_comments.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comments DROP COLUMN contains_spoiler;

--- a/backend/migrations/041_add_spoiler_flag_to_comments.up.sql
+++ b/backend/migrations/041_add_spoiler_flag_to_comments.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comments ADD COLUMN contains_spoiler BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- add migration `041_add_spoiler_flag_to_comments` to add `contains_spoiler` on `comments`
- set `contains_spoiler` to `BOOLEAN NOT NULL DEFAULT false` so existing rows remain unaffected
- add down migration to drop the column

## Validation
- `cd backend && go build ./...`

Closes #883