### PR TITLE
[Podcasts] Add podcast metadata model and validation for post links

### DIFF
--- a/backend/internal/handlers/highlights.go
+++ b/backend/internal/handlers/highlights.go
@@ -25,6 +25,39 @@ func writeHighlightValidationError(ctx context.Context, w http.ResponseWriter, e
 	case strings.HasPrefix(message, "highlight label must be less than"):
 		writeError(ctx, w, http.StatusBadRequest, "HIGHLIGHT_LABEL_TOO_LONG", message)
 		return true
+	case strings.HasPrefix(message, "podcast metadata is not allowed"):
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_METADATA_NOT_ALLOWED", message)
+		return true
+	case message == "podcast kind is required":
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_KIND_REQUIRED", message)
+		return true
+	case message == `podcast kind must be either "show" or "episode"`:
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_KIND_INVALID", message)
+		return true
+	case message == `podcast highlight episodes are only allowed for kind "show"`:
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODES_NOT_ALLOWED", message)
+		return true
+	case message == "too many podcast highlight episodes":
+		writeError(ctx, w, http.StatusBadRequest, "TOO_MANY_PODCAST_HIGHLIGHT_EPISODES", message)
+		return true
+	case message == "podcast highlight episode title is required":
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_TITLE_REQUIRED", message)
+		return true
+	case strings.HasPrefix(message, "podcast highlight episode title must be less than"):
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_TITLE_TOO_LONG", message)
+		return true
+	case message == "podcast highlight episode url is required":
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_URL_REQUIRED", message)
+		return true
+	case strings.HasPrefix(message, "podcast highlight episode url must be less than"):
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_URL_TOO_LONG", message)
+		return true
+	case message == "podcast highlight episode url must be a valid http or https URL":
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_URL_INVALID", message)
+		return true
+	case strings.HasPrefix(message, "podcast highlight episode note must be less than"):
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_HIGHLIGHT_EPISODE_NOTE_TOO_LONG", message)
+		return true
 	default:
 		return false
 	}

--- a/backend/internal/handlers/highlights_test.go
+++ b/backend/internal/handlers/highlights_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+func TestWriteHighlightValidationError_PodcastErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		code    string
+	}{
+		{
+			name:    "metadata not allowed",
+			message: `podcast metadata is not allowed for section type "general"`,
+			code:    "PODCAST_METADATA_NOT_ALLOWED",
+		},
+		{
+			name:    "kind required",
+			message: "podcast kind is required",
+			code:    "PODCAST_KIND_REQUIRED",
+		},
+		{
+			name:    "episode highlights not allowed",
+			message: `podcast highlight episodes are only allowed for kind "show"`,
+			code:    "PODCAST_HIGHLIGHT_EPISODES_NOT_ALLOWED",
+		},
+		{
+			name:    "url invalid",
+			message: "podcast highlight episode url must be a valid http or https URL",
+			code:    "PODCAST_HIGHLIGHT_EPISODE_URL_INVALID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handled := writeHighlightValidationError(context.Background(), recorder, errors.New(tt.message))
+			if !handled {
+				t.Fatalf("expected error to be handled")
+			}
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("expected status 400, got %d", recorder.Code)
+			}
+
+			var response models.ErrorResponse
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if response.Code != tt.code {
+				t.Fatalf("expected code %q, got %q", tt.code, response.Code)
+			}
+		})
+	}
+}

