### PR TITLE
[Books] Create book quote service

### DIFF
--- a/backend/internal/services/book_quote.go
+++ b/backend/internal/services/book_quote.go
@@ -1,0 +1,711 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	defaultBookQuoteLimit       = 20
+	maxBookQuoteLimit           = 100
+	bookQuoteLegacyCursorLayout = "2006-01-02T15:04:05.000Z07:00"
+	bookQuoteCursorSeparator    = "|"
+)
+
+// BookQuoteService handles CRUD operations for book quotes.
+type BookQuoteService struct {
+	db *sql.DB
+}
+
+// NewBookQuoteService creates a new book quote service.
+func NewBookQuoteService(db *sql.DB) *BookQuoteService {
+	return &BookQuoteService{db: db}
+}
+
+// CreateQuote creates a new quote for a book post.
+func (s *BookQuoteService) CreateQuote(
+	ctx context.Context,
+	userID uuid.UUID,
+	postID uuid.UUID,
+	req models.CreateBookQuoteRequest,
+) (*models.BookQuoteWithUser, error) {
+	ctx, span := otel.Tracer("clubhouse.book_quotes").Start(ctx, "BookQuoteService.CreateQuote")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+		attribute.Bool("has_page_number", req.PageNumber != nil),
+		attribute.Bool("has_chapter", req.Chapter != nil && strings.TrimSpace(*req.Chapter) != ""),
+		attribute.Bool("has_note", req.Note != nil && strings.TrimSpace(*req.Note) != ""),
+	)
+	defer span.End()
+
+	quoteText := strings.TrimSpace(req.QuoteText)
+	if quoteText == "" {
+		err := errors.New("quote text is required")
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.verifyBookPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	chapter := sanitizeOptionalBookQuoteText(req.Chapter)
+	note := sanitizeOptionalBookQuoteText(req.Note)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	quoteID := uuid.New()
+	query := `
+		INSERT INTO book_quotes (id, post_id, user_id, quote_text, page_number, chapter, note, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
+		RETURNING id, post_id, user_id, quote_text, page_number, chapter, note, created_at, updated_at, deleted_at
+	`
+
+	row := tx.QueryRowContext(
+		ctx,
+		query,
+		quoteID,
+		postID,
+		userID,
+		quoteText,
+		nullableInt(req.PageNumber),
+		nullableString(chapter),
+		nullableString(note),
+	)
+	quote, err := scanBookQuoteWithUser(row)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to create book quote: %w", err)
+	}
+
+	username, displayName, err := getBookQuoteUserSummary(ctx, tx, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	quote.Username = username
+	quote.DisplayName = displayName
+
+	metadata := map[string]interface{}{
+		"quote_id":        quote.ID.String(),
+		"post_id":         quote.PostID.String(),
+		"quote_excerpt":   truncateAuditExcerpt(quoteText),
+		"has_page_number": req.PageNumber != nil,
+		"has_chapter":     chapter != nil,
+		"has_note":        note != nil,
+	}
+	if req.PageNumber != nil {
+		metadata["page_number"] = *req.PageNumber
+	}
+	if chapter != nil {
+		metadata["chapter"] = *chapter
+	}
+	if note != nil {
+		metadata["note"] = *note
+	}
+
+	auditService := NewAuditService(tx)
+	if err := auditService.LogAuditWithMetadata(ctx, "create_book_quote", userID, userID, metadata); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to create audit log: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return quote, nil
+}
+
+// UpdateQuote updates an existing quote.
+func (s *BookQuoteService) UpdateQuote(
+	ctx context.Context,
+	userID uuid.UUID,
+	quoteID uuid.UUID,
+	req models.UpdateBookQuoteRequest,
+) (*models.BookQuoteWithUser, error) {
+	ctx, span := otel.Tracer("clubhouse.book_quotes").Start(ctx, "BookQuoteService.UpdateQuote")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("quote_id", quoteID.String()),
+		attribute.Bool("has_quote_text", req.QuoteText != nil),
+		attribute.Bool("has_page_number", req.PageNumber != nil),
+		attribute.Bool("has_chapter", req.Chapter != nil),
+		attribute.Bool("has_note", req.Note != nil),
+	)
+	defer span.End()
+
+	existing, err := s.getQuoteByID(ctx, quoteID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	isAdmin, err := s.isAdmin(ctx, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	if existing.UserID != userID && !isAdmin {
+		unauthorizedErr := errors.New("unauthorized to edit this quote")
+		recordSpanError(span, unauthorizedErr)
+		return nil, unauthorizedErr
+	}
+
+	quoteText := existing.QuoteText
+	if req.QuoteText != nil {
+		trimmed := strings.TrimSpace(*req.QuoteText)
+		if trimmed == "" {
+			err := errors.New("quote text is required")
+			recordSpanError(span, err)
+			return nil, err
+		}
+		quoteText = trimmed
+	}
+
+	pageNumber := existing.PageNumber
+	if req.PageNumber != nil {
+		updated := *req.PageNumber
+		pageNumber = &updated
+	}
+
+	chapter := existing.Chapter
+	if req.Chapter != nil {
+		chapter = sanitizeOptionalBookQuoteText(req.Chapter)
+	}
+
+	note := existing.Note
+	if req.Note != nil {
+		note = sanitizeOptionalBookQuoteText(req.Note)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	query := `
+		UPDATE book_quotes
+		SET quote_text = $2, page_number = $3, chapter = $4, note = $5, updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, post_id, user_id, quote_text, page_number, chapter, note, created_at, updated_at, deleted_at
+	`
+	row := tx.QueryRowContext(
+		ctx,
+		query,
+		quoteID,
+		quoteText,
+		nullableInt(pageNumber),
+		nullableString(chapter),
+		nullableString(note),
+	)
+
+	updatedQuote, err := scanBookQuoteWithUser(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			notFoundErr := errors.New("book quote not found")
+			recordSpanError(span, notFoundErr)
+			return nil, notFoundErr
+		}
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to update book quote: %w", err)
+	}
+
+	username, displayName, err := getBookQuoteUserSummary(ctx, tx, updatedQuote.UserID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	updatedQuote.Username = username
+	updatedQuote.DisplayName = displayName
+
+	metadata := map[string]interface{}{
+		"quote_id":            updatedQuote.ID.String(),
+		"post_id":             updatedQuote.PostID.String(),
+		"quote_excerpt":       truncateAuditExcerpt(updatedQuote.QuoteText),
+		"previous_quote_text": existing.QuoteText,
+	}
+	if req.PageNumber != nil {
+		metadata["page_number"] = nullableInt(pageNumber)
+	}
+	if req.Chapter != nil {
+		metadata["chapter"] = nullableString(chapter)
+	}
+	if req.Note != nil {
+		metadata["note"] = nullableString(note)
+	}
+	if existing.UserID != userID && isAdmin {
+		metadata["updated_by_admin"] = true
+	}
+
+	auditService := NewAuditService(tx)
+	if err := auditService.LogAuditWithMetadata(ctx, "update_book_quote", userID, existing.UserID, metadata); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to create audit log: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return updatedQuote, nil
+}
+
+// DeleteQuote soft deletes an existing quote.
+func (s *BookQuoteService) DeleteQuote(ctx context.Context, userID uuid.UUID, quoteID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.book_quotes").Start(ctx, "BookQuoteService.DeleteQuote")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("quote_id", quoteID.String()),
+	)
+	defer span.End()
+
+	existing, err := s.getQuoteByID(ctx, quoteID)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	isAdmin, err := s.isAdmin(ctx, userID)
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	if existing.UserID != userID && !isAdmin {
+		unauthorizedErr := errors.New("unauthorized to delete this quote")
+		recordSpanError(span, unauthorizedErr)
+		return unauthorizedErr
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	result, err := tx.ExecContext(
+		ctx,
+		`UPDATE book_quotes SET deleted_at = now(), updated_at = now() WHERE id = $1 AND deleted_at IS NULL`,
+		quoteID,
+	)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to delete book quote: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to verify book quote deletion: %w", err)
+	}
+	if rowsAffected == 0 {
+		notFoundErr := errors.New("book quote not found")
+		recordSpanError(span, notFoundErr)
+		return notFoundErr
+	}
+
+	isSelfDelete := existing.UserID == userID
+	metadata := map[string]interface{}{
+		"quote_id":           existing.ID.String(),
+		"post_id":            existing.PostID.String(),
+		"quote_excerpt":      truncateAuditExcerpt(existing.QuoteText),
+		"deleted_by_user_id": userID.String(),
+		"is_self_delete":     isSelfDelete,
+	}
+	if !isSelfDelete && isAdmin {
+		metadata["deleted_by_admin"] = true
+	}
+
+	auditService := NewAuditService(tx)
+	if err := auditService.LogAuditWithMetadata(ctx, "delete_book_quote", userID, existing.UserID, metadata); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to create audit log: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// GetQuotesForPost returns paginated quotes for a post.
+func (s *BookQuoteService) GetQuotesForPost(
+	ctx context.Context,
+	postID uuid.UUID,
+	cursor *string,
+	limit int,
+) (*models.BookQuotesListResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.book_quotes").Start(ctx, "BookQuoteService.GetQuotesForPost")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+	)
+	defer span.End()
+
+	if err := s.verifyBookPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	response, err := s.listQuotes(ctx, "bq.post_id = $1", []interface{}{postID}, cursor, limit)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// GetQuotesByUser returns paginated quotes created by a specific user.
+func (s *BookQuoteService) GetQuotesByUser(
+	ctx context.Context,
+	userID uuid.UUID,
+	cursor *string,
+	limit int,
+) (*models.BookQuotesListResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.book_quotes").Start(ctx, "BookQuoteService.GetQuotesByUser")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+	)
+	defer span.End()
+
+	response, err := s.listQuotes(ctx, "bq.user_id = $1", []interface{}{userID}, cursor, limit)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *BookQuoteService) listQuotes(
+	ctx context.Context,
+	filterClause string,
+	filterArgs []interface{},
+	cursor *string,
+	limit int,
+) (*models.BookQuotesListResponse, error) {
+	if limit <= 0 || limit > maxBookQuoteLimit {
+		limit = defaultBookQuoteLimit
+	}
+
+	query := `
+		SELECT
+			bq.id, bq.post_id, bq.user_id, bq.quote_text, bq.page_number, bq.chapter, bq.note,
+			bq.created_at, bq.updated_at, bq.deleted_at,
+			u.username
+		FROM book_quotes bq
+		JOIN users u ON bq.user_id = u.id
+		WHERE ` + filterClause + ` AND bq.deleted_at IS NULL
+	`
+
+	args := append([]interface{}{}, filterArgs...)
+	argIndex := len(args) + 1
+
+	if cursor != nil && strings.TrimSpace(*cursor) != "" {
+		cursorCreatedAt, cursorQuoteID, hasQuoteID, err := parseBookQuoteCursor(strings.TrimSpace(*cursor))
+		if err != nil {
+			return nil, err
+		}
+
+		if hasQuoteID {
+			query += fmt.Sprintf(
+				" AND (bq.created_at < $%d OR (bq.created_at = $%d AND bq.id < $%d))",
+				argIndex,
+				argIndex,
+				argIndex+1,
+			)
+			args = append(args, cursorCreatedAt, cursorQuoteID)
+			argIndex += 2
+		} else {
+			query += fmt.Sprintf(" AND bq.created_at < $%d", argIndex)
+			args = append(args, cursorCreatedAt)
+			argIndex++
+		}
+	}
+
+	query += fmt.Sprintf(" ORDER BY bq.created_at DESC, bq.id DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query book quotes: %w", err)
+	}
+	defer rows.Close()
+
+	quotes := make([]models.BookQuoteWithUser, 0, limit+1)
+	for rows.Next() {
+		quote, err := scanBookQuoteWithUser(rows)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan book quote: %w", err)
+		}
+		quotes = append(quotes, *quote)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate book quotes: %w", err)
+	}
+
+	hasMore := len(quotes) > limit
+	if hasMore {
+		quotes = quotes[:limit]
+	}
+
+	var nextCursor *string
+	if hasMore && len(quotes) > 0 {
+		cursorValue := buildBookQuoteCursor(quotes[len(quotes)-1].CreatedAt, quotes[len(quotes)-1].ID)
+		nextCursor = &cursorValue
+	}
+
+	return &models.BookQuotesListResponse{
+		Quotes:     quotes,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+func (s *BookQuoteService) getQuoteByID(ctx context.Context, quoteID uuid.UUID) (*models.BookQuote, error) {
+	query := `
+		SELECT id, post_id, user_id, quote_text, page_number, chapter, note, created_at, updated_at, deleted_at
+		FROM book_quotes
+		WHERE id = $1 AND deleted_at IS NULL
+	`
+	row := s.db.QueryRowContext(ctx, query, quoteID)
+	quote, err := scanBookQuote(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("book quote not found")
+		}
+		return nil, fmt.Errorf("failed to fetch book quote: %w", err)
+	}
+	return quote, nil
+}
+
+func (s *BookQuoteService) verifyBookPost(ctx context.Context, postID uuid.UUID) error {
+	var sectionType string
+	query := `
+		SELECT s.type
+		FROM posts p
+		JOIN sections s ON p.section_id = s.id
+		WHERE p.id = $1 AND p.deleted_at IS NULL
+	`
+	if err := s.db.QueryRowContext(ctx, query, postID).Scan(&sectionType); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("post not found")
+		}
+		return fmt.Errorf("failed to verify book post: %w", err)
+	}
+	if sectionType != "book" {
+		return errors.New("post is not a book")
+	}
+	return nil
+}
+
+func (s *BookQuoteService) isAdmin(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var isAdmin bool
+	if err := s.db.QueryRowContext(
+		ctx,
+		"SELECT is_admin FROM users WHERE id = $1 AND deleted_at IS NULL",
+		userID,
+	).Scan(&isAdmin); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, errors.New("user not found")
+		}
+		return false, fmt.Errorf("failed to verify user role: %w", err)
+	}
+	return isAdmin, nil
+}
+
+func getBookQuoteUserSummary(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+}, userID uuid.UUID) (string, string, error) {
+	var username string
+	if err := q.QueryRowContext(
+		ctx,
+		"SELECT username FROM users WHERE id = $1 AND deleted_at IS NULL",
+		userID,
+	).Scan(&username); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", "", errors.New("user not found")
+		}
+		return "", "", fmt.Errorf("failed to fetch quote user: %w", err)
+	}
+
+	return username, username, nil
+}
+
+func scanBookQuote(scanner interface {
+	Scan(dest ...interface{}) error
+}) (*models.BookQuote, error) {
+	var quote models.BookQuote
+	var pageNumber sql.NullInt64
+	var chapter sql.NullString
+	var note sql.NullString
+	var deletedAt sql.NullTime
+
+	if err := scanner.Scan(
+		&quote.ID,
+		&quote.PostID,
+		&quote.UserID,
+		&quote.QuoteText,
+		&pageNumber,
+		&chapter,
+		&note,
+		&quote.CreatedAt,
+		&quote.UpdatedAt,
+		&deletedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if pageNumber.Valid {
+		value := int(pageNumber.Int64)
+		quote.PageNumber = &value
+	}
+	if chapter.Valid {
+		value := chapter.String
+		quote.Chapter = &value
+	}
+	if note.Valid {
+		value := note.String
+		quote.Note = &value
+	}
+	if deletedAt.Valid {
+		quote.DeletedAt = &deletedAt.Time
+	}
+
+	return &quote, nil
+}
+
+func scanBookQuoteWithUser(scanner interface {
+	Scan(dest ...interface{}) error
+}) (*models.BookQuoteWithUser, error) {
+	var quote models.BookQuoteWithUser
+	var pageNumber sql.NullInt64
+	var chapter sql.NullString
+	var note sql.NullString
+	var deletedAt sql.NullTime
+	var username string
+
+	if err := scanner.Scan(
+		&quote.ID,
+		&quote.PostID,
+		&quote.UserID,
+		&quote.QuoteText,
+		&pageNumber,
+		&chapter,
+		&note,
+		&quote.CreatedAt,
+		&quote.UpdatedAt,
+		&deletedAt,
+		&username,
+	); err != nil {
+		return nil, err
+	}
+
+	if pageNumber.Valid {
+		value := int(pageNumber.Int64)
+		quote.PageNumber = &value
+	}
+	if chapter.Valid {
+		value := chapter.String
+		quote.Chapter = &value
+	}
+	if note.Valid {
+		value := note.String
+		quote.Note = &value
+	}
+	if deletedAt.Valid {
+		quote.DeletedAt = &deletedAt.Time
+	}
+	quote.Username = username
+	quote.DisplayName = username
+
+	return &quote, nil
+}
+
+func buildBookQuoteCursor(createdAt time.Time, quoteID uuid.UUID) string {
+	return createdAt.UTC().Format(time.RFC3339Nano) + bookQuoteCursorSeparator + quoteID.String()
+}
+
+func parseBookQuoteCursor(cursor string) (time.Time, uuid.UUID, bool, error) {
+	parts := strings.Split(cursor, bookQuoteCursorSeparator)
+	if len(parts) == 2 {
+		createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+
+		quoteID, err := uuid.Parse(parts[1])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+
+		return createdAt.UTC(), quoteID, true, nil
+	}
+
+	createdAt, err := time.Parse(bookQuoteLegacyCursorLayout, cursor)
+	if err != nil {
+		return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+	}
+
+	return createdAt.UTC(), uuid.Nil, false, nil
+}
+
+func nullableInt(value *int) interface{} {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullableString(value *string) interface{} {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func sanitizeOptionalBookQuoteText(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+
+	return &trimmed
+}

--- a/backend/internal/services/book_quote_test.go
+++ b/backend/internal/services/book_quote_test.go
@@ -1,0 +1,425 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestCreateQuoteWithAllFields(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteall", "bookquoteall@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	quote, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{
+		QuoteText:  "  A room without books is like a body without a soul.  ",
+		PageNumber: intPtr(42),
+		Chapter:    stringPtr("  Chapter 2  "),
+		Note:       stringPtr("  Favorite quote  "),
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	if quote.QuoteText != "A room without books is like a body without a soul." {
+		t.Fatalf("expected trimmed quote text, got %q", quote.QuoteText)
+	}
+	if quote.PageNumber == nil || *quote.PageNumber != 42 {
+		t.Fatalf("expected page number 42, got %v", quote.PageNumber)
+	}
+	if quote.Chapter == nil || *quote.Chapter != "Chapter 2" {
+		t.Fatalf("expected chapter %q, got %v", "Chapter 2", quote.Chapter)
+	}
+	if quote.Note == nil || *quote.Note != "Favorite quote" {
+		t.Fatalf("expected note %q, got %v", "Favorite quote", quote.Note)
+	}
+	if quote.Username != "bookquoteall" {
+		t.Fatalf("expected username %q, got %q", "bookquoteall", quote.Username)
+	}
+	if quote.DisplayName != "bookquoteall" {
+		t.Fatalf("expected display name %q, got %q", "bookquoteall", quote.DisplayName)
+	}
+}
+
+func TestCreateQuoteWithMinimalFields(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquotemin", "bookquotemin@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	quote, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{
+		QuoteText: "Minimal quote",
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	if quote.QuoteText != "Minimal quote" {
+		t.Fatalf("expected quote text %q, got %q", "Minimal quote", quote.QuoteText)
+	}
+	if quote.PageNumber != nil {
+		t.Fatalf("expected nil page number, got %v", quote.PageNumber)
+	}
+	if quote.Chapter != nil {
+		t.Fatalf("expected nil chapter, got %v", quote.Chapter)
+	}
+	if quote.Note != nil {
+		t.Fatalf("expected nil note, got %v", quote.Note)
+	}
+}
+
+func TestUpdateQuote(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteupdate", "bookquoteupdate@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	created, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{
+		QuoteText:  "Original quote",
+		PageNumber: intPtr(10),
+		Chapter:    stringPtr("Chapter 1"),
+		Note:       stringPtr("Original note"),
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	updated, err := service.UpdateQuote(context.Background(), userID, created.ID, models.UpdateBookQuoteRequest{
+		QuoteText:  stringPtr("Updated quote"),
+		PageNumber: intPtr(25),
+		Note:       stringPtr("Updated note"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateQuote failed: %v", err)
+	}
+
+	if updated.QuoteText != "Updated quote" {
+		t.Fatalf("expected quote text %q, got %q", "Updated quote", updated.QuoteText)
+	}
+	if updated.PageNumber == nil || *updated.PageNumber != 25 {
+		t.Fatalf("expected page number 25, got %v", updated.PageNumber)
+	}
+	if updated.Chapter == nil || *updated.Chapter != "Chapter 1" {
+		t.Fatalf("expected chapter to remain %q, got %v", "Chapter 1", updated.Chapter)
+	}
+	if updated.Note == nil || *updated.Note != "Updated note" {
+		t.Fatalf("expected note %q, got %v", "Updated note", updated.Note)
+	}
+}
+
+func TestDeleteOwnQuote(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquotedelete", "bookquotedelete@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	created, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{
+		QuoteText: "Delete me",
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	if err := service.DeleteQuote(context.Background(), userID, created.ID); err != nil {
+		t.Fatalf("DeleteQuote failed: %v", err)
+	}
+
+	var deletedAt time.Time
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT deleted_at
+		FROM book_quotes
+		WHERE id = $1
+	`, created.ID).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query deleted quote: %v", err)
+	}
+	if deletedAt.IsZero() {
+		t.Fatalf("expected deleted_at to be set")
+	}
+}
+
+func TestAdminDeleteAnyQuote(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	ownerID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteowner", "bookquoteowner@test.com", false, true))
+	adminID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteadmin", "bookquoteadmin@test.com", true, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, ownerID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	created, err := service.CreateQuote(context.Background(), ownerID, postID, models.CreateBookQuoteRequest{
+		QuoteText: "Admin can delete this",
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	if err := service.DeleteQuote(context.Background(), adminID, created.ID); err != nil {
+		t.Fatalf("DeleteQuote failed: %v", err)
+	}
+
+	var deletedAt time.Time
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT deleted_at
+		FROM book_quotes
+		WHERE id = $1
+	`, created.ID).Scan(&deletedAt); err != nil {
+		t.Fatalf("failed to query deleted quote: %v", err)
+	}
+	if deletedAt.IsZero() {
+		t.Fatalf("expected deleted_at to be set")
+	}
+}
+
+func TestNonOwnerCannotEditOrDeleteQuote(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	ownerID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteowner2", "bookquoteowner2@test.com", false, true))
+	otherUserID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteother", "bookquoteother@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, ownerID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	created, err := service.CreateQuote(context.Background(), ownerID, postID, models.CreateBookQuoteRequest{
+		QuoteText: "Protected quote",
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	_, err = service.UpdateQuote(context.Background(), otherUserID, created.ID, models.UpdateBookQuoteRequest{
+		QuoteText: stringPtr("Unauthorized edit"),
+	})
+	if err == nil {
+		t.Fatalf("expected update error for non-owner")
+	}
+	if err.Error() != "unauthorized to edit this quote" {
+		t.Fatalf("expected unauthorized edit error, got %q", err.Error())
+	}
+
+	err = service.DeleteQuote(context.Background(), otherUserID, created.ID)
+	if err == nil {
+		t.Fatalf("expected delete error for non-owner")
+	}
+	if err.Error() != "unauthorized to delete this quote" {
+		t.Fatalf("expected unauthorized delete error, got %q", err.Error())
+	}
+}
+
+func TestBookQuotePagination(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquotepage", "bookquotepage@test.com", false, true))
+	otherUserID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquotepage2", "bookquotepage2@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Book quote post"))
+	otherPostID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Another book quote post"))
+
+	service := NewBookQuoteService(db)
+	oldest, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{QuoteText: "Oldest"})
+	if err != nil {
+		t.Fatalf("CreateQuote oldest failed: %v", err)
+	}
+	middle, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{QuoteText: "Middle"})
+	if err != nil {
+		t.Fatalf("CreateQuote middle failed: %v", err)
+	}
+	newest, err := service.CreateQuote(context.Background(), userID, postID, models.CreateBookQuoteRequest{QuoteText: "Newest"})
+	if err != nil {
+		t.Fatalf("CreateQuote newest failed: %v", err)
+	}
+	if _, err := service.CreateQuote(context.Background(), otherUserID, otherPostID, models.CreateBookQuoteRequest{QuoteText: "Other user quote"}); err != nil {
+		t.Fatalf("CreateQuote other user failed: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if _, err := db.ExecContext(context.Background(), `UPDATE book_quotes SET created_at = $1 WHERE id = $2`, now.Add(-3*time.Hour), oldest.ID); err != nil {
+		t.Fatalf("failed to set oldest created_at: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `UPDATE book_quotes SET created_at = $1 WHERE id = $2`, now.Add(-2*time.Hour), middle.ID); err != nil {
+		t.Fatalf("failed to set middle created_at: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `UPDATE book_quotes SET created_at = $1 WHERE id = $2`, now.Add(-1*time.Hour), newest.ID); err != nil {
+		t.Fatalf("failed to set newest created_at: %v", err)
+	}
+
+	firstPage, err := service.GetQuotesForPost(context.Background(), postID, nil, 2)
+	if err != nil {
+		t.Fatalf("GetQuotesForPost first page failed: %v", err)
+	}
+	if len(firstPage.Quotes) != 2 {
+		t.Fatalf("expected 2 quotes on first page, got %d", len(firstPage.Quotes))
+	}
+	if !firstPage.HasMore {
+		t.Fatalf("expected HasMore on first page")
+	}
+	if firstPage.NextCursor == nil || *firstPage.NextCursor == "" {
+		t.Fatalf("expected next cursor on first page")
+	}
+	if firstPage.Quotes[0].ID != newest.ID {
+		t.Fatalf("expected newest quote first, got %s", firstPage.Quotes[0].ID)
+	}
+	if firstPage.Quotes[1].ID != middle.ID {
+		t.Fatalf("expected middle quote second, got %s", firstPage.Quotes[1].ID)
+	}
+
+	secondPage, err := service.GetQuotesForPost(context.Background(), postID, firstPage.NextCursor, 2)
+	if err != nil {
+		t.Fatalf("GetQuotesForPost second page failed: %v", err)
+	}
+	if len(secondPage.Quotes) != 1 {
+		t.Fatalf("expected 1 quote on second page, got %d", len(secondPage.Quotes))
+	}
+	if secondPage.HasMore {
+		t.Fatalf("expected no more pages after second page")
+	}
+	if secondPage.NextCursor != nil {
+		t.Fatalf("expected nil next cursor on final page")
+	}
+	if secondPage.Quotes[0].ID != oldest.ID {
+		t.Fatalf("expected oldest quote on second page, got %s", secondPage.Quotes[0].ID)
+	}
+
+	byUser, err := service.GetQuotesByUser(context.Background(), userID, nil, 10)
+	if err != nil {
+		t.Fatalf("GetQuotesByUser failed: %v", err)
+	}
+	if len(byUser.Quotes) != 3 {
+		t.Fatalf("expected 3 quotes for user, got %d", len(byUser.Quotes))
+	}
+}
+
+func TestBookQuoteAuditLogEntries(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	ownerID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteaudit", "bookquoteaudit@test.com", false, true))
+	adminID := uuid.MustParse(testutil.CreateTestUser(t, db, "bookquoteauditadmin", "bookquoteauditadmin@test.com", true, true))
+	sectionID := testutil.CreateTestSection(t, db, "Books", "book")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, ownerID.String(), sectionID, "Book quote post"))
+
+	service := NewBookQuoteService(db)
+	created, err := service.CreateQuote(context.Background(), ownerID, postID, models.CreateBookQuoteRequest{
+		QuoteText: "Audit quote",
+	})
+	if err != nil {
+		t.Fatalf("CreateQuote failed: %v", err)
+	}
+
+	_, err = service.UpdateQuote(context.Background(), ownerID, created.ID, models.UpdateBookQuoteRequest{
+		QuoteText: stringPtr("Audit quote updated"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateQuote failed: %v", err)
+	}
+
+	if err := service.DeleteQuote(context.Background(), adminID, created.ID); err != nil {
+		t.Fatalf("DeleteQuote failed: %v", err)
+	}
+
+	var createMetadataBytes []byte
+	var createAdminID uuid.UUID
+	var createTargetID uuid.NullUUID
+	err = db.QueryRowContext(context.Background(), `
+		SELECT admin_user_id, target_user_id, metadata
+		FROM audit_logs
+		WHERE action = 'create_book_quote'
+	`).Scan(&createAdminID, &createTargetID, &createMetadataBytes)
+	if err != nil {
+		t.Fatalf("failed to query create audit log: %v", err)
+	}
+	if createAdminID != ownerID {
+		t.Fatalf("expected create admin_user_id %s, got %s", ownerID, createAdminID)
+	}
+	if !createTargetID.Valid || createTargetID.UUID != ownerID {
+		t.Fatalf("expected create target_user_id %s, got %v", ownerID, createTargetID)
+	}
+
+	createMetadata := parseAuditMetadata(t, createMetadataBytes)
+	if createMetadata["quote_id"] != created.ID.String() {
+		t.Fatalf("expected create quote_id %s, got %v", created.ID, createMetadata["quote_id"])
+	}
+	if createMetadata["post_id"] != postID.String() {
+		t.Fatalf("expected create post_id %s, got %v", postID, createMetadata["post_id"])
+	}
+
+	var updateMetadataBytes []byte
+	var updateAdminID uuid.UUID
+	err = db.QueryRowContext(context.Background(), `
+		SELECT admin_user_id, metadata
+		FROM audit_logs
+		WHERE action = 'update_book_quote'
+	`).Scan(&updateAdminID, &updateMetadataBytes)
+	if err != nil {
+		t.Fatalf("failed to query update audit log: %v", err)
+	}
+	if updateAdminID != ownerID {
+		t.Fatalf("expected update admin_user_id %s, got %s", ownerID, updateAdminID)
+	}
+
+	updateMetadata := parseAuditMetadata(t, updateMetadataBytes)
+	if updateMetadata["quote_id"] != created.ID.String() {
+		t.Fatalf("expected update quote_id %s, got %v", created.ID, updateMetadata["quote_id"])
+	}
+	if updateMetadata["previous_quote_text"] != "Audit quote" {
+		t.Fatalf("expected previous_quote_text %q, got %v", "Audit quote", updateMetadata["previous_quote_text"])
+	}
+
+	var deleteMetadataBytes []byte
+	var deleteAdminID uuid.UUID
+	var deleteTargetID uuid.NullUUID
+	err = db.QueryRowContext(context.Background(), `
+		SELECT admin_user_id, target_user_id, metadata
+		FROM audit_logs
+		WHERE action = 'delete_book_quote'
+	`).Scan(&deleteAdminID, &deleteTargetID, &deleteMetadataBytes)
+	if err != nil {
+		t.Fatalf("failed to query delete audit log: %v", err)
+	}
+	if deleteAdminID != adminID {
+		t.Fatalf("expected delete admin_user_id %s, got %s", adminID, deleteAdminID)
+	}
+	if !deleteTargetID.Valid || deleteTargetID.UUID != ownerID {
+		t.Fatalf("expected delete target_user_id %s, got %v", ownerID, deleteTargetID)
+	}
+
+	deleteMetadata := parseAuditMetadata(t, deleteMetadataBytes)
+	if deleteMetadata["quote_id"] != created.ID.String() {
+		t.Fatalf("expected delete quote_id %s, got %v", created.ID, deleteMetadata["quote_id"])
+	}
+	deletedByAdmin, ok := deleteMetadata["deleted_by_admin"].(bool)
+	if !ok || !deletedByAdmin {
+		t.Fatalf("expected deleted_by_admin true, got %v", deleteMetadata["deleted_by_admin"])
+	}
+}
+
+func parseAuditMetadata(t *testing.T, metadata []byte) map[string]interface{} {
+	t.Helper()
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(metadata, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal audit metadata: %v", err)
+	}
+
+	return parsed
+}


### PR DESCRIPTION
## Summary
- add `BookQuoteService` in `backend/internal/services/book_quote.go` with full CRUD methods:
  - `CreateQuote(ctx, userID, postID, req)`
  - `UpdateQuote(ctx, userID, quoteID, req)`
  - `DeleteQuote(ctx, userID, quoteID)`
  - `GetQuotesForPost(ctx, postID, cursor, limit)`
  - `GetQuotesByUser(ctx, userID, cursor, limit)`
- enforce ownership rules in update/delete with admin override (`users.is_admin`)
- add soft delete behavior via `deleted_at`
- implement cursor pagination ordered by `created_at DESC, id DESC`
- add audit logging for state changes with actions:
  - `create_book_quote`
  - `update_book_quote`
  - `delete_book_quote`

## Tests
- add `backend/internal/services/book_quote_test.go` covering:
  - create quote with all fields
  - create quote with minimal fields
  - update quote
  - delete own quote
  - admin delete any quote
  - non-owner cannot edit/delete
  - pagination
  - audit log entries
- local validation run:
  - `cd backend && go build ./...`
  - `cd backend && go test ./internal/services -run 'BookQuote|CreateQuoteWith|UpdateQuote|DeleteOwnQuote|AdminDeleteAnyQuote|NonOwnerCannotEditOrDeleteQuote|BookQuotePagination|BookQuoteAuditLogEntries' -v`
  - tests are present and pass/skip appropriately when `CLUBHOUSE_TEST_DATABASE_URL` is not set

Closes #878