### PR TITLE
[Books] Create bookStore

### DIFF
--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -139,6 +139,33 @@ describe('mapApiPost', () => {
     expect(post.movieStats?.viewerCategories).toEqual(['Top Picks']);
   });
 
+  it('maps book stats from API shape', () => {
+    const post = mapApiPost({
+      id: 'post-book-stats',
+      user_id: 'user-book-stats',
+      section_id: 'section-book',
+      content: 'Book stats',
+      created_at: '2025-01-01T00:00:00Z',
+      book_stats: {
+        bookshelf_count: 8,
+        read_count: 5,
+        average_rating: 4.4,
+        viewer_on_bookshelf: true,
+        viewer_categories: ['Favorites'],
+        viewer_read: true,
+        viewer_rating: 5,
+      },
+    });
+
+    expect(post.bookStats?.bookshelfCount).toBe(8);
+    expect(post.bookStats?.readCount).toBe(5);
+    expect(post.bookStats?.averageRating).toBe(4.4);
+    expect(post.bookStats?.viewerOnBookshelf).toBe(true);
+    expect(post.bookStats?.viewerCategories).toEqual(['Favorites']);
+    expect(post.bookStats?.viewerRead).toBe(true);
+    expect(post.bookStats?.viewerRating).toBe(5);
+  });
+
   it('preserves and normalizes nested movie metadata payload', () => {
     const post = mapApiPost({
       id: 'post-movie-metadata',

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -281,6 +281,80 @@ describe('postStore', () => {
     });
   });
 
+  it('setBookBookshelfState updates viewer bookshelf flags and count', () => {
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          bookStats: {
+            bookshelfCount: 2,
+            readCount: 1,
+            averageRating: 4,
+            viewerOnBookshelf: false,
+            viewerCategories: [],
+            viewerRead: false,
+            viewerRating: null,
+          },
+        },
+      ],
+      null,
+      true
+    );
+
+    postStore.setBookBookshelfState('post-1', true, ['Favorites']);
+    let state = get(postStore);
+    expect(state.posts[0].bookStats?.bookshelfCount).toBe(3);
+    expect(state.posts[0].bookStats?.viewerOnBookshelf).toBe(true);
+    expect(state.posts[0].bookStats?.viewerCategories).toEqual(['Favorites']);
+
+    postStore.setBookBookshelfState('post-1', false, []);
+    state = get(postStore);
+    expect(state.posts[0].bookStats?.bookshelfCount).toBe(2);
+    expect(state.posts[0].bookStats?.viewerOnBookshelf).toBe(false);
+    expect(state.posts[0].bookStats?.viewerCategories).toEqual([]);
+  });
+
+  it('setBookReadState and setBookStats update read stats', () => {
+    postStore.setPosts(
+      [
+        {
+          ...basePost,
+          bookStats: {
+            bookshelfCount: 1,
+            readCount: 1,
+            averageRating: 3,
+            viewerOnBookshelf: true,
+            viewerCategories: ['Favorites'],
+            viewerRead: false,
+            viewerRating: null,
+          },
+        },
+      ],
+      null,
+      true
+    );
+
+    postStore.setBookReadState('post-1', true, 4);
+    let state = get(postStore);
+    expect(state.posts[0].bookStats?.readCount).toBe(2);
+    expect(state.posts[0].bookStats?.viewerRead).toBe(true);
+    expect(state.posts[0].bookStats?.viewerRating).toBe(4);
+
+    postStore.setBookStats('post-1', {
+      readCount: 7,
+      averageRating: 4.3,
+      viewerRead: true,
+      viewerRating: 5,
+    });
+    state = get(postStore);
+    expect(state.posts[0].bookStats).toMatchObject({
+      readCount: 7,
+      averageRating: 4.3,
+      viewerRead: true,
+      viewerRating: 5,
+    });
+  });
+
   it('reset restores defaults', () => {
     postStore.setPosts([basePost], 'cursor-1', false);
     postStore.reset();

--- a/frontend/src/stores/bookStore.test.ts
+++ b/frontend/src/stores/bookStore.test.ts
@@ -1,0 +1,423 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+const apiGetBookshelfCategories = vi.hoisted(() => vi.fn());
+const apiAddToBookshelf = vi.hoisted(() => vi.fn());
+const apiRemoveFromBookshelf = vi.hoisted(() => vi.fn());
+const apiCreateBookshelfCategory = vi.hoisted(() => vi.fn());
+const apiUpdateBookshelfCategory = vi.hoisted(() => vi.fn());
+const apiDeleteBookshelfCategory = vi.hoisted(() => vi.fn());
+const apiLogRead = vi.hoisted(() => vi.fn());
+const apiRemoveReadLog = vi.hoisted(() => vi.fn());
+const apiUpdateReadRating = vi.hoisted(() => vi.fn());
+const apiGetMyBookshelf = vi.hoisted(() => vi.fn());
+const apiGetAllBookshelfItems = vi.hoisted(() => vi.fn());
+const apiGetReadHistory = vi.hoisted(() => vi.fn());
+const apiGetPostReadLogs = vi.hoisted(() => vi.fn());
+
+vi.mock('../services/api', () => ({
+  api: {
+    getBookshelfCategories: apiGetBookshelfCategories,
+    addToBookshelf: apiAddToBookshelf,
+    removeFromBookshelf: apiRemoveFromBookshelf,
+    createBookshelfCategory: apiCreateBookshelfCategory,
+    updateBookshelfCategory: apiUpdateBookshelfCategory,
+    deleteBookshelfCategory: apiDeleteBookshelfCategory,
+    logRead: apiLogRead,
+    removeReadLog: apiRemoveReadLog,
+    updateReadRating: apiUpdateReadRating,
+    getMyBookshelf: apiGetMyBookshelf,
+    getAllBookshelfItems: apiGetAllBookshelfItems,
+    getReadHistory: apiGetReadHistory,
+    getPostReadLogs: apiGetPostReadLogs,
+  },
+}));
+
+const {
+  bookStore,
+  bookshelfCategories,
+  myBookshelf,
+  allBookshelf,
+  readHistory,
+  bookStoreMeta,
+} = await import('./bookStore');
+const { authStore } = await import('./authStore');
+const { postStore } = await import('./postStore');
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(() => {
+  bookStore.reset();
+  postStore.reset();
+  authStore.setUser({
+    id: 'user-1',
+    username: 'reader',
+    email: 'reader@example.com',
+    isAdmin: false,
+    totpEnabled: false,
+  });
+
+  apiGetBookshelfCategories.mockReset();
+  apiAddToBookshelf.mockReset();
+  apiRemoveFromBookshelf.mockReset();
+  apiCreateBookshelfCategory.mockReset();
+  apiUpdateBookshelfCategory.mockReset();
+  apiDeleteBookshelfCategory.mockReset();
+  apiLogRead.mockReset();
+  apiRemoveReadLog.mockReset();
+  apiUpdateReadRating.mockReset();
+  apiGetMyBookshelf.mockReset();
+  apiGetAllBookshelfItems.mockReset();
+  apiGetReadHistory.mockReset();
+  apiGetPostReadLogs.mockReset();
+
+  apiGetBookshelfCategories.mockResolvedValue({ categories: [] });
+  apiAddToBookshelf.mockResolvedValue(undefined);
+  apiRemoveFromBookshelf.mockResolvedValue(undefined);
+  apiCreateBookshelfCategory.mockResolvedValue({
+    category: { id: 'cat-1', name: 'Favorites', position: 0 },
+  });
+  apiUpdateBookshelfCategory.mockResolvedValue({
+    category: { id: 'cat-1', name: 'Top Picks', position: 1 },
+  });
+  apiDeleteBookshelfCategory.mockResolvedValue(undefined);
+  apiLogRead.mockResolvedValue({
+    readLog: {
+      id: 'read-1',
+      userId: 'user-1',
+      postId: 'post-1',
+      rating: 4,
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+  });
+  apiRemoveReadLog.mockResolvedValue(undefined);
+  apiUpdateReadRating.mockResolvedValue({
+    readLog: {
+      id: 'read-1',
+      userId: 'user-1',
+      postId: 'post-1',
+      rating: 5,
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+  });
+  apiGetMyBookshelf.mockResolvedValue({ bookshelfItems: [], nextCursor: undefined });
+  apiGetAllBookshelfItems.mockResolvedValue({ bookshelfItems: [], nextCursor: undefined });
+  apiGetReadHistory.mockResolvedValue({ readLogs: [], nextCursor: undefined });
+  apiGetPostReadLogs.mockResolvedValue({
+    readCount: 1,
+    averageRating: 4,
+    viewerRead: true,
+    viewerRating: 4,
+    readers: [],
+  });
+});
+
+describe('bookStore', () => {
+  it('initializes and resets all writable state', async () => {
+    bookshelfCategories.set([{ id: 'cat-1', name: 'Favorites', position: 0 }]);
+    myBookshelf.set(
+      new Map([
+        [
+          'Favorites',
+          [{ id: 'item-1', userId: 'user-1', postId: 'post-1', categoryId: 'cat-1', createdAt: 'now' }],
+        ],
+      ])
+    );
+    allBookshelf.set(new Map([['Favorites', []]]));
+    readHistory.set([{ id: 'read-1', userId: 'user-1', postId: 'post-1', createdAt: 'now' }]);
+
+    bookStore.reset();
+    await bookStore.loadBookshelfCategories();
+
+    expect(get(bookshelfCategories)).toEqual([]);
+    expect(get(myBookshelf).size).toBe(0);
+    expect(get(allBookshelf).size).toBe(0);
+    expect(get(readHistory)).toEqual([]);
+    expect(get(bookStoreMeta).error).toBeNull();
+  });
+
+  it('optimistically adds and removes bookshelf entries', async () => {
+    postStore.setPosts(
+      [
+        {
+          id: 'post-1',
+          userId: 'user-1',
+          sectionId: 'section-books',
+          content: 'Book 1',
+          createdAt: '2026-01-01T00:00:00Z',
+          bookStats: {
+            bookshelfCount: 0,
+            readCount: 0,
+            averageRating: null,
+            viewerOnBookshelf: false,
+            viewerCategories: [],
+            viewerRead: false,
+            viewerRating: null,
+          },
+        },
+      ],
+      null,
+      false
+    );
+
+    const addDeferred = createDeferred<void>();
+    apiAddToBookshelf.mockReturnValueOnce(addDeferred.promise);
+    const addPromise = bookStore.addToBookshelf('post-1', ['Favorites']);
+
+    let grouped = get(myBookshelf);
+    expect(grouped.get('Favorites')).toHaveLength(1);
+    let post = get(postStore).posts[0];
+    expect(post.bookStats?.viewerOnBookshelf).toBe(true);
+
+    addDeferred.resolve(undefined);
+    await addPromise;
+
+    const removeDeferred = createDeferred<void>();
+    apiRemoveFromBookshelf.mockReturnValueOnce(removeDeferred.promise);
+    const removePromise = bookStore.removeFromBookshelf('post-1');
+
+    grouped = get(myBookshelf);
+    expect(grouped.get('Favorites')).toBeUndefined();
+    post = get(postStore).posts[0];
+    expect(post.bookStats?.viewerOnBookshelf).toBe(false);
+
+    removeDeferred.resolve(undefined);
+    await removePromise;
+  });
+
+  it('optimistically logs reads and removes them', async () => {
+    postStore.setPosts(
+      [
+        {
+          id: 'post-1',
+          userId: 'user-1',
+          sectionId: 'section-books',
+          content: 'Book 1',
+          createdAt: '2026-01-01T00:00:00Z',
+          bookStats: {
+            bookshelfCount: 0,
+            readCount: 0,
+            averageRating: null,
+            viewerOnBookshelf: false,
+            viewerCategories: [],
+            viewerRead: false,
+            viewerRating: null,
+          },
+        },
+      ],
+      null,
+      false
+    );
+
+    const logDeferred = createDeferred<{ readLog: { id: string; userId: string; postId: string; rating: number; createdAt: string } }>();
+    apiLogRead.mockReturnValueOnce(logDeferred.promise);
+    const logPromise = bookStore.logRead('post-1', 5);
+
+    let logs = get(readHistory);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].postId).toBe('post-1');
+    let post = get(postStore).posts[0];
+    expect(post.bookStats?.viewerRead).toBe(true);
+    expect(post.bookStats?.viewerRating).toBe(5);
+
+    logDeferred.resolve({
+      readLog: {
+        id: 'read-1',
+        userId: 'user-1',
+        postId: 'post-1',
+        rating: 5,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    });
+    await logPromise;
+
+    const removeDeferred = createDeferred<void>();
+    apiRemoveReadLog.mockReturnValueOnce(removeDeferred.promise);
+    const removePromise = bookStore.removeRead('post-1');
+
+    logs = get(readHistory);
+    expect(logs).toHaveLength(0);
+    post = get(postStore).posts[0];
+    expect(post.bookStats?.viewerRead).toBe(false);
+    expect(post.bookStats?.viewerRating).toBeNull();
+
+    removeDeferred.resolve(undefined);
+    await removePromise;
+  });
+
+  it('category CRUD updates categories and grouped bookshelf keys', async () => {
+    bookshelfCategories.set([{ id: 'cat-1', name: 'Favorites', position: 0 }]);
+    myBookshelf.set(
+      new Map([
+        [
+          'Favorites',
+          [
+            {
+              id: 'item-1',
+              userId: 'user-1',
+              postId: 'post-1',
+              categoryId: 'cat-1',
+              createdAt: '2026-01-01T00:00:00Z',
+            },
+          ],
+        ],
+      ])
+    );
+
+    await bookStore.createCategory('Favorites');
+    expect(get(bookshelfCategories)).toHaveLength(1);
+
+    await bookStore.updateCategory('cat-1', 'Top Picks', 1);
+    let grouped = get(myBookshelf);
+    expect(grouped.get('Favorites')).toBeUndefined();
+    expect(grouped.get('Top Picks')).toHaveLength(1);
+
+    await bookStore.deleteCategory('cat-1');
+    grouped = get(myBookshelf);
+    expect(get(bookshelfCategories)).toHaveLength(0);
+    expect(grouped.get('Top Picks')).toBeUndefined();
+    expect(grouped.get('Uncategorized')).toHaveLength(1);
+  });
+
+  it('rolls back optimistic state on API error', async () => {
+    readHistory.set([
+      {
+        id: 'read-1',
+        userId: 'user-1',
+        postId: 'post-1',
+        rating: 4,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    postStore.setPosts(
+      [
+        {
+          id: 'post-1',
+          userId: 'user-1',
+          sectionId: 'section-books',
+          content: 'Book 1',
+          createdAt: '2026-01-01T00:00:00Z',
+          bookStats: {
+            bookshelfCount: 0,
+            readCount: 1,
+            averageRating: 4,
+            viewerOnBookshelf: false,
+            viewerCategories: [],
+            viewerRead: true,
+            viewerRating: 4,
+          },
+        },
+      ],
+      null,
+      false
+    );
+
+    apiRemoveReadLog.mockRejectedValueOnce(new Error('remove failed'));
+    await bookStore.removeRead('post-1');
+
+    const logs = get(readHistory);
+    const post = get(postStore).posts[0];
+    expect(logs).toHaveLength(1);
+    expect(logs[0].postId).toBe('post-1');
+    expect(post.bookStats?.viewerRead).toBe(true);
+    expect(post.bookStats?.readCount).toBe(1);
+    expect(get(bookStoreMeta).error).toBe('remove failed');
+  });
+
+  it('loads paginated bookshelf and read history data', async () => {
+    bookshelfCategories.set([{ id: 'cat-1', name: 'Favorites', position: 0 }]);
+    apiGetMyBookshelf
+      .mockResolvedValueOnce({
+        bookshelfItems: [
+          {
+            id: 'item-1',
+            userId: 'user-1',
+            postId: 'post-1',
+            categoryId: 'cat-1',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+        nextCursor: 'cursor-1',
+      })
+      .mockResolvedValueOnce({
+        bookshelfItems: [
+          {
+            id: 'item-2',
+            userId: 'user-1',
+            postId: 'post-2',
+            categoryId: 'cat-1',
+            createdAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+        nextCursor: 'cursor-2',
+      });
+    apiGetAllBookshelfItems.mockResolvedValueOnce({
+      bookshelfItems: [
+        {
+          id: 'all-1',
+          userId: 'user-2',
+          postId: 'post-3',
+          categoryId: 'cat-1',
+          createdAt: '2026-01-03T00:00:00Z',
+        },
+      ],
+      nextCursor: 'all-cursor-1',
+    });
+    apiGetReadHistory
+      .mockResolvedValueOnce({
+        readLogs: [
+          {
+            id: 'read-1',
+            userId: 'user-1',
+            postId: 'post-1',
+            rating: 4,
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+        nextCursor: 'read-cursor-1',
+      })
+      .mockResolvedValueOnce({
+        readLogs: [
+          {
+            id: 'read-2',
+            userId: 'user-1',
+            postId: 'post-2',
+            rating: 5,
+            createdAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+        nextCursor: 'read-cursor-2',
+      });
+
+    const firstMyCursor = await bookStore.loadMyBookshelf(undefined);
+    const secondMyCursor = await bookStore.loadMyBookshelf(undefined, firstMyCursor);
+    const allCursor = await bookStore.loadAllBookshelf('Favorites');
+    const firstReadCursor = await bookStore.loadReadHistory();
+    const secondReadCursor = await bookStore.loadReadHistory(firstReadCursor);
+
+    expect(apiGetMyBookshelf).toHaveBeenNthCalledWith(1, undefined, undefined, 20);
+    expect(apiGetMyBookshelf).toHaveBeenNthCalledWith(2, undefined, 'cursor-1', 20);
+    expect(apiGetAllBookshelfItems).toHaveBeenCalledWith('Favorites', undefined, 20);
+    expect(apiGetReadHistory).toHaveBeenNthCalledWith(1, undefined, 20);
+    expect(apiGetReadHistory).toHaveBeenNthCalledWith(2, 'read-cursor-1', 20);
+
+    const myGrouped = get(myBookshelf);
+    const allGrouped = get(allBookshelf);
+    expect(myGrouped.get('Favorites')).toHaveLength(2);
+    expect(allGrouped.get('Favorites')).toHaveLength(1);
+    expect(get(readHistory)).toHaveLength(2);
+
+    expect(secondMyCursor).toBe('cursor-2');
+    expect(allCursor).toBe('all-cursor-1');
+    expect(secondReadCursor).toBe('read-cursor-2');
+    expect(get(bookStoreMeta).cursors.readHistory).toBe('read-cursor-2');
+  });
+});

--- a/frontend/src/stores/bookStore.ts
+++ b/frontend/src/stores/bookStore.ts
@@ -1,0 +1,583 @@
+import { get, writable } from 'svelte/store';
+import {
+  api,
+  type BookshelfCategory,
+  type BookshelfItem,
+  type ReadLog,
+  type PostReadLogsResponse,
+} from '../services/api';
+import { currentUser } from './authStore';
+import { postStore, type BookStats } from './postStore';
+
+const DEFAULT_BOOKSHELF_CATEGORY = 'Uncategorized';
+const DEFAULT_PAGE_SIZE = 20;
+
+export const bookshelfCategories = writable<BookshelfCategory[]>([]);
+export const myBookshelf = writable<Map<string, BookshelfItem[]>>(new Map());
+export const allBookshelf = writable<Map<string, BookshelfItem[]>>(new Map());
+export const readHistory = writable<ReadLog[]>([]);
+
+interface BookStoreLoadState {
+  categories: boolean;
+  myBookshelf: boolean;
+  allBookshelf: boolean;
+  readHistory: boolean;
+}
+
+interface BookStoreCursorState {
+  myBookshelf: string | null;
+  allBookshelf: string | null;
+  readHistory: string | null;
+}
+
+interface BookStoreMetaState {
+  loading: BookStoreLoadState;
+  cursors: BookStoreCursorState;
+  error: string | null;
+}
+
+const initialMetaState: BookStoreMetaState = {
+  loading: {
+    categories: false,
+    myBookshelf: false,
+    allBookshelf: false,
+    readHistory: false,
+  },
+  cursors: {
+    myBookshelf: null,
+    allBookshelf: null,
+    readHistory: null,
+  },
+  error: null,
+};
+
+export const bookStoreMeta = writable<BookStoreMetaState>({ ...initialMetaState });
+
+function setLoading(key: keyof BookStoreLoadState, value: boolean): void {
+  bookStoreMeta.update((state) => ({
+    ...state,
+    loading: {
+      ...state.loading,
+      [key]: value,
+    },
+    error: value ? null : state.error,
+  }));
+}
+
+function setCursor(key: keyof BookStoreCursorState, cursor?: string): void {
+  bookStoreMeta.update((state) => ({
+    ...state,
+    cursors: {
+      ...state.cursors,
+      [key]: cursor ?? null,
+    },
+    error: null,
+  }));
+}
+
+function setStoreError(error: string | null): void {
+  bookStoreMeta.update((state) => ({
+    ...state,
+    loading: {
+      categories: false,
+      myBookshelf: false,
+      allBookshelf: false,
+      readHistory: false,
+    },
+    error,
+  }));
+}
+
+function normalizeCategoryName(name: string): string {
+  return name.trim();
+}
+
+function normalizeCategoryList(categories: string[]): string[] {
+  if (!Array.isArray(categories)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const category of categories) {
+    const trimmed = normalizeCategoryName(category);
+    if (!trimmed || trimmed.toLowerCase() === DEFAULT_BOOKSHELF_CATEGORY.toLowerCase()) {
+      continue;
+    }
+    if (seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function buildCategoryIdToName(categories: BookshelfCategory[]): Map<string, string> {
+  const categoryMap = new Map<string, string>();
+  for (const category of categories) {
+    categoryMap.set(category.id, category.name);
+  }
+  return categoryMap;
+}
+
+function resolveCategoryKey(
+  item: BookshelfItem,
+  categoryMap: Map<string, string>,
+  fallbackCategory?: string
+): string {
+  if (item.categoryId) {
+    return categoryMap.get(item.categoryId) ?? fallbackCategory ?? item.categoryId;
+  }
+  return fallbackCategory ?? DEFAULT_BOOKSHELF_CATEGORY;
+}
+
+function removeBookshelfPost(
+  source: Map<string, BookshelfItem[]>,
+  postId: string
+): Map<string, BookshelfItem[]> {
+  const next = new Map(source);
+  for (const [category, items] of next.entries()) {
+    const filtered = items.filter((item) => item.postId !== postId);
+    if (filtered.length > 0) {
+      next.set(category, filtered);
+    } else {
+      next.delete(category);
+    }
+  }
+  return next;
+}
+
+function upsertBookshelfItem(
+  source: Map<string, BookshelfItem[]>,
+  item: BookshelfItem,
+  categoryMap: Map<string, string>,
+  fallbackCategory?: string
+): Map<string, BookshelfItem[]> {
+  const category = resolveCategoryKey(item, categoryMap, fallbackCategory);
+  const next = removeBookshelfPost(source, item.postId);
+  const existing = next.get(category) ?? [];
+  next.set(category, [item, ...existing]);
+  return next;
+}
+
+function mergeBookshelfItems(
+  source: Map<string, BookshelfItem[]>,
+  items: BookshelfItem[],
+  categories: BookshelfCategory[],
+  fallbackCategory?: string
+): Map<string, BookshelfItem[]> {
+  const categoryMap = buildCategoryIdToName(categories);
+  let next = source;
+  for (const item of items) {
+    next = upsertBookshelfItem(next, item, categoryMap, fallbackCategory);
+  }
+  return next;
+}
+
+function moveCategoryItems(
+  source: Map<string, BookshelfItem[]>,
+  fromCategory: string,
+  toCategory: string
+): Map<string, BookshelfItem[]> {
+  if (fromCategory === toCategory) {
+    return source;
+  }
+
+  const next = new Map(source);
+  const items = next.get(fromCategory) ?? [];
+  next.delete(fromCategory);
+  if (items.length === 0) {
+    return next;
+  }
+
+  const target = next.get(toCategory) ?? [];
+  next.set(toCategory, [...target, ...items]);
+  return next;
+}
+
+function upsertReadLog(logs: ReadLog[], nextLog: ReadLog): ReadLog[] {
+  const index = logs.findIndex((entry) => entry.postId === nextLog.postId);
+  if (index === -1) {
+    return [nextLog, ...logs];
+  }
+  const updated = [...logs];
+  updated[index] = {
+    ...updated[index],
+    ...nextLog,
+  };
+  return updated;
+}
+
+function normalizeAverageRating(value: number, readCount: number): number | null {
+  if (readCount <= 0) {
+    return null;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+function getCurrentBookStats(postId: string): BookStats | null {
+  const post = get(postStore).posts.find((entry) => entry.id === postId);
+  if (!post) {
+    return null;
+  }
+  return post.bookStats ?? post.book_stats ?? null;
+}
+
+function restoreBookStats(postId: string, previous: BookStats | null): void {
+  if (previous) {
+    postStore.setBookStats(postId, previous);
+    return;
+  }
+
+  postStore.setBookStats(postId, {
+    bookshelfCount: 0,
+    readCount: 0,
+    averageRating: null,
+    viewerOnBookshelf: false,
+    viewerCategories: [],
+    viewerRead: false,
+    viewerRating: null,
+  });
+}
+
+async function refreshPostReadStats(postId: string): Promise<void> {
+  try {
+    const readStats: PostReadLogsResponse = await api.getPostReadLogs(postId);
+    postStore.setBookStats(postId, {
+      readCount: readStats.readCount ?? 0,
+      averageRating: normalizeAverageRating(readStats.averageRating ?? 0, readStats.readCount ?? 0),
+      viewerRead: readStats.viewerRead ?? false,
+      viewerRating: readStats.viewerRating ?? null,
+    });
+  } catch {
+    // Ignore transient reconciliation errors.
+  }
+}
+
+function getCategoryIdForName(categoryName: string): string | undefined {
+  const categories = get(bookshelfCategories);
+  const match = categories.find((entry) => entry.name === categoryName);
+  return match?.id;
+}
+
+function buildOptimisticBookshelfItem(postId: string, categoryName?: string): BookshelfItem {
+  const selectedCategory = categoryName ? normalizeCategoryName(categoryName) : '';
+  const userId = get(currentUser)?.id ?? 'current-user';
+  return {
+    id: `optimistic-${postId}-${Date.now()}`,
+    userId,
+    postId,
+    categoryId: selectedCategory ? getCategoryIdForName(selectedCategory) : undefined,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+async function loadBookshelfCategories(): Promise<void> {
+  setLoading('categories', true);
+  try {
+    const response = await api.getBookshelfCategories();
+    bookshelfCategories.set(response.categories ?? []);
+    setLoading('categories', false);
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to load bookshelf categories');
+  }
+}
+
+async function addToBookshelf(postId: string, categories: string[]): Promise<void> {
+  const previousMyBookshelf = get(myBookshelf);
+  const previousAllBookshelf = get(allBookshelf);
+  const previousStats = getCurrentBookStats(postId);
+  const normalizedCategories = normalizeCategoryList(categories);
+  const selectedCategory = normalizedCategories[0] ?? DEFAULT_BOOKSHELF_CATEGORY;
+  const optimisticItem = buildOptimisticBookshelfItem(
+    postId,
+    selectedCategory === DEFAULT_BOOKSHELF_CATEGORY ? undefined : selectedCategory
+  );
+
+  const categoryMap = buildCategoryIdToName(get(bookshelfCategories));
+  myBookshelf.set(upsertBookshelfItem(previousMyBookshelf, optimisticItem, categoryMap, selectedCategory));
+  allBookshelf.set(upsertBookshelfItem(previousAllBookshelf, optimisticItem, categoryMap, selectedCategory));
+  postStore.setBookBookshelfState(
+    postId,
+    true,
+    selectedCategory === DEFAULT_BOOKSHELF_CATEGORY ? [] : [selectedCategory]
+  );
+
+  try {
+    await api.addToBookshelf(postId, categories);
+    void refreshPostReadStats(postId);
+    setStoreError(null);
+  } catch (error) {
+    myBookshelf.set(previousMyBookshelf);
+    allBookshelf.set(previousAllBookshelf);
+    restoreBookStats(postId, previousStats);
+    setStoreError(error instanceof Error ? error.message : 'Failed to add to bookshelf');
+  }
+}
+
+async function removeFromBookshelf(postId: string): Promise<void> {
+  const previousMyBookshelf = get(myBookshelf);
+  const previousAllBookshelf = get(allBookshelf);
+  const previousStats = getCurrentBookStats(postId);
+
+  myBookshelf.set(removeBookshelfPost(previousMyBookshelf, postId));
+  allBookshelf.set(removeBookshelfPost(previousAllBookshelf, postId));
+  postStore.setBookBookshelfState(postId, false, []);
+
+  try {
+    await api.removeFromBookshelf(postId);
+    void refreshPostReadStats(postId);
+    setStoreError(null);
+  } catch (error) {
+    myBookshelf.set(previousMyBookshelf);
+    allBookshelf.set(previousAllBookshelf);
+    restoreBookStats(postId, previousStats);
+    setStoreError(error instanceof Error ? error.message : 'Failed to remove from bookshelf');
+  }
+}
+
+async function createCategory(name: string): Promise<void> {
+  try {
+    const response = await api.createBookshelfCategory(name);
+    const category = response.category;
+    bookshelfCategories.update((existing) => {
+      const index = existing.findIndex((item) => item.id === category.id);
+      if (index === -1) {
+        return [...existing, category];
+      }
+      const updated = [...existing];
+      updated[index] = category;
+      return updated;
+    });
+    setStoreError(null);
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to create category');
+  }
+}
+
+async function updateCategory(id: string, name: string, position: number): Promise<void> {
+  const previousCategories = get(bookshelfCategories);
+  const existingCategory = previousCategories.find((category) => category.id === id);
+  try {
+    const response = await api.updateBookshelfCategory(id, name, position);
+    const updatedCategory = response.category;
+    bookshelfCategories.update((current) => {
+      const index = current.findIndex((item) => item.id === updatedCategory.id);
+      if (index === -1) {
+        return [...current, updatedCategory];
+      }
+      const updated = [...current];
+      updated[index] = updatedCategory;
+      return updated;
+    });
+
+    if (existingCategory && existingCategory.name !== updatedCategory.name) {
+      myBookshelf.update((current) =>
+        moveCategoryItems(current, existingCategory.name, updatedCategory.name)
+      );
+      allBookshelf.update((current) =>
+        moveCategoryItems(current, existingCategory.name, updatedCategory.name)
+      );
+    }
+    setStoreError(null);
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to update category');
+  }
+}
+
+async function deleteCategory(id: string): Promise<void> {
+  const previousCategories = get(bookshelfCategories);
+  const existingCategory = previousCategories.find((category) => category.id === id);
+  const deletedCategoryName = existingCategory?.name ?? '';
+
+  try {
+    await api.deleteBookshelfCategory(id);
+    bookshelfCategories.set(previousCategories.filter((category) => category.id !== id));
+    if (deletedCategoryName) {
+      myBookshelf.update((current) =>
+        moveCategoryItems(current, deletedCategoryName, DEFAULT_BOOKSHELF_CATEGORY)
+      );
+      allBookshelf.update((current) =>
+        moveCategoryItems(current, deletedCategoryName, DEFAULT_BOOKSHELF_CATEGORY)
+      );
+    }
+    setStoreError(null);
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to delete category');
+  }
+}
+
+async function logRead(postId: string, rating?: number): Promise<void> {
+  const previousHistory = get(readHistory);
+  const previousStats = getCurrentBookStats(postId);
+  const existingLog = previousHistory.find((entry) => entry.postId === postId);
+  const userId = get(currentUser)?.id ?? existingLog?.userId ?? 'current-user';
+  const optimisticLog: ReadLog = {
+    id: existingLog?.id ?? `optimistic-read-${postId}`,
+    userId,
+    postId,
+    rating,
+    createdAt: existingLog?.createdAt ?? new Date().toISOString(),
+    deletedAt: undefined,
+  };
+
+  readHistory.set(upsertReadLog(previousHistory, optimisticLog));
+  postStore.setBookReadState(postId, true, rating ?? existingLog?.rating ?? null);
+
+  try {
+    const response = await api.logRead(postId, rating);
+    readHistory.update((current) => upsertReadLog(current, response.readLog));
+    void refreshPostReadStats(postId);
+    setStoreError(null);
+  } catch (error) {
+    readHistory.set(previousHistory);
+    restoreBookStats(postId, previousStats);
+    setStoreError(error instanceof Error ? error.message : 'Failed to log read');
+  }
+}
+
+async function removeRead(postId: string): Promise<void> {
+  const previousHistory = get(readHistory);
+  const previousStats = getCurrentBookStats(postId);
+
+  readHistory.set(previousHistory.filter((entry) => entry.postId !== postId));
+  postStore.setBookReadState(postId, false, null);
+
+  try {
+    await api.removeReadLog(postId);
+    void refreshPostReadStats(postId);
+    setStoreError(null);
+  } catch (error) {
+    readHistory.set(previousHistory);
+    restoreBookStats(postId, previousStats);
+    setStoreError(error instanceof Error ? error.message : 'Failed to remove read');
+  }
+}
+
+async function updateRating(postId: string, rating: number): Promise<void> {
+  const previousHistory = get(readHistory);
+  const previousStats = getCurrentBookStats(postId);
+  const existingLog = previousHistory.find((entry) => entry.postId === postId);
+  const optimisticLog: ReadLog = existingLog
+    ? {
+        ...existingLog,
+        rating,
+      }
+    : {
+        id: `optimistic-read-${postId}`,
+        userId: get(currentUser)?.id ?? 'current-user',
+        postId,
+        rating,
+        createdAt: new Date().toISOString(),
+      };
+
+  readHistory.set(upsertReadLog(previousHistory, optimisticLog));
+  postStore.setBookReadState(postId, true, rating);
+
+  try {
+    const response = await api.updateReadRating(postId, rating);
+    readHistory.update((current) => upsertReadLog(current, response.readLog));
+    void refreshPostReadStats(postId);
+    setStoreError(null);
+  } catch (error) {
+    readHistory.set(previousHistory);
+    restoreBookStats(postId, previousStats);
+    setStoreError(error instanceof Error ? error.message : 'Failed to update rating');
+  }
+}
+
+async function loadMyBookshelf(category?: string, cursor?: string): Promise<string | undefined> {
+  setLoading('myBookshelf', true);
+  try {
+    const response = await api.getMyBookshelf(category, cursor, DEFAULT_PAGE_SIZE);
+    const categories = get(bookshelfCategories);
+    if (cursor) {
+      myBookshelf.update((current) =>
+        mergeBookshelfItems(current, response.bookshelfItems ?? [], categories, category)
+      );
+    } else {
+      const grouped = mergeBookshelfItems(new Map(), response.bookshelfItems ?? [], categories, category);
+      myBookshelf.set(grouped);
+    }
+    setCursor('myBookshelf', response.nextCursor);
+    setLoading('myBookshelf', false);
+    return response.nextCursor;
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to load bookshelf');
+    return undefined;
+  }
+}
+
+async function loadAllBookshelf(category?: string, cursor?: string): Promise<string | undefined> {
+  setLoading('allBookshelf', true);
+  try {
+    const response = await api.getAllBookshelfItems(category, cursor, DEFAULT_PAGE_SIZE);
+    const categories = get(bookshelfCategories);
+    if (cursor) {
+      allBookshelf.update((current) =>
+        mergeBookshelfItems(current, response.bookshelfItems ?? [], categories, category)
+      );
+    } else {
+      const grouped = mergeBookshelfItems(new Map(), response.bookshelfItems ?? [], categories, category);
+      allBookshelf.set(grouped);
+    }
+    setCursor('allBookshelf', response.nextCursor);
+    setLoading('allBookshelf', false);
+    return response.nextCursor;
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to load community bookshelf');
+    return undefined;
+  }
+}
+
+async function loadReadHistory(cursor?: string): Promise<string | undefined> {
+  setLoading('readHistory', true);
+  try {
+    const response = await api.getReadHistory(cursor, DEFAULT_PAGE_SIZE);
+    if (cursor) {
+      readHistory.update((current) => {
+        let next = current;
+        for (const log of response.readLogs ?? []) {
+          next = upsertReadLog(next, log);
+        }
+        return next;
+      });
+    } else {
+      readHistory.set(response.readLogs ?? []);
+    }
+    setCursor('readHistory', response.nextCursor);
+    setLoading('readHistory', false);
+    return response.nextCursor;
+  } catch (error) {
+    setStoreError(error instanceof Error ? error.message : 'Failed to load read history');
+    return undefined;
+  }
+}
+
+function reset(): void {
+  bookshelfCategories.set([]);
+  myBookshelf.set(new Map());
+  allBookshelf.set(new Map());
+  readHistory.set([]);
+  bookStoreMeta.set({ ...initialMetaState });
+}
+
+export const bookStore = {
+  loadBookshelfCategories,
+  addToBookshelf,
+  removeFromBookshelf,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  logRead,
+  removeRead,
+  updateRating,
+  loadMyBookshelf,
+  loadAllBookshelf,
+  loadReadHistory,
+  reset,
+};

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -6,6 +6,7 @@ import type {
   Highlight,
   RecipeStats,
   MovieStats,
+  BookStats,
   EmbedData,
   RecipeMetadata,
   MovieMetadata,
@@ -50,6 +51,8 @@ export interface ApiPost {
   recipeStats?: ApiRecipeStats | null;
   movie_stats?: ApiMovieStats | null;
   movieStats?: ApiMovieStats | null;
+  book_stats?: ApiBookStats | null;
+  bookStats?: ApiBookStats | null;
   created_at: string;
   updated_at?: string;
 }
@@ -82,6 +85,25 @@ export interface ApiMovieStats {
   viewerWatched?: boolean | null;
   viewerRating?: number | null;
   viewerCategories?: string[] | null;
+}
+
+export interface ApiBookStats {
+  bookshelf_count?: number | null;
+  read_count?: number | null;
+  avg_rating?: number | null;
+  average_rating?: number | null;
+  viewer_on_bookshelf?: boolean | null;
+  viewer_categories?: string[] | null;
+  viewer_read?: boolean | null;
+  viewer_rating?: number | null;
+  bookshelfCount?: number | null;
+  readCount?: number | null;
+  avgRating?: number | null;
+  averageRating?: number | null;
+  viewerOnBookshelf?: boolean | null;
+  viewerCategories?: string[] | null;
+  viewerRead?: boolean | null;
+  viewerRating?: number | null;
 }
 
 function normalizeString(value: unknown): string | undefined {
@@ -453,6 +475,49 @@ function normalizeMovieStats(rawStats: unknown): MovieStats | undefined {
   };
 }
 
+function normalizeBookStats(rawStats: unknown): BookStats | undefined {
+  if (!rawStats || typeof rawStats !== 'object') {
+    return undefined;
+  }
+
+  const record = rawStats as Record<string, unknown>;
+  const bookshelfCount = normalizeNumber(record.bookshelf_count ?? record.bookshelfCount) ?? 0;
+  const readCount = normalizeNumber(record.read_count ?? record.readCount) ?? 0;
+  const averageRating =
+    normalizeNumber(
+      record.avg_rating ??
+        record.avgRating ??
+        record.average_rating ??
+        record.averageRating
+    ) ?? null;
+  const viewerOnBookshelf =
+    typeof record.viewer_on_bookshelf === 'boolean'
+      ? record.viewer_on_bookshelf
+      : typeof record.viewerOnBookshelf === 'boolean'
+        ? record.viewerOnBookshelf
+        : undefined;
+  const viewerCategories = normalizeStringArray(
+    record.viewer_categories ?? record.viewerCategories
+  );
+  const viewerRead =
+    typeof record.viewer_read === 'boolean'
+      ? record.viewer_read
+      : typeof record.viewerRead === 'boolean'
+        ? record.viewerRead
+        : undefined;
+  const viewerRating = normalizeNumber(record.viewer_rating ?? record.viewerRating) ?? undefined;
+
+  return {
+    bookshelfCount,
+    readCount,
+    averageRating,
+    ...(typeof viewerOnBookshelf === 'boolean' ? { viewerOnBookshelf } : {}),
+    ...(viewerCategories ? { viewerCategories } : {}),
+    ...(typeof viewerRead === 'boolean' ? { viewerRead } : {}),
+    ...(typeof viewerRating === 'number' ? { viewerRating } : {}),
+  };
+}
+
 function normalizeEmbedData(rawEmbed: unknown): EmbedData | undefined {
   if (!rawEmbed || typeof rawEmbed !== 'object' || Array.isArray(rawEmbed)) {
     return undefined;
@@ -654,6 +719,7 @@ export function mapApiPost(apiPost: ApiPost): Post {
     viewerReactions: apiPost.viewer_reactions,
     recipeStats: normalizeRecipeStats(apiPost.recipe_stats ?? apiPost.recipeStats),
     movieStats: normalizeMovieStats(apiPost.movie_stats ?? apiPost.movieStats),
+    bookStats: normalizeBookStats(apiPost.book_stats ?? apiPost.bookStats),
     createdAt: apiPost.created_at,
     updatedAt: apiPost.updated_at,
   };


### PR DESCRIPTION
## Summary
- add `frontend/src/stores/bookStore.ts` with writable bookshelf/read stores and all required actions
- implement optimistic bookshelf + read-log updates with rollback-on-error behavior
- add pagination-aware loaders for my bookshelf, all bookshelf, and read history
- extend post stats support for books (`bookStats`) in `postStore` and `postMapper` so book actions update post aggregates
- add tests for `bookStore`, plus `postStore` and `postMapper` coverage for new book-stat behavior

## Testing
- `cd frontend && npm run test -- src/stores/bookStore.test.ts src/stores/__tests__/postStore.test.ts src/stores/__tests__/postMapper.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run lint`

Closes #867