### PR TITLE
[Books] Create SpoilerToggle and SpoilerWrapper components

### DIFF
--- a/frontend/src/components/books/SpoilerToggle.svelte
+++ b/frontend/src/components/books/SpoilerToggle.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let checked = false;
+
+  const dispatch = createEventDispatcher<{ change: boolean }>();
+
+  function handleChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement | null;
+    const nextChecked = Boolean(input?.checked);
+    checked = nextChecked;
+    dispatch('change', nextChecked);
+  }
+</script>
+
+<label class="inline-flex cursor-pointer select-none items-center gap-3" data-testid="spoiler-toggle">
+  <input
+    type="checkbox"
+    checked={checked}
+    on:change={handleChange}
+    aria-label="Contains spoiler"
+    class="h-4 w-4 rounded border-gray-300 text-slate-700 focus:ring-slate-500"
+    data-testid="spoiler-toggle-input"
+  />
+  <span class="text-sm font-medium text-slate-700">Contains spoiler</span>
+
+  {#if checked}
+    <span
+      class="inline-flex h-5 w-5 items-center justify-center text-slate-600"
+      data-testid="spoiler-toggle-eye-slash"
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 24 24" class="h-4 w-4 fill-none stroke-current stroke-2">
+        <path
+          d="M3 12s3.5-6 9-6c2.1 0 3.9.6 5.4 1.5M21 12s-3.5 6-9 6c-2.1 0-3.9-.6-5.4-1.5M9.9 9.9A3 3 0 0 1 12 9a3 3 0 0 1 3 3c0 .8-.3 1.5-.8 2.1M3 3l18 18"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </span>
+  {/if}
+</label>

--- a/frontend/src/components/books/SpoilerToggle.test.ts
+++ b/frontend/src/components/books/SpoilerToggle.test.ts
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { default: SpoilerToggle } = await import('./SpoilerToggle.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SpoilerToggle', () => {
+  it('renders unchecked state', () => {
+    render(SpoilerToggle, { checked: false });
+
+    const input = screen.getByLabelText('Contains spoiler') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    expect(screen.queryByTestId('spoiler-toggle-eye-slash')).not.toBeInTheDocument();
+  });
+
+  it('renders checked state with eye-slash icon', () => {
+    render(SpoilerToggle, { checked: true });
+
+    const input = screen.getByLabelText('Contains spoiler') as HTMLInputElement;
+    expect(input.checked).toBe(true);
+    expect(screen.getByTestId('spoiler-toggle-eye-slash')).toBeInTheDocument();
+  });
+
+  it('emits change events with boolean value', async () => {
+    const { component } = render(SpoilerToggle, { checked: false });
+    const onChange = vi.fn();
+    component.$on('change', onChange);
+
+    const input = screen.getByLabelText('Contains spoiler');
+    await fireEvent.click(input);
+    await fireEvent.click(input);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[0]?.[0]?.detail).toBe(true);
+    expect(onChange.mock.calls[1]?.[0]?.detail).toBe(false);
+  });
+});

--- a/frontend/src/components/books/SpoilerWrapper.svelte
+++ b/frontend/src/components/books/SpoilerWrapper.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  export let isSpoiler = false;
+
+  let revealed = false;
+  let lastSpoilerState = isSpoiler;
+
+  $: if (isSpoiler !== lastSpoilerState) {
+    lastSpoilerState = isSpoiler;
+    revealed = false;
+  }
+
+  $: isHidden = isSpoiler && !revealed;
+
+  function revealContent() {
+    if (!isHidden) {
+      return;
+    }
+
+    revealed = true;
+  }
+</script>
+
+<div class="relative overflow-hidden rounded-lg" data-testid="spoiler-wrapper">
+  <div
+    class="transition duration-300 ease-out"
+    class:pointer-events-none={isHidden}
+    style={`filter: ${isHidden ? 'blur(8px)' : 'none'}; opacity: ${isHidden ? 0.75 : 1};`}
+    data-testid="spoiler-content"
+  >
+    <slot />
+  </div>
+
+  {#if isHidden}
+    <button
+      type="button"
+      class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-white/70 text-center"
+      on:click={revealContent}
+      data-testid="spoiler-overlay"
+    >
+      <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-slate-700">
+        <svg viewBox="0 0 24 24" class="h-5 w-5 fill-none stroke-current stroke-2" aria-hidden="true">
+          <path
+            d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      </span>
+      <span class="text-sm font-semibold text-slate-900">Spoiler &mdash; Click to reveal</span>
+    </button>
+  {/if}
+
+  {#if isSpoiler && !isHidden}
+    <span
+      class="absolute right-2 top-2 rounded-full bg-slate-800/85 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white"
+      data-testid="spoiler-badge"
+    >
+      Spoiler
+    </span>
+  {/if}
+</div>

--- a/frontend/src/components/books/SpoilerWrapper.test.ts
+++ b/frontend/src/components/books/SpoilerWrapper.test.ts
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const { default: SpoilerWrapper } = await import('./SpoilerWrapper.svelte');
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SpoilerWrapper', () => {
+  it('blurs content and shows reveal overlay when spoiler is hidden', () => {
+    render(SpoilerWrapper, { isSpoiler: true });
+
+    expect(screen.getByTestId('spoiler-content')).toHaveStyle('filter: blur(8px)');
+    expect(screen.getByTestId('spoiler-overlay')).toBeInTheDocument();
+    expect(screen.getByText('Spoiler — Click to reveal')).toBeInTheDocument();
+  });
+
+  it('reveals spoiler content on click', async () => {
+    render(SpoilerWrapper, { isSpoiler: true });
+
+    await fireEvent.click(screen.getByTestId('spoiler-overlay'));
+
+    expect(screen.queryByTestId('spoiler-overlay')).not.toBeInTheDocument();
+    expect(screen.getByTestId('spoiler-content')).toHaveStyle('filter: none');
+    expect(screen.getByTestId('spoiler-badge')).toBeInTheDocument();
+  });
+
+  it('shows content normally when not marked as spoiler', () => {
+    render(SpoilerWrapper, { isSpoiler: false });
+
+    expect(screen.queryByTestId('spoiler-overlay')).not.toBeInTheDocument();
+    expect(screen.getByTestId('spoiler-content')).toHaveStyle('filter: none');
+    expect(screen.queryByTestId('spoiler-badge')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `SpoilerToggle` with a `checked` prop, "Contains spoiler" label, checked eye-slash icon, and `change` event dispatch carrying a boolean
- add `SpoilerWrapper` with spoiler blur state, reveal overlay (`Spoiler — Click to reveal`), click-to-reveal behavior, transition styling, and post-reveal spoiler badge
- add focused component tests for toggle state/event behavior and wrapper blur/reveal/non-spoiler behavior

## Testing
- `npm run test -- src/components/books/SpoilerToggle.test.ts src/components/books/SpoilerWrapper.test.ts`
- `npm run check`
- `npx eslint src/components/books/SpoilerToggle.svelte src/components/books/SpoilerWrapper.svelte src/components/books/SpoilerToggle.test.ts src/components/books/SpoilerWrapper.test.ts`

Closes #885