### PR TITLE
[Books] Create BookCard component

### DIFF
--- a/frontend/src/components/books/BookCard.svelte
+++ b/frontend/src/components/books/BookCard.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  type BookData = {
+    title?: string;
+    authors?: string[];
+    description?: string;
+    coverUrl?: string;
+    cover_url?: string;
+    pageCount?: number;
+    page_count?: number;
+    genres?: string[];
+    publishDate?: string;
+    publish_date?: string;
+    openLibraryKey?: string;
+    open_library_key?: string;
+    goodreadsUrl?: string;
+    goodreads_url?: string;
+  };
+
+  export let bookData: BookData = {};
+  export let compact = false;
+
+  let descriptionExpanded = false;
+  let previousDescription = '';
+
+  $: title = bookData.title?.trim() || 'Untitled book';
+  $: authors = (bookData.authors ?? []).filter(
+    (author): author is string => typeof author === 'string' && author.trim().length > 0
+  );
+  $: authorsLabel = authors.length > 0 ? authors.join(', ') : 'Unknown author';
+  $: description = bookData.description?.trim() ?? '';
+  $: if (description !== previousDescription) {
+    previousDescription = description;
+    descriptionExpanded = false;
+  }
+  $: descriptionLineClampClass = descriptionExpanded ? '' : compact ? 'line-clamp-2' : 'line-clamp-3';
+  $: showDescriptionToggle = description.length > (compact ? 120 : 180);
+  $: coverUrl = normalizeURL(bookData.coverUrl ?? bookData.cover_url);
+  $: pageCount = normalizePositiveInteger(bookData.pageCount ?? bookData.page_count);
+  $: publishYear = extractPublishYear(bookData.publishDate ?? bookData.publish_date);
+  $: details = [
+    typeof pageCount === 'number' ? `${pageCount} pages` : null,
+    publishYear,
+  ].filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  $: visibleGenres = (bookData.genres ?? [])
+    .filter((genre): genre is string => typeof genre === 'string' && genre.trim().length > 0)
+    .slice(0, 3);
+  $: goodreadsUrl = normalizeURL(bookData.goodreadsUrl ?? bookData.goodreads_url);
+  $: openLibraryUrl = resolveOpenLibraryURL(bookData.openLibraryKey ?? bookData.open_library_key);
+  $: titleUrl = goodreadsUrl ?? openLibraryUrl;
+
+  function normalizeURL(value?: string): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  function normalizePositiveInteger(value: unknown): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return null;
+    }
+    const rounded = Math.round(value);
+    return rounded > 0 ? rounded : null;
+  }
+
+  function extractPublishYear(value?: string): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const match = value.trim().match(/\b(\d{4})\b/);
+    return match ? match[1] : null;
+  }
+
+  function resolveOpenLibraryURL(openLibraryKey?: string): string | null {
+    if (typeof openLibraryKey !== 'string') {
+      return null;
+    }
+    const trimmed = openLibraryKey.trim();
+    if (!trimmed) {
+      return null;
+    }
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+      return trimmed;
+    }
+
+    const prefixed = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    if (/^\/works\/ol[0-9a-z]+w$/i.test(prefixed) || /^\/books\/ol[0-9a-z]+m$/i.test(prefixed)) {
+      return `https://openlibrary.org${prefixed}`;
+    }
+    if (/^ol[0-9a-z]+w$/i.test(trimmed)) {
+      return `https://openlibrary.org/works/${trimmed.toUpperCase()}`;
+    }
+    if (/^ol[0-9a-z]+m$/i.test(trimmed)) {
+      return `https://openlibrary.org/books/${trimmed.toUpperCase()}`;
+    }
+    return `https://openlibrary.org${prefixed}`;
+  }
+</script>
+
+<article class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" data-testid="book-card">
+  <div class={`flex flex-col gap-4 p-4 ${compact ? 'sm:p-4' : 'sm:p-5'} sm:flex-row sm:items-start`}>
+    <div
+      class={`w-full shrink-0 overflow-hidden rounded-lg bg-slate-100 ${
+        compact ? 'h-44 sm:h-36 sm:w-24' : 'h-56 sm:h-44 sm:w-[120px]'
+      }`}
+    >
+      {#if coverUrl}
+        <img
+          src={coverUrl}
+          alt={`${title} cover`}
+          class="h-full w-full object-cover"
+          loading="lazy"
+          data-testid="book-cover"
+        />
+      {:else}
+        <div
+          class="flex h-full w-full items-center justify-center px-4 text-center text-sm font-medium text-slate-600"
+          data-testid="book-cover-fallback"
+        >
+          Cover unavailable
+        </div>
+      {/if}
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <h3 class={`font-semibold text-slate-900 ${compact ? 'text-base' : 'text-lg'}`} data-testid="book-title">
+        {#if titleUrl}
+          <a
+            href={titleUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline-offset-2 hover:text-slate-700 hover:underline"
+          >
+            {title}
+          </a>
+        {:else}
+          {title}
+        {/if}
+      </h3>
+
+      <p class="mt-1 text-sm text-slate-700" data-testid="book-authors">{authorsLabel}</p>
+
+      {#if details.length > 0}
+        <p class="mt-1 text-xs text-slate-600" data-testid="book-details">{details.join(' · ')}</p>
+      {/if}
+
+      {#if description}
+        <div class="mt-3">
+          <p
+            class={`text-sm leading-relaxed text-slate-700 ${descriptionLineClampClass}`}
+            data-testid="book-description"
+          >
+            {description}
+          </p>
+          {#if showDescriptionToggle}
+            <button
+              type="button"
+              class="mt-1 text-xs font-medium text-slate-600 underline-offset-2 hover:text-slate-800 hover:underline"
+              on:click={() => (descriptionExpanded = !descriptionExpanded)}
+              data-testid="book-description-toggle"
+            >
+              {descriptionExpanded ? 'Show less' : 'Show more'}
+            </button>
+          {/if}
+        </div>
+      {/if}
+
+      {#if visibleGenres.length > 0}
+        <div class="mt-3 flex flex-wrap gap-2" data-testid="book-genres">
+          {#each visibleGenres as genre}
+            <span class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+              {genre}
+            </span>
+          {/each}
+        </div>
+      {/if}
+
+      {#if goodreadsUrl || openLibraryUrl}
+        <div class="mt-4 flex flex-wrap items-center gap-3">
+          {#if goodreadsUrl}
+            <a
+              href={goodreadsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="rounded-full bg-emerald-600 px-4 py-2 text-xs font-semibold text-white hover:bg-emerald-700"
+              data-testid="book-goodreads-link"
+            >
+              View on Goodreads
+            </a>
+          {/if}
+          {#if openLibraryUrl}
+            <a
+              href={openLibraryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xs font-medium text-slate-600 underline-offset-2 hover:text-slate-800 hover:underline"
+              data-testid="book-open-library-link"
+            >
+              View on Open Library
+            </a>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+</article>

--- a/frontend/src/components/books/BookCard.test.ts
+++ b/frontend/src/components/books/BookCard.test.ts
@@ -1,0 +1,88 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const { default: BookCard } = await import('./BookCard.svelte');
+
+type BookData = {
+  title?: string;
+  authors?: string[];
+  description?: string;
+  cover_url?: string;
+  page_count?: number;
+  genres?: string[];
+  publish_date?: string;
+  goodreads_url?: string;
+  open_library_key?: string;
+};
+
+const fullBookData: BookData = {
+  title: 'Neuromancer',
+  authors: ['William Gibson', 'Jane Doe'],
+  description:
+    'A cyberpunk classic that helped define the genre and follows a washed-up hacker pulled into a final dangerous heist.',
+  cover_url: 'https://covers.openlibrary.org/b/id/12345-L.jpg',
+  page_count: 271,
+  genres: ['Science Fiction', 'Cyberpunk', 'Noir', 'Thriller'],
+  publish_date: '1984-07-01',
+  goodreads_url: 'https://www.goodreads.com/book/show/22328-neuromancer',
+  open_library_key: '/works/OL45883W',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BookCard', () => {
+  it('renders title, authors, and description', () => {
+    render(BookCard, { bookData: fullBookData });
+
+    expect(screen.getByTestId('book-title')).toHaveTextContent('Neuromancer');
+    expect(screen.getByTestId('book-authors')).toHaveTextContent('William Gibson, Jane Doe');
+    expect(screen.getByTestId('book-description')).toHaveTextContent('A cyberpunk classic');
+    expect(screen.getByTestId('book-details')).toHaveTextContent('271 pages · 1984');
+  });
+
+  it('displays the cover image when provided', () => {
+    render(BookCard, { bookData: fullBookData });
+
+    const cover = screen.getByTestId('book-cover');
+    expect(cover).toHaveAttribute('src', 'https://covers.openlibrary.org/b/id/12345-L.jpg');
+    expect(cover).toHaveAttribute('alt', 'Neuromancer cover');
+  });
+
+  it('shows Goodreads button when Goodreads URL is available', () => {
+    render(BookCard, { bookData: fullBookData });
+
+    const goodreadsLink = screen.getByTestId('book-goodreads-link');
+    expect(goodreadsLink).toHaveAttribute(
+      'href',
+      'https://www.goodreads.com/book/show/22328-neuromancer'
+    );
+    expect(goodreadsLink).toHaveTextContent('View on Goodreads');
+  });
+
+  it('uses compact description truncation class in compact mode', () => {
+    render(BookCard, {
+      bookData: fullBookData,
+      compact: true,
+    });
+
+    expect(screen.getByTestId('book-description')).toHaveClass('line-clamp-2');
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    render(BookCard, {
+      bookData: {
+        title: 'Title only',
+      },
+    });
+
+    expect(screen.getByTestId('book-title')).toHaveTextContent('Title only');
+    expect(screen.getByTestId('book-authors')).toHaveTextContent('Unknown author');
+    expect(screen.getByTestId('book-cover-fallback')).toBeInTheDocument();
+    expect(screen.queryByTestId('book-details')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('book-description')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('book-goodreads-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('book-open-library-link')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/books/BookCard.test.ts
+++ b/frontend/src/components/books/BookCard.test.ts
@@ -34,9 +34,13 @@ afterEach(() => {
 
 describe('BookCard', () => {
   it('renders title, authors, and description', () => {
-    render(BookCard, { bookData: fullBookData });
+    render(BookCard, {
+      bookData: fullBookData,
+      threadHref: '/sections/books/posts/post-123',
+    });
 
     expect(screen.getByTestId('book-title')).toHaveTextContent('Neuromancer');
+    expect(screen.getByTestId('book-thread-link')).toHaveAttribute('href', '/sections/books/posts/post-123');
     expect(screen.getByTestId('book-authors')).toHaveTextContent('William Gibson, Jane Doe');
     expect(screen.getByTestId('book-description')).toHaveTextContent('A cyberpunk classic');
     expect(screen.getByTestId('book-details')).toHaveTextContent('271 pages · 1984');
@@ -59,6 +63,19 @@ describe('BookCard', () => {
       'https://www.goodreads.com/book/show/22328-neuromancer'
     );
     expect(goodreadsLink).toHaveTextContent('View on Goodreads');
+  });
+
+  it('does not render unsafe or mislabeled external links', () => {
+    render(BookCard, {
+      bookData: {
+        ...fullBookData,
+        goodreads_url: 'javascript:alert(1)',
+        open_library_key: 'https://evil.example/works/OL45883W',
+      },
+    });
+
+    expect(screen.queryByTestId('book-goodreads-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('book-open-library-link')).not.toBeInTheDocument();
   });
 
   it('uses compact description truncation class in compact mode', () => {


### PR DESCRIPTION
## Summary
- add `BookCard.svelte` under `frontend/src/components/books/` with responsive layout, compact mode, 3-line/2-line description truncation, description expand toggle, and genre chips limited to three
- support both snake_case and camelCase metadata keys for enriched `book_data` payloads
- render conditional external links for Goodreads and Open Library, including Open Library key normalization to valid URLs

## Tests
- `npm run test -- src/components/books/BookCard.test.ts`
- `npm run check`
- `npx eslint src/components/books/BookCard.svelte src/components/books/BookCard.test.ts`

Closes #868