### PR TITLE
[Podcasts] Implement show/episode auto-detection with explicit-selection fallback

### DIFF
--- a/backend/internal/handlers/highlights.go
+++ b/backend/internal/handlers/highlights.go
@@ -28,6 +28,9 @@ func writeHighlightValidationError(ctx context.Context, w http.ResponseWriter, e
 	case strings.HasPrefix(message, "podcast metadata is not allowed"):
 		writeError(ctx, w, http.StatusBadRequest, "PODCAST_METADATA_NOT_ALLOWED", message)
 		return true
+	case message == "podcast kind could not be detected; explicit selection required":
+		writeError(ctx, w, http.StatusBadRequest, "PODCAST_KIND_SELECTION_REQUIRED", message)
+		return true
 	case message == "podcast kind is required":
 		writeError(ctx, w, http.StatusBadRequest, "PODCAST_KIND_REQUIRED", message)
 		return true

--- a/backend/internal/handlers/highlights_test.go
+++ b/backend/internal/handlers/highlights_test.go
@@ -28,6 +28,11 @@ func TestWriteHighlightValidationError_PodcastErrors(t *testing.T) {
 			code:    "PODCAST_KIND_REQUIRED",
 		},
 		{
+			name:    "kind selection required",
+			message: "podcast kind could not be detected; explicit selection required",
+			code:    "PODCAST_KIND_SELECTION_REQUIRED",
+		},
+		{
 			name:    "episode highlights not allowed",
 			message: `podcast highlight episodes are only allowed for kind "show"`,
 			code:    "PODCAST_HIGHLIGHT_EPISODES_NOT_ALLOWED",

--- a/backend/internal/services/podcast_kind_detection.go
+++ b/backend/internal/services/podcast_kind_detection.go
@@ -1,0 +1,332 @@
+package services
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/sanderginn/clubhouse/internal/models"
+)
+
+var errPodcastKindSelectionRequired = errors.New("podcast kind could not be detected; explicit selection required")
+
+func shouldDetectPodcastKinds(links []models.LinkRequest) bool {
+	for _, link := range links {
+		if link.Podcast == nil {
+			continue
+		}
+		if strings.TrimSpace(link.Podcast.Kind) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func buildPodcastKindDetectionHints(requested []models.LinkRequest, existing []models.Link) []models.JSONMap {
+	if len(requested) == 0 || len(existing) == 0 {
+		return nil
+	}
+
+	existingByURL := make(map[string][]models.JSONMap)
+	for _, link := range existing {
+		if len(link.Metadata) == 0 {
+			continue
+		}
+		existingByURL[link.URL] = append(existingByURL[link.URL], models.JSONMap(link.Metadata))
+	}
+
+	hints := make([]models.JSONMap, len(requested))
+	hasHint := false
+	for i, link := range requested {
+		candidates := existingByURL[link.URL]
+		if len(candidates) == 0 {
+			continue
+		}
+		hints[i] = candidates[0]
+		existingByURL[link.URL] = candidates[1:]
+		hasHint = true
+	}
+
+	if !hasHint {
+		return nil
+	}
+	return hints
+}
+
+func mergePodcastKindDetectionHints(primary []models.JSONMap, secondary []models.JSONMap) []models.JSONMap {
+	if len(primary) == 0 {
+		return secondary
+	}
+	if len(secondary) == 0 {
+		return primary
+	}
+
+	maxLen := len(primary)
+	if len(secondary) > maxLen {
+		maxLen = len(secondary)
+	}
+
+	merged := make([]models.JSONMap, maxLen)
+	copy(merged, primary)
+	for i := 0; i < maxLen; i++ {
+		if len(merged[i]) > 0 {
+			continue
+		}
+		if i < len(secondary) && len(secondary[i]) > 0 {
+			merged[i] = secondary[i]
+		}
+	}
+	return merged
+}
+
+func resolvePodcastKinds(sectionType string, links []models.LinkRequest, metadataHints []models.JSONMap) ([]models.LinkRequest, error) {
+	if sectionType != "podcast" || len(links) == 0 {
+		return links, nil
+	}
+
+	resolved := make([]models.LinkRequest, len(links))
+	copy(resolved, links)
+
+	for i := range resolved {
+		podcast := resolved[i].Podcast
+		if podcast == nil {
+			continue
+		}
+		if strings.TrimSpace(podcast.Kind) != "" {
+			continue
+		}
+
+		if len(podcast.HighlightEpisodes) > 0 {
+			updated := *podcast
+			updated.Kind = "show"
+			resolved[i].Podcast = &updated
+			continue
+		}
+
+		var hint models.JSONMap
+		if i < len(metadataHints) {
+			hint = metadataHints[i]
+		}
+
+		kind, ok := detectPodcastKind(resolved[i].URL, hint)
+		if !ok {
+			return nil, errPodcastKindSelectionRequired
+		}
+
+		updated := *podcast
+		updated.Kind = kind
+		resolved[i].Podcast = &updated
+	}
+
+	return resolved, nil
+}
+
+func detectPodcastKind(linkURL string, metadata models.JSONMap) (string, bool) {
+	if kind, ok := detectPodcastKindFromMetadata(metadata); ok {
+		return kind, true
+	}
+	return detectPodcastKindFromURL(linkURL)
+}
+
+func detectPodcastKindFromMetadata(metadata models.JSONMap) (string, bool) {
+	if len(metadata) == 0 {
+		return "", false
+	}
+
+	for _, key := range []string{"kind", "type", "content_type", "resource_type", "og:type"} {
+		if kind, ok := podcastKindFromText(metadataStringField(metadata, key)); ok {
+			return kind, true
+		}
+	}
+
+	for _, key := range []string{"url", "canonical_url"} {
+		if kind, ok := detectPodcastKindFromURL(metadataStringField(metadata, key)); ok {
+			return kind, true
+		}
+	}
+
+	embed := metadataMapField(metadata, "embed")
+	if len(embed) > 0 {
+		for _, key := range []string{"embed_url", "url"} {
+			if kind, ok := detectPodcastKindFromURL(metadataStringField(embed, key)); ok {
+				return kind, true
+			}
+		}
+		if kind, ok := podcastKindFromText(metadataStringField(embed, "type")); ok {
+			return kind, true
+		}
+	}
+
+	return "", false
+}
+
+func detectPodcastKindFromURL(rawURL string) (string, bool) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Host == "" {
+		return "", false
+	}
+
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	pathSegments := splitPathSegments(parsed.Path)
+
+	if kind, ok := detectSpotifyPodcastKind(pathSegments); ok {
+		return kind, true
+	}
+
+	query := parsed.Query()
+	if strings.HasSuffix(host, "podcasts.apple.com") {
+		if strings.TrimSpace(query.Get("i")) != "" {
+			return "episode", true
+		}
+		if segmentsContainAny(pathSegments, "podcast", "podcasts") {
+			return "show", true
+		}
+	}
+
+	if hasEpisodeQueryParam(query) {
+		return "episode", true
+	}
+
+	if segmentsContainAny(pathSegments, "episode", "episodes") {
+		return "episode", true
+	}
+	if segmentsContainAny(pathSegments, "show", "shows") {
+		return "show", true
+	}
+	if segmentsContainAny(pathSegments, "podcast", "podcasts") {
+		return "show", true
+	}
+
+	return "", false
+}
+
+func detectSpotifyPodcastKind(pathSegments []string) (string, bool) {
+	if len(pathSegments) == 0 {
+		return "", false
+	}
+
+	index := 0
+	if strings.HasPrefix(pathSegments[index], "intl-") && len(pathSegments) > index+1 {
+		index++
+	}
+	if index < len(pathSegments) && pathSegments[index] == "embed" && len(pathSegments) > index+2 {
+		index++
+	}
+
+	if len(pathSegments) <= index {
+		return "", false
+	}
+
+	switch pathSegments[index] {
+	case "show":
+		return "show", true
+	case "episode":
+		return "episode", true
+	default:
+		return "", false
+	}
+}
+
+func hasEpisodeQueryParam(query url.Values) bool {
+	for _, key := range []string{"i", "episode", "episode_id", "episodeid"} {
+		if strings.TrimSpace(query.Get(key)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func splitPathSegments(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "/")
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part == "" {
+			continue
+		}
+		segments = append(segments, part)
+	}
+	return segments
+}
+
+func segmentsContainAny(segments []string, tokens ...string) bool {
+	if len(segments) == 0 {
+		return false
+	}
+	tokenSet := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" {
+			continue
+		}
+		tokenSet[token] = struct{}{}
+	}
+	for _, segment := range segments {
+		for _, part := range splitTextTokens(segment) {
+			if _, ok := tokenSet[part]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func podcastKindFromText(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+
+	for _, token := range splitTextTokens(value) {
+		switch token {
+		case "episode", "episodes":
+			return "episode", true
+		case "show", "shows", "podcast", "podcasts":
+			return "show", true
+		}
+	}
+
+	return "", false
+}
+
+func splitTextTokens(value string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(value), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func metadataStringField(metadata map[string]interface{}, key string) string {
+	raw, ok := metadata[key]
+	if !ok {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func metadataMapField(metadata map[string]interface{}, key string) map[string]interface{} {
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch typed := raw.(type) {
+	case map[string]interface{}:
+		return typed
+	case models.JSONMap:
+		return map[string]interface{}(typed)
+	default:
+		return nil
+	}
+}

--- a/backend/internal/services/post.go
+++ b/backend/internal/services/post.go
@@ -101,7 +101,17 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 		return nil, fmt.Errorf("section not found")
 	}
 
-	for _, link := range req.Links {
+	resolvedLinks := req.Links
+	if shouldDetectPodcastKinds(resolvedLinks) {
+		detectionHints := fetchLinkMetadata(ctx, resolvedLinks, sectionType)
+		resolvedLinks, err = resolvePodcastKinds(sectionType, resolvedLinks, detectionHints)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+	}
+
+	for _, link := range resolvedLinks {
 		if err := models.ValidateHighlights(sectionType, link.Highlights); err != nil {
 			recordSpanError(span, err)
 			return nil, err
@@ -111,7 +121,7 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 			return nil, err
 		}
 	}
-	highlightCount := countLinkHighlights(req.Links)
+	highlightCount := countLinkHighlights(resolvedLinks)
 	if highlightCount > 0 {
 		span.SetAttributes(attribute.Int("highlight_count", highlightCount))
 		observability.LogDebug(ctx, "post highlights provided", "highlight_count", strconv.Itoa(highlightCount), "section_type", sectionType)
@@ -121,7 +131,7 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 	postID := uuid.New()
 	trimmedContent := strings.TrimSpace(req.Content)
 	shouldEnqueueMetadataJobs := s.redis != nil && GetConfigService().IsLinkMetadataEnabled()
-	jobs := make([]MetadataJob, 0, len(req.Links))
+	jobs := make([]MetadataJob, 0, len(resolvedLinks))
 
 	// Begin transaction
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -150,10 +160,10 @@ func (s *PostService) CreatePost(ctx context.Context, req *models.CreatePostRequ
 	}
 
 	// Insert links if provided
-	if len(req.Links) > 0 {
-		post.Links = make([]models.Link, 0, len(req.Links))
+	if len(resolvedLinks) > 0 {
+		post.Links = make([]models.Link, 0, len(resolvedLinks))
 
-		for _, linkReq := range req.Links {
+		for _, linkReq := range resolvedLinks {
 			linkID := uuid.New()
 
 			mergedMetadata, sortedHighlights, podcast := mergeHighlightsIntoMetadata(linkReq, nil)
@@ -300,6 +310,7 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 	linkMetadataRemoved := false
 	imagesChanged := false
 	var normalizedImages []models.PostImageRequest
+	var resolvedLinks []models.LinkRequest
 	var existingLinks []models.Link
 	var removedLink *models.Link
 
@@ -349,13 +360,31 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 	}
 
 	if req.Links != nil {
-		highlightCount := countLinkHighlights(*req.Links)
+		resolvedLinks = make([]models.LinkRequest, len(*req.Links))
+		copy(resolvedLinks, *req.Links)
+
+		var detectionMetadata []models.JSONMap
+		if shouldDetectPodcastKinds(resolvedLinks) {
+			detectionHints := buildPodcastKindDetectionHints(resolvedLinks, existingLinks)
+			resolvedLinks, err = resolvePodcastKinds(sectionType, resolvedLinks, detectionHints)
+			if err != nil && errors.Is(err, errPodcastKindSelectionRequired) {
+				detectionMetadata = fetchLinkMetadata(ctx, resolvedLinks, sectionType)
+				detectionHints = mergePodcastKindDetectionHints(detectionHints, detectionMetadata)
+				resolvedLinks, err = resolvePodcastKinds(sectionType, resolvedLinks, detectionHints)
+			}
+			if err != nil {
+				recordSpanError(span, err)
+				return nil, err
+			}
+		}
+
+		highlightCount := countLinkHighlights(resolvedLinks)
 		if highlightCount > 0 {
 			span.SetAttributes(attribute.Int("highlight_count", highlightCount))
 			observability.LogDebug(ctx, "post highlights updated", "highlight_count", strconv.Itoa(highlightCount), "section_type", sectionType)
 		}
 
-		for _, link := range *req.Links {
+		for _, link := range resolvedLinks {
 			if err := models.ValidateHighlights(sectionType, link.Highlights); err != nil {
 				recordSpanError(span, err)
 				return nil, err
@@ -366,9 +395,13 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 			}
 		}
 
-		linksChanged = !linkRequestsMatchExistingLinks(existingLinks, *req.Links)
-		if linksChanged && len(*req.Links) > 0 {
-			linkMetadata = fetchLinkMetadata(ctx, *req.Links, sectionType)
+		linksChanged = !linkRequestsMatchExistingLinks(existingLinks, resolvedLinks)
+		if linksChanged && len(resolvedLinks) > 0 {
+			if len(detectionMetadata) > 0 {
+				linkMetadata = detectionMetadata
+			} else {
+				linkMetadata = fetchLinkMetadata(ctx, resolvedLinks, sectionType)
+			}
 		}
 	}
 
@@ -408,8 +441,8 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 			return nil, fmt.Errorf("failed to delete post links: %w", err)
 		}
 
-		if len(*req.Links) > 0 {
-			for i, linkReq := range *req.Links {
+		if len(resolvedLinks) > 0 {
+			for i, linkReq := range resolvedLinks {
 				linkID := uuid.New()
 
 				var fetchedMetadata models.JSONMap
@@ -483,7 +516,7 @@ func (s *PostService) UpdatePost(ctx context.Context, postID uuid.UUID, userID u
 		"images_provided":       req.Images != nil,
 	}
 	if req.Links != nil {
-		metadata["link_count"] = len(*req.Links)
+		metadata["link_count"] = len(resolvedLinks)
 	}
 	if req.Images != nil {
 		metadata["image_count"] = len(*req.Images)


### PR DESCRIPTION
## Summary
- add podcast kind detection helper with URL/provider/metadata heuristics and deterministic fallback error when classification is uncertain
- integrate kind auto-detection into `CreatePost` and `UpdatePost` before podcast metadata validation
- in update flow, use existing link metadata hints first and fall back to fetched metadata hints when needed
- add stable API validation mapping for uncertain detection: `PODCAST_KIND_SELECTION_REQUIRED`
- add service tests for detected `show`, detected `episode`, and uncertain fallback in both create and update flows
- extend handler validation tests for the new error code mapping

## Validation
- `cd backend && go test ./internal/services -run 'Test(CreatePostAutoDetectsPodcastKindWhenOmitted|CreatePostRejectsPodcastKindWhenDetectionIsUncertain|UpdatePostAutoDetectsPodcastKindWhenOmitted|UpdatePostRejectsPodcastKindWhenDetectionIsUncertain)' -count=1`
- `cd backend && go test ./internal/handlers -run TestWriteHighlightValidationError_PodcastErrors -count=1`
- `cd backend && go test ./internal/services ./internal/handlers -count=1`
- `cd backend && go build ./...`
- `cd backend && go test ./... -count=1`

Closes #889