### PR TITLE
[Podcasts] Add podcast section seed and ordering

### DIFF
--- a/backend/internal/services/section.go
+++ b/backend/internal/services/section.go
@@ -32,11 +32,12 @@ func (s *SectionService) ListSections(ctx context.Context) ([]models.Section, er
 		ORDER BY CASE type
 			WHEN 'general' THEN 1
 			WHEN 'music' THEN 2
-			WHEN 'movie' THEN 3
-			WHEN 'series' THEN 4
-			WHEN 'recipe' THEN 5
-			WHEN 'book' THEN 6
-			WHEN 'event' THEN 7
+			WHEN 'podcast' THEN 3
+			WHEN 'movie' THEN 4
+			WHEN 'series' THEN 5
+			WHEN 'recipe' THEN 6
+			WHEN 'book' THEN 7
+			WHEN 'event' THEN 8
 			ELSE 100
 		END,
 		name ASC`

--- a/backend/internal/services/section_test.go
+++ b/backend/internal/services/section_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -35,6 +38,88 @@ func TestSectionServiceListSections(t *testing.T) {
 
 	if len(sections) == 0 {
 		t.Error("expected at least one section")
+	}
+}
+
+func TestSectionServiceListSectionsDeterministicOrderIncludesPodcast(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	testutil.CreateTestSection(t, db, "Movies", "movie")
+	testutil.CreateTestSection(t, db, "General", "general")
+	testutil.CreateTestSection(t, db, "Books", "book")
+	testutil.CreateTestSection(t, db, "Series", "series")
+	testutil.CreateTestSection(t, db, "Music", "music")
+	testutil.CreateTestSection(t, db, "Events", "event")
+	testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	testutil.CreateTestSection(t, db, "Zeta Misc", "zeta")
+	testutil.CreateTestSection(t, db, "Alpha Misc", "alpha")
+
+	service := NewSectionService(db)
+	sections, err := service.ListSections(context.Background())
+	if err != nil {
+		t.Fatalf("ListSections failed: %v", err)
+	}
+
+	gotTypes := make([]string, 0, len(sections))
+	for _, section := range sections {
+		gotTypes = append(gotTypes, section.Type)
+	}
+
+	expectedTypes := []string{
+		"general",
+		"music",
+		"podcast",
+		"movie",
+		"series",
+		"recipe",
+		"book",
+		"event",
+		"alpha",
+		"zeta",
+	}
+
+	if !reflect.DeepEqual(gotTypes, expectedTypes) {
+		t.Fatalf("unexpected section ordering: got %v, want %v", gotTypes, expectedTypes)
+	}
+}
+
+func TestPodcastSectionMigrationIsIdempotent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	migrationSQL, err := readMigrationFile("../../migrations/042_seed_podcast_section.up.sql")
+	if err != nil {
+		t.Fatalf("failed to read migration file: %v", err)
+	}
+
+	_, err = db.Exec(migrationSQL)
+	if err != nil {
+		t.Fatalf("failed applying migration (first run): %v", err)
+	}
+
+	_, err = db.Exec(migrationSQL)
+	if err != nil {
+		t.Fatalf("failed applying migration (second run): %v", err)
+	}
+
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM sections WHERE type = 'podcast'`).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed counting podcast sections: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 podcast section after running migration twice, got %d", count)
+	}
+
+	var name string
+	err = db.QueryRow(`SELECT name FROM sections WHERE type = 'podcast' LIMIT 1`).Scan(&name)
+	if err != nil {
+		t.Fatalf("failed reading podcast section: %v", err)
+	}
+	if name != "Podcasts" {
+		t.Fatalf("expected seeded podcast section name to be Podcasts, got %q", name)
 	}
 }
 
@@ -144,4 +229,13 @@ func insertTestSectionLink(t *testing.T, db *sql.DB, postID, url string, metadat
 
 func ptr(value string) *string {
 	return &value
+}
+
+func readMigrationFile(relativePath string) (string, error) {
+	path := filepath.Clean(relativePath)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }

--- a/backend/migrations/042_seed_podcast_section.down.sql
+++ b/backend/migrations/042_seed_podcast_section.down.sql
@@ -1,0 +1,9 @@
+-- Remove default Podcasts section if it is not in use.
+DELETE FROM sections s
+WHERE s.type = 'podcast'
+  AND s.name = 'Podcasts'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM posts p
+    WHERE p.section_id = s.id
+  );

--- a/backend/migrations/042_seed_podcast_section.down.sql
+++ b/backend/migrations/042_seed_podcast_section.down.sql
@@ -1,9 +1,5 @@
--- Remove default Podcasts section if it is not in use.
-DELETE FROM sections s
-WHERE s.type = 'podcast'
-  AND s.name = 'Podcasts'
-  AND NOT EXISTS (
-    SELECT 1
-    FROM posts p
-    WHERE p.section_id = s.id
-  );
+-- No-op rollback by design.
+-- This seed migration cannot safely identify which podcast rows were created by the migration.
+-- Deleting by type/name risks removing pre-existing user-managed rows and can violate FKs
+-- (for example via section_subscriptions). Keep existing data intact on rollback.
+SELECT 1;

--- a/backend/migrations/042_seed_podcast_section.up.sql
+++ b/backend/migrations/042_seed_podcast_section.up.sql
@@ -1,0 +1,8 @@
+-- Seed default Podcasts section if missing.
+INSERT INTO sections (name, type)
+SELECT 'Podcasts', 'podcast'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM sections
+  WHERE type = 'podcast'
+);


### PR DESCRIPTION
## Summary
- add migration `042_seed_podcast_section` to seed a default `Podcasts` section (`type = 'podcast'`) only when missing
- add `podcast` into deterministic `SectionService.ListSections` ordering (between `music` and `movie`)
- add service tests for deterministic section ordering and migration idempotency behavior

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run 'TestSectionServiceListSections|TestSectionServiceListSectionsDeterministicOrderIncludesPodcast|TestPodcastSectionMigrationIsIdempotent' -v`
  - note: DB-backed tests are skipped when `CLUBHOUSE_TEST_DATABASE_URL` is not set

Closes #887