### PR TITLE
[Books] Add book stats to post responses

### DIFF
--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -27,6 +27,7 @@ type Post struct {
 	ReactionCounts  map[string]int `json:"reaction_counts,omitempty"`
 	ViewerReactions []string       `json:"viewer_reactions,omitempty"`
 	RecipeStats     *RecipeStats   `json:"recipe_stats,omitempty"`
+	BookStats       *BookStats     `json:"book_stats,omitempty"`
 	MovieStats      *MovieStats    `json:"movie_stats,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add `book_stats` to `models.Post` so book post responses can carry aggregate + viewer reading data
- implement `getBookStatsForPosts` (and single-post wrapper) in `PostService` by combining bookshelf stats and read-log stats
- wire book stats population into post-fetch paths: `GetPostByID`, `GetFeed` (book sections), and `GetPostsByUserID` (mixed section feeds)
- add service tests covering populated book stats, non-book omission, and counts/ratings across single post, section feed, and user feed responses

## Validation
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run "TestGetPostByIDIncludesBookStats|TestGetPostByIDNonBookOmitsBookStats|TestGetFeedIncludesBookStatsForBookSection|TestGetPostsByUserIDIncludesBookStatsForBookPosts|TestGetPostByIDIncludesMovieStats|TestGetFeedIncludesMovieStatsForMovieSection|TestGetPostsByUserIDIncludesMovieStatsForMovieAndSeries" -v`
- note: DB-backed tests are skipped in this environment because `CLUBHOUSE_TEST_DATABASE_URL` is not set

Closes #864