--- a/backend/internal/models/post_test.go
+++ b/backend/internal/models/post_test.go
@@ -76,3 +76,162 @@ func TestValidateHighlights(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePodcastMetadata(t *testing.T) {
+	validShow := &PodcastMetadata{
+		Kind: "show",
+		HighlightEpisodes: []PodcastHighlightEpisode{
+			{
+				Title: strings.Repeat("a", maxPodcastHighlightEpisodeTitleSize),
+				URL:   "https://example.com/episodes/1",
+			},
+		},
+	}
+	validEpisode := &PodcastMetadata{Kind: "episode"}
+
+	tests := []struct {
+		name        string
+		sectionType string
+		podcast     *PodcastMetadata
+		wantErr     bool
+	}{
+		{
+			name:        "nil metadata allowed",
+			sectionType: "general",
+			podcast:     nil,
+			wantErr:     false,
+		},
+		{
+			name:        "podcast metadata not allowed in non podcast section",
+			sectionType: "music",
+			podcast:     validShow,
+			wantErr:     true,
+		},
+		{
+			name:        "kind required",
+			sectionType: "podcast",
+			podcast:     &PodcastMetadata{},
+			wantErr:     true,
+		},
+		{
+			name:        "kind must be show or episode",
+			sectionType: "podcast",
+			podcast:     &PodcastMetadata{Kind: "series"},
+			wantErr:     true,
+		},
+		{
+			name:        "episode cannot include highlights",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "episode",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: "https://example.com/episodes/1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "too many highlighted episodes",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind:              "show",
+				HighlightEpisodes: make([]PodcastHighlightEpisode, maxPodcastHighlightEpisodesPerLink+1),
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight title required",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: " ", URL: "https://example.com/episodes/1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight title too long",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: strings.Repeat("b", maxPodcastHighlightEpisodeTitleSize+1), URL: "https://example.com/episodes/1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight url required",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: " "},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight url too long",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: "https://" + strings.Repeat("x", 2050)},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight url must be http or https",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: "ftp://example.com/episodes/1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "highlight note too long",
+			sectionType: "podcast",
+			podcast: &PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []PodcastHighlightEpisode{
+					{
+						Title: "Episode 1",
+						URL:   "https://example.com/episodes/1",
+						Note:  func() *string { value := strings.Repeat("n", maxPodcastHighlightEpisodeNoteSize+1); return &value }(),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "valid show metadata",
+			sectionType: "podcast",
+			podcast:     validShow,
+			wantErr:     false,
+		},
+		{
+			name:        "valid episode metadata",
+			sectionType: "podcast",
+			podcast:     validEpisode,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePodcastMetadata(tt.sectionType, tt.podcast)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -106,6 +106,10 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 			recordSpanError(span, err)
 			return nil, err
 		}
+		if err := models.ValidatePodcastMetadata(sectionType, link.Podcast); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
 	}
 	highlightCount := countLinkHighlights(req.Links)
 	if highlightCount > 0 {
@@ -152,7 +156,7 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 		for _, linkReq := range req.Links {
 			linkID := uuid.New()
 
-			mergedMetadata, sortedHighlights := mergeHighlightsIntoMetadata(linkReq, nil)
+			mergedMetadata, sortedHighlights, podcast := mergeHighlightsIntoMetadata(linkReq, nil)
 			metadataValue := interface{}(nil)
 			if len(mergedMetadata) > 0 {
 				metadataValue = mergedMetadata
@@ -179,6 +183,9 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 			}
 			if len(sortedHighlights) > 0 {
 				link.Highlights = sortedHighlights
+			}
+			if podcast != nil {
+				link.Podcast = podcast
 			}
 
 			post.Links = append(post.Links, link)
@@ -353,6 +360,10 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 				recordSpanError(span, err)
 				return nil, err
 			}
+			if err := models.ValidatePodcastMetadata(sectionType, link.Podcast); err != nil {
+				recordSpanError(span, err)
+				return nil, err
+			}
 		}
 
 		linksChanged = !linkRequestsMatchExistingLinks(existingLinks, *req.Links)
@@ -406,7 +417,7 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 					fetchedMetadata = linkMetadata[i]
 				}
 
-				mergedMetadata, _ := mergeHighlightsIntoMetadata(linkReq, fetchedMetadata)
+				mergedMetadata, _, _ := mergeHighlightsIntoMetadata(linkReq, fetchedMetadata)
 				metadataValue := interface{}(nil)
 				if len(mergedMetadata) > 0 {
 					metadataValue = mergedMetadata
@@ -656,6 +667,13 @@ func (s *PostService) getPostLinks(ctx context.Context, postID uuid.UUID, viewer
 					highlightCount += len(highlights)
 					delete(metadata, "highlights")
 				}
+				podcast, err := extractPodcastFromMetadata(metadata)
+				if err != nil {
+					observability.LogWarn(ctx, "failed to parse podcast metadata", "post_id", postID.String(), "link_id", link.ID.String())
+				} else if podcast != nil {
+					link.Podcast = podcast
+					delete(metadata, "podcast")
+				}
 				if len(metadata) > 0 {
 					link.Metadata = metadata
 				}
@@ -897,10 +915,11 @@ func countLinkHighlights(links []models.LinkRequest) int {
 	return count
 }
 
-func mergeHighlightsIntoMetadata(link models.LinkRequest, fetched models.JSONMap) (models.JSONMap, []models.Highlight) {
+func mergeHighlightsIntoMetadata(link models.LinkRequest, fetched models.JSONMap) (models.JSONMap, []models.Highlight, *models.PodcastMetadata) {
 	sortedHighlights := sortHighlights(sanitizeHighlights(link.Highlights))
-	if len(sortedHighlights) == 0 && len(fetched) == 0 {
-		return nil, sortedHighlights
+	sanitizedPodcast := sanitizePodcastMetadata(link.Podcast)
+	if len(sortedHighlights) == 0 && sanitizedPodcast == nil && len(fetched) == 0 {
+		return nil, sortedHighlights, nil
 	}
 	metadata := make(models.JSONMap)
 	for key, value := range fetched {
@@ -909,7 +928,10 @@ func mergeHighlightsIntoMetadata(link models.LinkRequest, fetched models.JSONMap
 	if len(sortedHighlights) > 0 {
 		metadata["highlights"] = sortedHighlights
 	}
-	return metadata, sortedHighlights
+	if sanitizedPodcast != nil {
+		metadata["podcast"] = sanitizedPodcast
+	}
+	return metadata, sortedHighlights, sanitizedPodcast
 }
 
 func stripHighlightsFromMetadata(metadata models.JSONMap) map[string]interface{} {
@@ -918,7 +940,7 @@ func stripHighlightsFromMetadata(metadata models.JSONMap) map[string]interface{}
 	}
 	trimmed := make(map[string]interface{}, len(metadata))
 	for key, value := range metadata {
-		if key == "highlights" {
+		if key == "highlights" || key == "podcast" {
 			continue
 		}
 		trimmed[key] = value
@@ -945,6 +967,22 @@ func extractHighlightsFromMetadata(metadata map[string]interface{}) ([]models.Hi
 	return sortHighlights(highlights), nil
 }
 
+func extractPodcastFromMetadata(metadata map[string]interface{}) (*models.PodcastMetadata, error) {
+	raw, ok := metadata["podcast"]
+	if !ok {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var podcast models.PodcastMetadata
+	if err := json.Unmarshal(encoded, &podcast); err != nil {
+		return nil, err
+	}
+	return sanitizePodcastMetadata(&podcast), nil
+}
+
 func sanitizeHighlights(highlights []models.Highlight) []models.Highlight {
 	if len(highlights) == 0 {
 		return nil
@@ -954,6 +992,28 @@ func sanitizeHighlights(highlights []models.Highlight) []models.Highlight {
 		sanitized = append(sanitized, models.Highlight{
 			Timestamp: highlight.Timestamp,
 			Label:     highlight.Label,
+		})
+	}
+	return sanitized
+}
+
+func sanitizePodcastMetadata(podcast *models.PodcastMetadata) *models.PodcastMetadata {
+	if podcast == nil {
+		return nil
+	}
+	sanitized := &models.PodcastMetadata{
+		Kind: strings.ToLower(strings.TrimSpace(podcast.Kind)),
+	}
+	if len(podcast.HighlightEpisodes) == 0 {
+		return sanitized
+	}
+
+	sanitized.HighlightEpisodes = make([]models.PodcastHighlightEpisode, 0, len(podcast.HighlightEpisodes))
+	for _, episode := range podcast.HighlightEpisodes {
+		sanitized.HighlightEpisodes = append(sanitized.HighlightEpisodes, models.PodcastHighlightEpisode{
+			Title: strings.TrimSpace(episode.Title),
+			URL:   strings.TrimSpace(episode.URL),
+			Note:  normalizeOptionalText(episode.Note),
 		})
 	}
 	return sanitized
@@ -988,7 +1048,33 @@ func linkRequestsMatchExistingLinks(existing []models.Link, requested []models.L
 				return false
 			}
 		}
+		if !podcastMetadataMatches(existing[i].Podcast, link.Podcast) {
+			return false
+		}
 	}
+	return true
+}
+
+func podcastMetadataMatches(existing *models.PodcastMetadata, requested *models.PodcastMetadata) bool {
+	existingSanitized := sanitizePodcastMetadata(existing)
+	requestedSanitized := sanitizePodcastMetadata(requested)
+
+	if existingSanitized == nil || requestedSanitized == nil {
+		return existingSanitized == nil && requestedSanitized == nil
+	}
+
+	if existingSanitized.Kind != requestedSanitized.Kind {
+		return false
+	}
+	if len(existingSanitized.HighlightEpisodes) != len(requestedSanitized.HighlightEpisodes) {
+		return false
+	}
+	for i := range existingSanitized.HighlightEpisodes {
+		if existingSanitized.HighlightEpisodes[i] != requestedSanitized.HighlightEpisodes[i] {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -1070,12 +1070,27 @@ func podcastMetadataMatches(existing *models.PodcastMetadata, requested *models.
 		return false
 	}
 	for i := range existingSanitized.HighlightEpisodes {
-		if existingSanitized.HighlightEpisodes[i] != requestedSanitized.HighlightEpisodes[i] {
+		existingEpisode := existingSanitized.HighlightEpisodes[i]
+		requestedEpisode := requestedSanitized.HighlightEpisodes[i]
+		if existingEpisode.Title != requestedEpisode.Title {
+			return false
+		}
+		if existingEpisode.URL != requestedEpisode.URL {
+			return false
+		}
+		if !optionalStringPtrEqual(existingEpisode.Note, requestedEpisode.Note) {
 			return false
 		}
 	}
 
 	return true
+}
+
+func optionalStringPtrEqual(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func findPrimaryNonImageLink(links []models.Link) *models.Link {

--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -347,6 +347,208 @@ func TestCreatePostRejectsHighlightsForNonMusicSection(t *testing.T) {
 	}
 }
 
+func TestCreatePostWithPodcastMetadataStoresPodcastPayload(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	disableLinkMetadata(t)
+
+	userID := testutil.CreateTestUser(t, db, "podcastmeta", "podcastmeta@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcast Section", "podcast")
+
+	service := NewPostService(db)
+	req := &models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Podcast show",
+		Links: []models.LinkRequest{
+			{
+				URL: "https://example.com/show",
+				Podcast: &models.PodcastMetadata{
+					Kind: "show",
+					HighlightEpisodes: []models.PodcastHighlightEpisode{
+						{
+							Title: "Episode 1",
+							URL:   "https://example.com/show/episodes/1",
+							Note:  stringPtr("Kickoff"),
+						},
+						{
+							Title: "Episode 2",
+							URL:   "https://example.com/show/episodes/2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	post, err := service.CreatePost(context.Background(), req, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("CreatePost failed: %v", err)
+	}
+
+	if len(post.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(post.Links))
+	}
+	if post.Links[0].Podcast == nil {
+		t.Fatalf("expected podcast metadata on response link")
+	}
+	if post.Links[0].Podcast.Kind != "show" {
+		t.Fatalf("expected podcast kind show, got %q", post.Links[0].Podcast.Kind)
+	}
+	if len(post.Links[0].Podcast.HighlightEpisodes) != 2 {
+		t.Fatalf("expected 2 highlight episodes, got %d", len(post.Links[0].Podcast.HighlightEpisodes))
+	}
+
+	var metadataBytes []byte
+	if err := db.QueryRow(`SELECT metadata FROM links WHERE post_id = $1`, post.ID).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query link metadata: %v", err)
+	}
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal link metadata: %v", err)
+	}
+	rawPodcast, ok := metadata["podcast"]
+	if !ok {
+		t.Fatalf("expected podcast metadata to be persisted")
+	}
+	encoded, err := json.Marshal(rawPodcast)
+	if err != nil {
+		t.Fatalf("failed to marshal podcast metadata: %v", err)
+	}
+	var storedPodcast models.PodcastMetadata
+	if err := json.Unmarshal(encoded, &storedPodcast); err != nil {
+		t.Fatalf("failed to unmarshal podcast metadata: %v", err)
+	}
+	if storedPodcast.Kind != "show" {
+		t.Fatalf("expected stored kind show, got %q", storedPodcast.Kind)
+	}
+	if len(storedPodcast.HighlightEpisodes) != 2 {
+		t.Fatalf("expected 2 stored highlight episodes, got %d", len(storedPodcast.HighlightEpisodes))
+	}
+
+	loaded, err := service.GetPostByID(context.Background(), post.ID, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("GetPostByID failed: %v", err)
+	}
+	if len(loaded.Links) != 1 || loaded.Links[0].Podcast == nil {
+		t.Fatalf("expected podcast metadata to be extracted from stored link metadata")
+	}
+	if loaded.Links[0].Metadata != nil {
+		if _, exists := loaded.Links[0].Metadata["podcast"]; exists {
+			t.Fatalf("expected podcast key to be stripped from generic metadata")
+		}
+	}
+}
+
+func TestCreatePostRejectsPodcastMetadataValidation(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	disableLinkMetadata(t)
+
+	userID := testutil.CreateTestUser(t, db, "podcastreject", "podcastreject@test.com", false, true)
+	podcastSectionID := testutil.CreateTestSection(t, db, "Podcast Section", "podcast")
+	generalSectionID := testutil.CreateTestSection(t, db, "General Section", "general")
+	service := NewPostService(db)
+
+	tests := []struct {
+		name      string
+		sectionID string
+		podcast   *models.PodcastMetadata
+		wantErr   string
+	}{
+		{
+			name:      "podcast metadata not allowed outside podcast section",
+			sectionID: generalSectionID,
+			podcast: &models.PodcastMetadata{
+				Kind: "show",
+			},
+			wantErr: "podcast metadata is not allowed",
+		},
+		{
+			name:      "episode kind rejects highlight episodes",
+			sectionID: podcastSectionID,
+			podcast: &models.PodcastMetadata{
+				Kind: "episode",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: "https://example.com/episodes/1"},
+				},
+			},
+			wantErr: "only allowed for kind",
+		},
+		{
+			name:      "invalid highlight episode url",
+			sectionID: podcastSectionID,
+			podcast: &models.PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{Title: "Episode 1", URL: "ftp://example.com/episodes/1"},
+				},
+			},
+			wantErr: "valid http or https URL",
+		},
+		{
+			name:      "too many highlight episodes",
+			sectionID: podcastSectionID,
+			podcast: &models.PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{Title: "1", URL: "https://example.com/e/1"},
+					{Title: "2", URL: "https://example.com/e/2"},
+					{Title: "3", URL: "https://example.com/e/3"},
+					{Title: "4", URL: "https://example.com/e/4"},
+					{Title: "5", URL: "https://example.com/e/5"},
+					{Title: "6", URL: "https://example.com/e/6"},
+					{Title: "7", URL: "https://example.com/e/7"},
+					{Title: "8", URL: "https://example.com/e/8"},
+					{Title: "9", URL: "https://example.com/e/9"},
+					{Title: "10", URL: "https://example.com/e/10"},
+					{Title: "11", URL: "https://example.com/e/11"},
+				},
+			},
+			wantErr: "too many podcast highlight episodes",
+		},
+		{
+			name:      "highlight note too long",
+			sectionID: podcastSectionID,
+			podcast: &models.PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{
+						Title: "Episode 1",
+						URL:   "https://example.com/e/1",
+						Note:  stringPtr(strings.Repeat("n", 501)),
+					},
+				},
+			},
+			wantErr: "note must be less than",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &models.CreatePostRequest{
+				SectionID: tt.sectionID,
+				Content:   "Podcast post",
+				Links: []models.LinkRequest{
+					{
+						URL:     "https://example.com/show",
+						Podcast: tt.podcast,
+					},
+				},
+			}
+
+			_, err := service.CreatePost(context.Background(), req, uuid.MustParse(userID))
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestCreatePostWithLinksNoContent(t *testing.T) {
 	db := testutil.RequireTestDB(t)
 	t.Cleanup(func() { testutil.CleanupTables(t, db) })
@@ -1668,6 +1870,61 @@ func TestUpdatePostHighlights(t *testing.T) {
 	}
 	if len(storedHighlights) != 2 || storedHighlights[0].Timestamp != 12 || storedHighlights[1].Timestamp != 30 {
 		t.Errorf("expected stored highlights sorted, got %+v", storedHighlights)
+	}
+}
+
+func TestUpdatePostRejectsPodcastEpisodeHighlightEpisodes(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	disableLinkMetadata(t)
+
+	userID := testutil.CreateTestUser(t, db, "updatepodcastreject", "updatepodcastreject@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Update Podcast Section", "podcast")
+
+	service := NewPostService(db)
+	createReq := &models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Podcast post",
+		Links: []models.LinkRequest{
+			{
+				URL: "https://example.com/show",
+				Podcast: &models.PodcastMetadata{
+					Kind: "show",
+				},
+			},
+		},
+	}
+
+	post, err := service.CreatePost(context.Background(), createReq, uuid.MustParse(userID))
+	if err != nil {
+		t.Fatalf("CreatePost failed: %v", err)
+	}
+
+	updateReq := &models.UpdatePostRequest{
+		Content: "Podcast post",
+		Links: &[]models.LinkRequest{
+			{
+				URL: "https://example.com/show",
+				Podcast: &models.PodcastMetadata{
+					Kind: "episode",
+					HighlightEpisodes: []models.PodcastHighlightEpisode{
+						{
+							Title: "Episode 1",
+							URL:   "https://example.com/show/episodes/1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = service.UpdatePost(context.Background(), post.ID, uuid.MustParse(userID), updateReq)
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "only allowed for kind") {
+		t.Fatalf("expected episode highlight validation error, got %v", err)
 	}
 }
 

--- a/backend/internal/services/post_test.go
+++ b/backend/internal/services/post_test.go
@@ -2179,6 +2179,47 @@ func TestAdminDeletePostCreatesAuditLogWithMetadata(t *testing.T) {
 	}
 }
 
+func TestLinkRequestsMatchExistingLinks_PodcastNotesUseValueComparison(t *testing.T) {
+	existingNote := "Same note value"
+	requestedNote := "Same note value"
+
+	existing := []models.Link{
+		{
+			URL: "https://example.com/show",
+			Podcast: &models.PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{
+						Title: "Episode 1",
+						URL:   "https://example.com/show/1",
+						Note:  &existingNote,
+					},
+				},
+			},
+		},
+	}
+
+	requested := []models.LinkRequest{
+		{
+			URL: "https://example.com/show",
+			Podcast: &models.PodcastMetadata{
+				Kind: "show",
+				HighlightEpisodes: []models.PodcastHighlightEpisode{
+					{
+						Title: "Episode 1",
+						URL:   "https://example.com/show/1",
+						Note:  &requestedNote,
+					},
+				},
+			},
+		},
+	}
+
+	if !linkRequestsMatchExistingLinks(existing, requested) {
+		t.Fatalf("expected links to match when note values are equal but pointers differ")
+	}
+}
+
 func disableLinkMetadata(t *testing.T) {
 	t.Helper()
 	config := GetConfigService()


### PR DESCRIPTION
## Summary
- extend post link request/response models with structured `podcast` metadata (`kind`, `highlight_episodes[]`)
- add section-aware podcast validation rules in the model layer (podcast-only usage, `show`/`episode` constraints, URL/title/note limits, max highlighted episodes, HTTP(S) URL checks)
- enforce podcast validation during post create/update, persist podcast metadata in link JSON, and hydrate `link.podcast` on read while stripping internal metadata keys from generic metadata
- include podcast metadata in update link-change detection so podcast-only edits are persisted
- add canonical 400 error mappings for podcast validation failures and add focused tests for model/service/handler coverage

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/models -run 'TestValidate(Highlights|PodcastMetadata)' -v`
- `cd backend && go test ./internal/handlers -run 'TestWriteHighlightValidationError_PodcastErrors' -v`
- `cd backend && go test ./internal/services -run 'TestCreatePostWithPodcastMetadataStoresPodcastPayload|TestCreatePostRejectsPodcastMetadataValidation|TestUpdatePostRejectsPodcastEpisodeHighlightEpisodes' -v` *(DB-backed tests are skipped when `CLUBHOUSE_TEST_DATABASE_URL` is unset)*

Closes #888