### PR TITLE
[Podcasts] Add frontend section type/icon and app-level podcasts container mount

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,6 +7,7 @@
   import ThreadView from './components/ThreadView.svelte';
   import UserProfile from './components/UserProfile.svelte';
   import Watchlist from './components/movies/Watchlist.svelte';
+  import PodcastsTopContainer from './components/podcasts/PodcastsTopContainer.svelte';
   import Cookbook from './components/recipes/Cookbook.svelte';
   import { Login, Register, AdminPanel, PasswordReset, Settings } from './routes';
   import {
@@ -547,6 +548,10 @@
               <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
                 <Cookbook />
               </div>
+            {/if}
+
+            {#if $activeSection.type === 'podcast'}
+              <PodcastsTopContainer />
             {/if}
 
             <MusicLinksContainer />

--- a/frontend/src/__tests__/App.watchlist.test.ts
+++ b/frontend/src/__tests__/App.watchlist.test.ts
@@ -6,10 +6,17 @@ import { movieStore } from '../stores/movieStore';
 const loadFeedMock = vi.hoisted(() => vi.fn());
 const loadMorePostsMock = vi.hoisted(() => vi.fn());
 const loadThreadTargetPostMock = vi.hoisted(() => vi.fn());
+const loadSectionLinksMock = vi.hoisted(() => vi.fn());
+const loadMoreSectionLinksMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../stores/feedStore', () => ({
   loadFeed: loadFeedMock,
   loadMorePosts: loadMorePostsMock,
+}));
+
+vi.mock('../stores/sectionLinksFeedStore', () => ({
+  loadSectionLinks: loadSectionLinksMock,
+  loadMoreSectionLinks: loadMoreSectionLinksMock,
 }));
 
 vi.mock('../stores/threadRouteStore', async () => {
@@ -57,6 +64,8 @@ beforeEach(() => {
   loadFeedMock.mockResolvedValue(undefined);
   loadMorePostsMock.mockResolvedValue(undefined);
   loadThreadTargetPostMock.mockResolvedValue(undefined);
+  loadSectionLinksMock.mockResolvedValue(undefined);
+  loadMoreSectionLinksMock.mockResolvedValue(undefined);
 
   stores.authStore.setUser(null);
   stores.sectionStore.setSections([
@@ -145,5 +154,51 @@ describe('App watchlist routing', () => {
       expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('heading', { name: 'Create your account' })).not.toBeInTheDocument();
+  });
+
+  it('renders podcast top container only for podcast sections', async () => {
+    stores.authStore.setUser(defaultUser);
+    stores.sectionStore.setSections([
+      { id: 'section-general', name: 'General', type: 'general', icon: '💬', slug: 'general' },
+      { id: 'section-podcasts', name: 'Podcasts', type: 'podcast', icon: '🎙️', slug: 'podcasts' },
+    ]);
+    stores.sectionStore.setActiveSection({
+      id: 'section-podcasts',
+      name: 'Podcasts',
+      type: 'podcast',
+      icon: '🎙️',
+      slug: 'podcasts',
+    });
+    window.history.replaceState(null, '', '/');
+
+    render(App);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('podcasts-top-container')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render podcast top container for non-podcast sections', async () => {
+    stores.authStore.setUser(defaultUser);
+    stores.sectionStore.setSections([
+      { id: 'section-general', name: 'General', type: 'general', icon: '💬', slug: 'general' },
+      { id: 'section-music', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-podcasts', name: 'Podcasts', type: 'podcast', icon: '🎙️', slug: 'podcasts' },
+    ]);
+    stores.sectionStore.setActiveSection({
+      id: 'section-music',
+      name: 'Music',
+      type: 'music',
+      icon: '🎵',
+      slug: 'music',
+    });
+    window.history.replaceState(null, '', '/');
+
+    render(App);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Music' })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('podcasts-top-container')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/podcasts/PodcastsTopContainer.svelte
+++ b/frontend/src/components/podcasts/PodcastsTopContainer.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { activeSection } from '../../stores';
+
+  $: isPodcastSection = $activeSection?.type === 'podcast';
+</script>
+
+{#if isPodcastSection}
+  <div
+    class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+    data-testid="podcasts-top-container"
+  >
+    <h2 class="text-sm font-semibold text-gray-900">Podcast Spotlight</h2>
+    <p class="mt-1 text-sm text-gray-600">
+      Podcast highlights and episode tools will appear here for this section.
+    </p>
+  </div>
+{/if}

--- a/frontend/src/stores/__tests__/sectionStore.test.ts
+++ b/frontend/src/stores/__tests__/sectionStore.test.ts
@@ -23,16 +23,18 @@ describe('sectionStore', () => {
         { id: 'section-1', name: 'Music', type: 'music' },
         { id: 'section-2', name: 'General', type: 'general' },
         { id: 'section-3', name: 'Books', type: 'book' },
+        { id: 'section-4', name: 'Podcasts', type: 'podcast' },
       ],
     });
 
     await sectionStore.loadSections();
     const state = get(sectionStore);
 
-    expect(state.sections).toHaveLength(3);
+    expect(state.sections).toHaveLength(4);
     expect(state.sections[0].icon).toBe('💬');
     expect(state.sections[1].icon).toBe('🎵');
-    expect(state.sections[2].icon).toBe('📚');
+    expect(state.sections[2].icon).toBe('🎙️');
+    expect(state.sections[3].icon).toBe('📚');
     expect(state.activeSection?.id).toBe('section-2');
     expect(state.isLoading).toBe(false);
   });
@@ -110,5 +112,24 @@ describe('sectionStore', () => {
 
     const state = get(sectionStore);
     expect(state.sections[0].icon).toBe('📁');
+  });
+
+  it('orders sections deterministically with podcast support', () => {
+    sectionStore.setSections([
+      { id: 'section-1', name: 'Events', type: 'event', icon: '📅', slug: 'events' },
+      { id: 'section-2', name: 'Podcasts', type: 'podcast', icon: '🎙️', slug: 'podcasts' },
+      { id: 'section-3', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-4', name: 'General', type: 'general', icon: '💬', slug: 'general' },
+      { id: 'section-5', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
+    ]);
+
+    const state = get(sectionStore);
+    expect(state.sections.map((section) => section.type)).toEqual([
+      'general',
+      'music',
+      'podcast',
+      'movie',
+      'event',
+    ]);
   });
 });

--- a/frontend/src/stores/sectionStore.ts
+++ b/frontend/src/stores/sectionStore.ts
@@ -10,10 +10,19 @@ export interface Section {
   slug: string;
 }
 
-export type SectionType = 'music' | 'series' | 'event' | 'recipe' | 'book' | 'movie' | 'general';
+export type SectionType =
+  | 'music'
+  | 'podcast'
+  | 'series'
+  | 'event'
+  | 'recipe'
+  | 'book'
+  | 'movie'
+  | 'general';
 
 const sectionIcons: Record<SectionType, string> = {
   music: '🎵',
+  podcast: '🎙️',
   series: '📺',
   event: '📅',
   recipe: '🍳',
@@ -37,6 +46,7 @@ interface SectionState {
 const sectionOrder: SectionType[] = [
   'general',
   'music',
+  'podcast',
   'movie',
   'series',
   'recipe',


### PR DESCRIPTION
## Summary
- add `podcast` to frontend `SectionType`, icon mapping (`🎙️`), and deterministic section ordering
- mount a new `PodcastsTopContainer` in `App.svelte` above `PostForm`, rendered only when the active section type is `podcast`
- extend frontend tests for podcast ordering/icon behavior in `sectionStore` and conditional app render behavior

## Validation
- `cd frontend && npm run lint`
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/stores/__tests__/sectionStore.test.ts src/__tests__/App.watchlist.test.ts`

Closes #895