### PR TITLE
[Books] Create read log handler

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -168,6 +168,8 @@ func main() {
 	highlightReactionHandler := handlers.NewHighlightReactionHandler(dbConn, redisConn)
 	cookLogHandler := handlers.NewCookLogHandler(dbConn, redisConn)
 	watchLogHandler := handlers.NewWatchLogHandler(dbConn, redisConn)
+	readLogService := services.NewReadLogService(dbConn)
+	readLogHandler := handlers.NewReadLogHandler(readLogService)
 	userHandler := handlers.NewUserHandler(dbConn)
 	sectionHandler := handlers.NewSectionHandler(dbConn)
 	searchHandler := handlers.NewSearchHandler(dbConn)
@@ -328,6 +330,10 @@ func main() {
 		updateWatchLog:          watchLogHandler.UpdateWatchLog,
 		removeWatchLog:          watchLogHandler.RemoveWatchLog,
 		getWatchLogs:            watchLogHandler.GetPostWatchLogs,
+		logRead:                 readLogHandler.LogRead,
+		updateReadLog:           readLogHandler.UpdateReadLog,
+		removeReadLog:           readLogHandler.RemoveReadLog,
+		getReadLogs:             readLogHandler.GetPostReadLogs,
 		getPost:                 postHandler.GetPost,
 		updatePost:              postHandler.UpdatePost,
 		deletePost:              postHandler.DeletePost,
@@ -403,6 +409,7 @@ func main() {
 	// Cook log routes (protected)
 	mux.Handle("/api/v1/me/cook-logs", requireAuth(http.HandlerFunc(cookLogHandler.GetMyCookLogs)))
 	mux.Handle("/api/v1/me/watch-logs", requireAuth(http.HandlerFunc(watchLogHandler.GetMyWatchLogs)))
+	mux.Handle("/api/v1/read-history", requireAuth(http.HandlerFunc(readLogHandler.GetReadHistory)))
 
 	// Link preview route (protected with CSRF - POST only, prevents SSRF)
 	mux.Handle("/api/v1/links/preview", requireAuthCSRF(http.HandlerFunc(linkHandler.PreviewLink)))

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -32,6 +32,10 @@ type postRouteDeps struct {
 	updateWatchLog          http.HandlerFunc
 	removeWatchLog          http.HandlerFunc
 	getWatchLogs            http.HandlerFunc
+	logRead                 http.HandlerFunc
+	updateReadLog           http.HandlerFunc
+	removeReadLog           http.HandlerFunc
+	getReadLogs             http.HandlerFunc
 	getPost                 http.HandlerFunc
 	updatePost              http.HandlerFunc
 	deletePost              http.HandlerFunc
@@ -119,6 +123,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuth(http.HandlerFunc(deps.getWatchLogs)).ServeHTTP(w, r)
 			return
 		}
+		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/read") {
+			// GET /api/v1/posts/{id}/read
+			requireAuth(http.HandlerFunc(deps.getReadLogs)).ServeHTTP(w, r)
+			return
+		}
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/cook-log") {
 			// POST /api/v1/posts/{id}/cook-log
 			requireAuthCSRF(http.HandlerFunc(deps.logCook)).ServeHTTP(w, r)
@@ -127,6 +136,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-log") {
 			// POST /api/v1/posts/{id}/watch-log
 			requireAuthCSRF(http.HandlerFunc(deps.logWatch)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/read") {
+			// POST /api/v1/posts/{id}/read
+			requireAuthCSRF(http.HandlerFunc(deps.logRead)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/cook-log") {
@@ -139,6 +153,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 			requireAuthCSRF(http.HandlerFunc(deps.updateWatchLog)).ServeHTTP(w, r)
 			return
 		}
+		if r.Method == http.MethodPut && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/read") {
+			// PUT /api/v1/posts/{id}/read
+			requireAuthCSRF(http.HandlerFunc(deps.updateReadLog)).ServeHTTP(w, r)
+			return
+		}
 		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/cook-log") {
 			// DELETE /api/v1/posts/{id}/cook-log
 			requireAuthCSRF(http.HandlerFunc(deps.removeCookLog)).ServeHTTP(w, r)
@@ -147,6 +166,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watch-log") {
 			// DELETE /api/v1/posts/{id}/watch-log
 			requireAuthCSRF(http.HandlerFunc(deps.removeWatchLog)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/read") {
+			// DELETE /api/v1/posts/{id}/read
+			requireAuthCSRF(http.HandlerFunc(deps.removeReadLog)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPatch && isPostIDPath(r.URL.Path) {

--- a/backend/internal/handlers/read_log.go
+++ b/backend/internal/handlers/read_log.go
@@ -1,0 +1,310 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+// ReadLogHandler handles book read log endpoints.
+type ReadLogHandler struct {
+	readLogService *services.ReadLogService
+}
+
+// NewReadLogHandler creates a new read log handler.
+func NewReadLogHandler(readLogService *services.ReadLogService) *ReadLogHandler {
+	return &ReadLogHandler{
+		readLogService: readLogService,
+	}
+}
+
+// LogRead handles POST /api/v1/posts/{postId}/read.
+func (h *ReadLogHandler) LogRead(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.LogReadRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.Rating != nil && (*req.Rating < 1 || *req.Rating > 5) {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", "rating must be between 1 and 5")
+		return
+	}
+
+	readLog, err := h.readLogService.LogRead(r.Context(), userID, postID, req.Rating)
+	if err != nil {
+		switch err.Error() {
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a book":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_BOOK", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "READ_LOG_CREATE_FAILED", "Failed to log read")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "read log created",
+		"read_log_id", readLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	response := models.CreateReadLogResponse{ReadLog: *readLog}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode create read log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusCreated,
+			Err:        err,
+		})
+	}
+}
+
+// RemoveReadLog handles DELETE /api/v1/posts/{postId}/read.
+func (h *ReadLogHandler) RemoveReadLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	if err := h.readLogService.RemoveReadLog(r.Context(), userID, postID); err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a book":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_BOOK", err.Error())
+		case "read log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "READ_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "READ_LOG_DELETE_FAILED", "Failed to remove read log")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "read log removed",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// UpdateReadLog handles PUT /api/v1/posts/{postId}/read.
+func (h *ReadLogHandler) UpdateReadLog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only PUT requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	var req models.UpdateReadLogRequest
+	if err := decodeJSONBody(w, r, &req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			writeError(r.Context(), w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body too large")
+			return
+		}
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	if req.Rating == nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "RATING_REQUIRED", "Rating is required")
+		return
+	}
+	if *req.Rating < 1 || *req.Rating > 5 {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", "rating must be between 1 and 5")
+		return
+	}
+
+	readLog, err := h.readLogService.UpdateRating(r.Context(), userID, postID, *req.Rating)
+	if err != nil {
+		switch err.Error() {
+		case "rating must be between 1 and 5":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_RATING", err.Error())
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a book":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_BOOK", err.Error())
+		case "read log not found":
+			writeError(r.Context(), w, http.StatusNotFound, "READ_LOG_NOT_FOUND", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "READ_LOG_UPDATE_FAILED", "Failed to update read log")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "read log updated",
+		"read_log_id", readLog.ID.String(),
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	response := models.UpdateReadLogResponse{ReadLog: *readLog}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode update read log response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// GetPostReadLogs handles GET /api/v1/posts/{postId}/read.
+func (h *ReadLogHandler) GetPostReadLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.readLogService.GetPostReadLogs(r.Context(), postID, &userID)
+	if err != nil {
+		switch err.Error() {
+		case "post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", err.Error())
+		case "post is not a book":
+			writeError(r.Context(), w, http.StatusBadRequest, "POST_NOT_BOOK", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_READ_LOGS_FAILED", "Failed to get read logs")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode get post read logs response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// GetReadHistory handles GET /api/v1/read-history.
+func (h *ReadLogHandler) GetReadHistory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	limit := 20
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	cursor := r.URL.Query().Get("cursor")
+	var cursorPtr *string
+	if cursor != "" {
+		cursorPtr = &cursor
+	}
+
+	readLogs, nextCursor, err := h.readLogService.GetUserReadHistory(r.Context(), userID, cursorPtr, limit)
+	if err != nil {
+		switch err.Error() {
+		case "user not found":
+			writeError(r.Context(), w, http.StatusNotFound, "USER_NOT_FOUND", err.Error())
+		case "invalid cursor":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CURSOR", err.Error())
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_READ_HISTORY_FAILED", "Failed to get read history")
+		}
+		return
+	}
+
+	response := models.ListReadHistoryResponse{
+		ReadLogs:   readLogs,
+		NextCursor: nextCursor,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode list read history response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}

--- a/backend/internal/handlers/read_log_test.go
+++ b/backend/internal/handlers/read_log_test.go
@@ -1,0 +1,481 @@
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestReadLogHandlerLogRead(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readloghandleruser", "readloghandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	body := bytes.NewBufferString(`{"rating":4}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/read", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readloghandleruser", false))
+	w := httptest.NewRecorder()
+
+	handler.LogRead(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.CreateReadLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.ReadLog.PostID != uuid.MustParse(postID) {
+		t.Fatalf("expected post_id %s, got %s", postID, response.ReadLog.PostID.String())
+	}
+	if response.ReadLog.Rating == nil || *response.ReadLog.Rating != 4 {
+		t.Fatalf("expected rating 4, got %v", response.ReadLog.Rating)
+	}
+}
+
+func TestReadLogHandlerLogReadRequiresAuth(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+uuid.New().String()+"/read", bytes.NewBufferString(`{"rating":3}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.LogRead(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestReadLogHandlerLogReadInvalidRating(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readloginvalid", "readloginvalid@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/read", bytes.NewBufferString(`{"rating":6}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readloginvalid", false))
+	w := httptest.NewRecorder()
+
+	handler.LogRead(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "INVALID_RATING" {
+		t.Fatalf("expected INVALID_RATING, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerLogReadPostNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogpostmissing", "readlogpostmissing@test.com", false, true)
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+uuid.New().String()+"/read", bytes.NewBufferString(`{"rating":3}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogpostmissing", false))
+	w := httptest.NewRecorder()
+
+	handler.LogRead(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "POST_NOT_FOUND" {
+		t.Fatalf("expected POST_NOT_FOUND, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerRemoveReadLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogremove", "readlogremove@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	readLogID := uuid.New()
+	if _, err := db.Exec(`
+		INSERT INTO read_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, readLogID, userID, postID, 5); err != nil {
+		t.Fatalf("failed to create read log: %v", err)
+	}
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/read", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogremove", false))
+	w := httptest.NewRecorder()
+
+	handler.RemoveReadLog(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var deletedAt sql.NullTime
+	if err := db.QueryRow(`SELECT deleted_at FROM read_logs WHERE id = $1`, readLogID).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query deleted read log: %v", err)
+	}
+	if !deletedAt.Valid {
+		t.Fatal("expected deleted_at to be set")
+	}
+}
+
+func TestReadLogHandlerRemoveReadLogNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogremove404", "readlogremove404@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/read", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogremove404", false))
+	w := httptest.NewRecorder()
+
+	handler.RemoveReadLog(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "READ_LOG_NOT_FOUND" {
+		t.Fatalf("expected READ_LOG_NOT_FOUND, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerUpdateReadLog(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogupdate", "readlogupdate@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	if _, err := db.Exec(`
+		INSERT INTO read_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now())
+	`, uuid.New(), userID, postID, 2); err != nil {
+		t.Fatalf("failed to create read log: %v", err)
+	}
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/read", bytes.NewBufferString(`{"rating":5}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogupdate", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateReadLog(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.UpdateReadLogResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.ReadLog.Rating == nil || *response.ReadLog.Rating != 5 {
+		t.Fatalf("expected rating 5, got %v", response.ReadLog.Rating)
+	}
+}
+
+func TestReadLogHandlerUpdateReadLogInvalidRating(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogupdateinvalid", "readlogupdateinvalid@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/read", bytes.NewBufferString(`{"rating":0}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogupdateinvalid", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateReadLog(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "INVALID_RATING" {
+		t.Fatalf("expected INVALID_RATING, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerUpdateReadLogNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readlogupdate404", "readlogupdate404@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Book post")
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/read", bytes.NewBufferString(`{"rating":3}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readlogupdate404", false))
+	w := httptest.NewRecorder()
+
+	handler.UpdateReadLog(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "READ_LOG_NOT_FOUND" {
+		t.Fatalf("expected READ_LOG_NOT_FOUND, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerGetPostReadLogs(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	viewerID := testutil.CreateTestUser(t, db, "readlogviewer", "readlogviewer@test.com", false, true)
+	otherUserID := testutil.CreateTestUser(t, db, "readlogviewer2", "readlogviewer2@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := testutil.CreateTestPost(t, db, viewerID, sectionID, "Book post")
+
+	if _, err := db.Exec(`
+		INSERT INTO read_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, now()), ($5, $6, $7, $8, now())
+	`,
+		uuid.New(), viewerID, postID, 5,
+		uuid.New(), otherUserID, postID, 3,
+	); err != nil {
+		t.Fatalf("failed to create read logs: %v", err)
+	}
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/read", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(viewerID), "readlogviewer", false))
+	w := httptest.NewRecorder()
+
+	handler.GetPostReadLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.PostReadLogsResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.ReadCount != 2 {
+		t.Fatalf("expected read_count 2, got %d", response.ReadCount)
+	}
+	if response.AverageRating < 3.9 || response.AverageRating > 4.1 {
+		t.Fatalf("expected average_rating around 4.0, got %f", response.AverageRating)
+	}
+	if !response.ViewerRead {
+		t.Fatal("expected viewer_read true")
+	}
+	if response.ViewerRating == nil || *response.ViewerRating != 5 {
+		t.Fatalf("expected viewer_rating 5, got %v", response.ViewerRating)
+	}
+	if len(response.Readers) != 2 {
+		t.Fatalf("expected 2 readers, got %d", len(response.Readers))
+	}
+}
+
+func TestReadLogHandlerGetPostReadLogsNotFound(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readloglist404", "readloglist404@test.com", false, true)
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+uuid.New().String()+"/read", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readloglist404", false))
+	w := httptest.NewRecorder()
+
+	handler.GetPostReadLogs(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "POST_NOT_FOUND" {
+		t.Fatalf("expected POST_NOT_FOUND, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerGetReadHistory(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readhistoryhandler", "readhistoryhandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postIDOne := testutil.CreateTestPost(t, db, userID, sectionID, "History one")
+	postIDTwo := testutil.CreateTestPost(t, db, userID, sectionID, "History two")
+
+	logOneID := uuid.New()
+	logTwoID := uuid.New()
+	firstCreatedAt := time.Now().Add(-2 * time.Hour)
+	secondCreatedAt := time.Now().Add(-1 * time.Hour)
+	if _, err := db.Exec(`
+		INSERT INTO read_logs (id, user_id, post_id, rating, created_at)
+		VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)
+	`,
+		logOneID, userID, postIDOne, 2, firstCreatedAt,
+		logTwoID, userID, postIDTwo, 5, secondCreatedAt,
+	); err != nil {
+		t.Fatalf("failed to create read logs: %v", err)
+	}
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/read-history?limit=1", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readhistoryhandler", false))
+	w := httptest.NewRecorder()
+
+	handler.GetReadHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ListReadHistoryResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.ReadLogs) != 1 {
+		t.Fatalf("expected 1 read log, got %d", len(response.ReadLogs))
+	}
+	if response.NextCursor == nil {
+		t.Fatal("expected next_cursor to be set")
+	}
+	if response.ReadLogs[0].PostID != uuid.MustParse(postIDTwo) {
+		t.Fatalf("expected newest post_id %s, got %s", postIDTwo, response.ReadLogs[0].PostID.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/read-history?limit=1&cursor="+*response.NextCursor, nil)
+	req2 = req2.WithContext(createTestUserContext(req2.Context(), uuid.MustParse(userID), "readhistoryhandler", false))
+	w2 := httptest.NewRecorder()
+
+	handler.GetReadHistory(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", w2.Code, w2.Body.String())
+	}
+
+	var response2 models.ListReadHistoryResponse
+	if err := json.NewDecoder(w2.Body).Decode(&response2); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response2.ReadLogs) != 1 {
+		t.Fatalf("expected 1 read log on second page, got %d", len(response2.ReadLogs))
+	}
+	if response2.NextCursor != nil {
+		t.Fatal("expected next_cursor to be nil on second page")
+	}
+	if response2.ReadLogs[0].PostID != uuid.MustParse(postIDOne) {
+		t.Fatalf("expected older post_id %s, got %s", postIDOne, response2.ReadLogs[0].PostID.String())
+	}
+}
+
+func TestReadLogHandlerGetReadHistoryInvalidCursor(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "readhistorycursor", "readhistorycursor@test.com", false, true)
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/read-history?cursor=bad-cursor", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "readhistorycursor", false))
+	w := httptest.NewRecorder()
+
+	handler.GetReadHistory(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Code != "INVALID_CURSOR" {
+		t.Fatalf("expected INVALID_CURSOR, got %s", response.Code)
+	}
+}
+
+func TestReadLogHandlerGetReadHistoryRequiresAuth(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	handler := NewReadLogHandler(services.NewReadLogService(db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/read-history", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetReadHistory(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}

--- a/backend/internal/models/book.go
+++ b/backend/internal/models/book.go
@@ -116,3 +116,24 @@ type PostReadLogsResponse struct {
 type LogReadRequest struct {
 	Rating *int `json:"rating,omitempty"`
 }
+
+// UpdateReadLogRequest represents the request body for updating a read rating.
+type UpdateReadLogRequest struct {
+	Rating *int `json:"rating"`
+}
+
+// CreateReadLogResponse represents the response for creating a read log.
+type CreateReadLogResponse struct {
+	ReadLog ReadLog `json:"read_log"`
+}
+
+// UpdateReadLogResponse represents the response for updating a read log.
+type UpdateReadLogResponse struct {
+	ReadLog ReadLog `json:"read_log"`
+}
+
+// ListReadHistoryResponse represents paginated read history for a viewer.
+type ListReadHistoryResponse struct {
+	ReadLogs   []ReadLog `json:"read_logs"`
+	NextCursor *string   `json:"next_cursor,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add `ReadLogHandler` with endpoints for `POST/PUT/DELETE/GET /api/v1/posts/{id}/read` and `GET /api/v1/read-history`
- validate request input at the handler layer (including rating bounds and required update rating) and map service errors to standard API error codes
- wire read-log routes into server routing and add route tests to verify auth/CSRF middleware behavior for `/read` endpoints
- add response/request model types for read-log handler payloads
- add handler tests covering happy paths, unauthorized access, invalid ratings, and not-found cases for read log operations

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/handlers -run 'ReadLogHandler' -v`
- `cd backend && go test ./cmd/server -run 'PostRouteHandler.*Read' -v`
- `cd backend && go test ./...`

Closes #863