### PR TITLE
feat: add books quote API client functions and quote store

### DIFF
--- a/frontend/src/stores/__tests__/bookQuoteStore.test.ts
+++ b/frontend/src/stores/__tests__/bookQuoteStore.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+const apiGetPostQuotes = vi.hoisted(() => vi.fn());
+const apiCreateBookQuote = vi.hoisted(() => vi.fn());
+const apiUpdateBookQuote = vi.hoisted(() => vi.fn());
+const apiDeleteBookQuote = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getPostQuotes: apiGetPostQuotes,
+    createBookQuote: apiCreateBookQuote,
+    updateBookQuote: apiUpdateBookQuote,
+    deleteBookQuote: apiDeleteBookQuote,
+  },
+}));
+
+const { bookQuoteStore } = await import('../bookQuoteStore');
+
+function buildQuote(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'quote-1',
+    postId: 'post-1',
+    userId: 'user-1',
+    quoteText: 'Start quote',
+    pageNumber: 42,
+    chapter: 'Chapter 1',
+    note: 'Original note',
+    createdAt: '2026-02-10T10:00:00Z',
+    updatedAt: '2026-02-10T10:00:00Z',
+    username: 'reader',
+    displayName: 'Reader',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  bookQuoteStore.reset();
+  apiGetPostQuotes.mockReset();
+  apiCreateBookQuote.mockReset();
+  apiUpdateBookQuote.mockReset();
+  apiDeleteBookQuote.mockReset();
+});
+
+describe('bookQuoteStore', () => {
+  it('initializes with empty per-post state maps', () => {
+    const state = get(bookQuoteStore);
+
+    expect(state.quotes).toEqual({});
+    expect(state.cursors).toEqual({});
+    expect(state.hasMore).toEqual({});
+    expect(state.isLoading).toEqual({});
+    expect(state.errors).toEqual({});
+  });
+
+  it('addQuote, editQuote, and removeQuote update store data', async () => {
+    const postId = 'post-1';
+    const quoteId = 'quote-1';
+
+    apiCreateBookQuote.mockResolvedValue({
+      quote: buildQuote({ id: quoteId, postId, quoteText: 'Created quote' }),
+    });
+    apiUpdateBookQuote.mockResolvedValue({
+      quote: buildQuote({
+        id: quoteId,
+        postId,
+        quoteText: 'Edited quote',
+        note: 'Updated note',
+        updatedAt: '2026-02-10T11:00:00Z',
+      }),
+    });
+    apiDeleteBookQuote.mockResolvedValue(undefined);
+
+    await bookQuoteStore.addQuote(postId, { quoteText: 'Created quote' });
+    let state = get(bookQuoteStore);
+    expect(state.quotes[postId]).toHaveLength(1);
+    expect(state.quotes[postId][0].quoteText).toBe('Created quote');
+
+    await bookQuoteStore.editQuote(quoteId, { quoteText: 'Edited quote', note: 'Updated note' });
+    state = get(bookQuoteStore);
+    expect(state.quotes[postId]).toHaveLength(1);
+    expect(state.quotes[postId][0].quoteText).toBe('Edited quote');
+    expect(state.quotes[postId][0].note).toBe('Updated note');
+
+    await bookQuoteStore.removeQuote(quoteId);
+    state = get(bookQuoteStore);
+    expect(state.quotes[postId]).toBeUndefined();
+
+    expect(apiCreateBookQuote).toHaveBeenCalledWith(postId, { quoteText: 'Created quote' });
+    expect(apiUpdateBookQuote).toHaveBeenCalledWith(quoteId, {
+      quoteText: 'Edited quote',
+      note: 'Updated note',
+    });
+    expect(apiDeleteBookQuote).toHaveBeenCalledWith(quoteId);
+  });
+
+  it('loadQuotesForPost loads first page and appends deduped pagination results', async () => {
+    const postId = 'post-2';
+    const first = buildQuote({ id: 'quote-a', postId, quoteText: 'First' });
+    const second = buildQuote({ id: 'quote-b', postId, quoteText: 'Second' });
+    const third = buildQuote({ id: 'quote-c', postId, quoteText: 'Third' });
+
+    apiGetPostQuotes
+      .mockResolvedValueOnce({
+        quotes: [first, second],
+        nextCursor: 'cursor-1',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        quotes: [second, third],
+        hasMore: false,
+      });
+
+    await bookQuoteStore.loadQuotesForPost(postId, undefined, 2);
+    let state = get(bookQuoteStore);
+    expect(state.quotes[postId].map((quote) => quote.id)).toEqual(['quote-a', 'quote-b']);
+    expect(state.cursors[postId]).toBe('cursor-1');
+    expect(state.hasMore[postId]).toBe(true);
+
+    await bookQuoteStore.loadQuotesForPost(postId, 'cursor-1', 2);
+    state = get(bookQuoteStore);
+    expect(state.quotes[postId].map((quote) => quote.id)).toEqual(['quote-a', 'quote-b', 'quote-c']);
+    expect(state.cursors[postId]).toBeNull();
+    expect(state.hasMore[postId]).toBe(false);
+
+    expect(apiGetPostQuotes).toHaveBeenNthCalledWith(1, postId, undefined, 2);
+    expect(apiGetPostQuotes).toHaveBeenNthCalledWith(2, postId, 'cursor-1', 2);
+  });
+});

--- a/frontend/src/stores/bookQuoteStore.ts
+++ b/frontend/src/stores/bookQuoteStore.ts
@@ -1,0 +1,267 @@
+import { derived, writable } from 'svelte/store';
+import {
+  api,
+  type BookQuoteWithUser,
+  type CreateBookQuoteRequest,
+  type UpdateBookQuoteRequest,
+} from '../services/api';
+
+export interface BookQuoteStoreState {
+  quotes: Record<string, BookQuoteWithUser[]>;
+  cursors: Record<string, string | null>;
+  hasMore: Record<string, boolean>;
+  isLoading: Record<string, boolean>;
+  errors: Record<string, string | null>;
+}
+
+const initialState: BookQuoteStoreState = {
+  quotes: {},
+  cursors: {},
+  hasMore: {},
+  isLoading: {},
+  errors: {},
+};
+
+function appendUniqueQuotes(
+  existingQuotes: BookQuoteWithUser[],
+  newQuotes: BookQuoteWithUser[]
+): BookQuoteWithUser[] {
+  const seen = new Set(existingQuotes.map((quote) => quote.id));
+  const uniqueQuotes = newQuotes.filter((quote) => {
+    if (seen.has(quote.id)) {
+      return false;
+    }
+    seen.add(quote.id);
+    return true;
+  });
+  return [...existingQuotes, ...uniqueQuotes];
+}
+
+function upsertQuote(
+  quotesByPost: Record<string, BookQuoteWithUser[]>,
+  quote: BookQuoteWithUser
+): Record<string, BookQuoteWithUser[]> {
+  const nextQuotesByPost = { ...quotesByPost };
+  const existingQuotes = nextQuotesByPost[quote.postId] ?? [];
+  const existingIndex = existingQuotes.findIndex((item) => item.id === quote.id);
+
+  if (existingIndex === -1) {
+    nextQuotesByPost[quote.postId] = [quote, ...existingQuotes];
+    return nextQuotesByPost;
+  }
+
+  const updatedQuotes = [...existingQuotes];
+  updatedQuotes[existingIndex] = {
+    ...updatedQuotes[existingIndex],
+    ...quote,
+  };
+  nextQuotesByPost[quote.postId] = updatedQuotes;
+  return nextQuotesByPost;
+}
+
+function removeQuoteByID(
+  quotesByPost: Record<string, BookQuoteWithUser[]>,
+  quoteID: string
+): Record<string, BookQuoteWithUser[]> {
+  const nextQuotesByPost = { ...quotesByPost };
+  for (const [postID, quotes] of Object.entries(nextQuotesByPost)) {
+    const filtered = quotes.filter((quote) => quote.id !== quoteID);
+    if (filtered.length !== quotes.length) {
+      if (filtered.length > 0) {
+        nextQuotesByPost[postID] = filtered;
+      } else {
+        delete nextQuotesByPost[postID];
+      }
+      return nextQuotesByPost;
+    }
+  }
+  return nextQuotesByPost;
+}
+
+function createBookQuoteStore() {
+  const { subscribe, set, update } = writable<BookQuoteStoreState>({ ...initialState });
+
+  const setLoading = (postId: string, isLoading: boolean) =>
+    update((state) => ({
+      ...state,
+      isLoading: {
+        ...state.isLoading,
+        [postId]: isLoading,
+      },
+      errors: {
+        ...state.errors,
+        [postId]: isLoading ? null : state.errors[postId] ?? null,
+      },
+    }));
+
+  const setError = (postId: string, error: string | null) =>
+    update((state) => ({
+      ...state,
+      isLoading: {
+        ...state.isLoading,
+        [postId]: false,
+      },
+      errors: {
+        ...state.errors,
+        [postId]: error,
+      },
+    }));
+
+  return {
+    subscribe,
+    reset: () => set({ ...initialState }),
+    setQuotesForPost: (
+      postId: string,
+      quotes: BookQuoteWithUser[],
+      nextCursor: string | null,
+      hasMore: boolean
+    ) =>
+      update((state) => ({
+        ...state,
+        quotes: {
+          ...state.quotes,
+          [postId]: quotes,
+        },
+        cursors: {
+          ...state.cursors,
+          [postId]: nextCursor,
+        },
+        hasMore: {
+          ...state.hasMore,
+          [postId]: hasMore,
+        },
+        isLoading: {
+          ...state.isLoading,
+          [postId]: false,
+        },
+        errors: {
+          ...state.errors,
+          [postId]: null,
+        },
+      })),
+    appendQuotesForPost: (
+      postId: string,
+      quotes: BookQuoteWithUser[],
+      nextCursor: string | null,
+      hasMore: boolean
+    ) =>
+      update((state) => ({
+        ...state,
+        quotes: {
+          ...state.quotes,
+          [postId]: appendUniqueQuotes(state.quotes[postId] ?? [], quotes),
+        },
+        cursors: {
+          ...state.cursors,
+          [postId]: nextCursor,
+        },
+        hasMore: {
+          ...state.hasMore,
+          [postId]: hasMore,
+        },
+        isLoading: {
+          ...state.isLoading,
+          [postId]: false,
+        },
+        errors: {
+          ...state.errors,
+          [postId]: null,
+        },
+      })),
+    applyQuote: (quote: BookQuoteWithUser) =>
+      update((state) => ({
+        ...state,
+        quotes: upsertQuote(state.quotes, quote),
+        errors: {
+          ...state.errors,
+          [quote.postId]: null,
+        },
+      })),
+    applyQuoteRemoval: (quoteID: string) =>
+      update((state) => ({
+        ...state,
+        quotes: removeQuoteByID(state.quotes, quoteID),
+      })),
+    loadQuotesForPost: async (postId: string, cursor?: string, limit?: number): Promise<void> => {
+      setLoading(postId, true);
+      try {
+        const response = await api.getPostQuotes(postId, cursor, limit);
+        const nextCursor = response.nextCursor ?? null;
+        if (cursor) {
+          bookQuoteStore.appendQuotesForPost(postId, response.quotes ?? [], nextCursor, response.hasMore);
+        } else {
+          bookQuoteStore.setQuotesForPost(postId, response.quotes ?? [], nextCursor, response.hasMore);
+        }
+      } catch (error) {
+        setError(postId, error instanceof Error ? error.message : 'Failed to load quotes');
+      }
+    },
+    addQuote: async (postId: string, req: CreateBookQuoteRequest): Promise<void> => {
+      try {
+        const response = await api.createBookQuote(postId, req);
+        bookQuoteStore.applyQuote(response.quote);
+      } catch (error) {
+        setError(postId, error instanceof Error ? error.message : 'Failed to add quote');
+      }
+    },
+    editQuote: async (quoteId: string, req: UpdateBookQuoteRequest): Promise<void> => {
+      try {
+        const response = await api.updateBookQuote(quoteId, req);
+        bookQuoteStore.applyQuote(response.quote);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to update quote';
+        update((state) => {
+          const postID =
+            Object.entries(state.quotes).find(([, quotes]) =>
+              quotes.some((quote) => quote.id === quoteId)
+            )?.[0] ?? '';
+          if (!postID) {
+            return state;
+          }
+          return {
+            ...state,
+            isLoading: {
+              ...state.isLoading,
+              [postID]: false,
+            },
+            errors: {
+              ...state.errors,
+              [postID]: message,
+            },
+          };
+        });
+      }
+    },
+    removeQuote: async (quoteId: string): Promise<void> => {
+      try {
+        await api.deleteBookQuote(quoteId);
+        bookQuoteStore.applyQuoteRemoval(quoteId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to remove quote';
+        update((state) => {
+          const postID =
+            Object.entries(state.quotes).find(([, quotes]) =>
+              quotes.some((quote) => quote.id === quoteId)
+            )?.[0] ?? '';
+          if (!postID) {
+            return state;
+          }
+          return {
+            ...state,
+            isLoading: {
+              ...state.isLoading,
+              [postID]: false,
+            },
+            errors: {
+              ...state.errors,
+              [postID]: message,
+            },
+          };
+        });
+      }
+    },
+  };
+}
+
+export const bookQuoteStore = createBookQuoteStore();
+export const quotesByPost = derived(bookQuoteStore, ($store) => $store.quotes);


### PR DESCRIPTION
## Summary
- add Book Quote API types and client methods in `frontend/src/services/api.ts`
- add `bookQuoteStore` for per-post quote state, pagination, and CRUD updates
- add `bookQuoteStore` unit tests for initialization, add/edit/remove flows, and paginated loading with de-duplication

## Testing
- `cd frontend && npm run test -- src/stores/__tests__/bookQuoteStore.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npx eslint src/services/api.ts src/stores/bookQuoteStore.ts src/stores/__tests__/bookQuoteStore.test.ts`

Closes #880