### PR TITLE
[Books] Create QuoteCard and QuoteForm components

### DIFF
--- a/frontend/src/components/books/QuoteCard.svelte
+++ b/frontend/src/components/books/QuoteCard.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { api, type BookQuoteWithUser } from '../../services/api';
+  import { bookQuoteStore } from '../../stores/bookQuoteStore';
+  import QuoteForm from './QuoteForm.svelte';
+
+  export let quote: BookQuoteWithUser;
+  export let currentUserId: string;
+  export let isAdmin: boolean;
+
+  let isEditing = false;
+  let isDeleting = false;
+  let error: string | null = null;
+
+  type QuoteFormSubmitPayload = {
+    postId: string;
+    quoteText: string;
+    pageNumber?: number;
+    chapter?: string;
+    note?: string;
+    quoteId?: string;
+  };
+
+  $: canManage = currentUserId === quote.userId || isAdmin;
+  $: quoteReference = [formatPageNumber(quote.pageNumber), formatChapter(quote.chapter)]
+    .filter((part): part is string => Boolean(part))
+    .join(' - ');
+  $: authorLabel = quote.displayName?.trim() || quote.username;
+  $: formattedDate = formatDate(quote.createdAt);
+
+  function formatPageNumber(pageNumber?: number): string | null {
+    if (typeof pageNumber !== 'number' || pageNumber < 1) {
+      return null;
+    }
+    return `Page ${pageNumber}`;
+  }
+
+  function formatChapter(chapter?: string): string | null {
+    if (typeof chapter !== 'string') {
+      return null;
+    }
+    const trimmed = chapter.trim();
+    return trimmed ? `Chapter ${trimmed}` : null;
+  }
+
+  function formatDate(value: string): string {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return value;
+    }
+    return parsed.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function startEdit() {
+    isEditing = true;
+    error = null;
+  }
+
+  function cancelEdit() {
+    isEditing = false;
+    error = null;
+  }
+
+  async function handleEditSubmit(payload: QuoteFormSubmitPayload) {
+    const response = await api.updateBookQuote(quote.id, {
+      quoteText: payload.quoteText,
+      pageNumber: payload.pageNumber,
+      chapter: payload.chapter,
+      note: payload.note,
+    });
+    bookQuoteStore.applyQuote(response.quote);
+    isEditing = false;
+  }
+
+  async function deleteQuote() {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm('Delete this quote?');
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    isDeleting = true;
+    error = null;
+    try {
+      await api.deleteBookQuote(quote.id);
+      bookQuoteStore.applyQuoteRemoval(quote.id);
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to delete quote.';
+    } finally {
+      isDeleting = false;
+    }
+  }
+</script>
+
+<article class="space-y-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" data-testid="quote-card">
+  {#if isEditing}
+    <QuoteForm postId={quote.postId} existingQuote={quote} onSubmit={handleEditSubmit} onCancel={cancelEdit} />
+  {:else}
+    <blockquote class="rounded-lg border-l-4 border-slate-400 bg-slate-50 px-4 py-3 text-sm text-slate-800">
+      <p data-testid="quote-text">{quote.quoteText}</p>
+    </blockquote>
+
+    {#if quoteReference}
+      <p class="text-xs font-medium uppercase tracking-wide text-slate-500" data-testid="quote-reference">
+        {quoteReference}
+      </p>
+    {/if}
+
+    {#if quote.note}
+      <p class="text-sm text-slate-500" data-testid="quote-note">{quote.note}</p>
+    {/if}
+
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <p class="text-xs text-slate-600" data-testid="quote-author">
+        <span class="font-medium text-slate-800">{authorLabel}</span>
+        <span> (@{quote.username})</span>
+      </p>
+      <time class="text-xs text-slate-500" datetime={quote.createdAt} data-testid="quote-date">{formattedDate}</time>
+    </div>
+
+    {#if canManage}
+      <div class="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          on:click={startEdit}
+          class="rounded-lg border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100"
+          data-testid="quote-edit-button"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          on:click={deleteQuote}
+          disabled={isDeleting}
+          class="rounded-lg border border-red-200 px-2.5 py-1 text-xs font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+          data-testid="quote-delete-button"
+        >
+          {isDeleting ? 'Deleting...' : 'Delete'}
+        </button>
+      </div>
+    {/if}
+  {/if}
+
+  {#if error}
+    <p class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" data-testid="quote-card-error">
+      {error}
+    </p>
+  {/if}
+</article>

--- a/frontend/src/components/books/QuoteCard.test.ts
+++ b/frontend/src/components/books/QuoteCard.test.ts
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import QuoteCard from './QuoteCard.svelte';
+
+const baseQuote = {
+  id: 'quote-1',
+  postId: 'post-1',
+  userId: 'user-1',
+  quoteText: 'This is how worlds begin.',
+  pageNumber: 120,
+  chapter: '12',
+  note: 'Sets up the ending perfectly.',
+  createdAt: '2026-01-15T08:30:00Z',
+  updatedAt: '2026-01-15T08:30:00Z',
+  username: 'sander',
+  displayName: 'Sander Ginn',
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('QuoteCard', () => {
+  it('renders quote text, context, note, author, and date', () => {
+    render(QuoteCard, {
+      quote: baseQuote,
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    expect(screen.getByTestId('quote-text')).toHaveTextContent('This is how worlds begin.');
+    expect(screen.getByTestId('quote-reference')).toHaveTextContent('Page 120 - Chapter 12');
+    expect(screen.getByTestId('quote-note')).toHaveTextContent('Sets up the ending perfectly.');
+    expect(screen.getByTestId('quote-author')).toHaveTextContent('Sander Ginn (@sander)');
+    expect(screen.getByTestId('quote-date')).toHaveAttribute('datetime', '2026-01-15T08:30:00Z');
+  });
+
+  it('shows edit and delete controls for quote owner', () => {
+    render(QuoteCard, {
+      quote: baseQuote,
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    expect(screen.getByTestId('quote-edit-button')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-delete-button')).toBeInTheDocument();
+  });
+
+  it('shows edit and delete controls for admin on another user quote', () => {
+    render(QuoteCard, {
+      quote: { ...baseQuote, userId: 'user-2' },
+      currentUserId: 'admin-1',
+      isAdmin: true,
+    });
+
+    expect(screen.getByTestId('quote-edit-button')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-delete-button')).toBeInTheDocument();
+  });
+
+  it('hides edit and delete controls for unrelated non-admin user', () => {
+    render(QuoteCard, {
+      quote: { ...baseQuote, userId: 'user-2' },
+      currentUserId: 'user-3',
+      isAdmin: false,
+    });
+
+    expect(screen.queryByTestId('quote-edit-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-delete-button')).not.toBeInTheDocument();
+  });
+
+  it('opens inline quote form when edit is clicked', async () => {
+    render(QuoteCard, {
+      quote: baseQuote,
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    await fireEvent.click(screen.getByTestId('quote-edit-button'));
+    expect(screen.getByLabelText('Quote text')).toHaveValue('This is how worlds begin.');
+    expect(screen.getByRole('button', { name: 'Save Quote' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/books/QuoteForm.svelte
+++ b/frontend/src/components/books/QuoteForm.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import type { BookQuoteWithUser } from '../../services/api';
+
+  type QuoteFormSubmitPayload = {
+    postId: string;
+    quoteText: string;
+    pageNumber?: number;
+    chapter?: string;
+    note?: string;
+    quoteId?: string;
+  };
+
+  export let postId: string;
+  export let existingQuote: BookQuoteWithUser | undefined = undefined;
+  export let onSubmit: (payload: QuoteFormSubmitPayload) => Promise<void> | void;
+  export let onCancel: () => void;
+
+  let quoteText = '';
+  let pageNumberInput: string | number = '';
+  let chapter = '';
+  let note = '';
+  let error: string | null = null;
+  let isSubmitting = false;
+  let lastHydratedQuoteId: string | null = null;
+
+  $: hydratedQuoteID = existingQuote?.id ?? null;
+  $: if (hydratedQuoteID !== lastHydratedQuoteId) {
+    quoteText = existingQuote?.quoteText ?? '';
+    pageNumberInput =
+      typeof existingQuote?.pageNumber === 'number' ? String(existingQuote.pageNumber) : '';
+    chapter = existingQuote?.chapter ?? '';
+    note = existingQuote?.note ?? '';
+    error = null;
+    lastHydratedQuoteId = hydratedQuoteID;
+  }
+
+  function parsePageNumber(value: string | number): number | undefined {
+    const trimmed = String(value ?? '').trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (!/^\d+$/.test(trimmed)) {
+      return NaN;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    return parsed > 0 ? parsed : NaN;
+  }
+
+  async function handleSubmit() {
+    const trimmedQuoteText = quoteText.trim();
+    if (!trimmedQuoteText) {
+      error = 'Quote text is required.';
+      return;
+    }
+
+    const pageNumber = parsePageNumber(pageNumberInput);
+    if (Number.isNaN(pageNumber)) {
+      error = 'Page number must be a positive integer.';
+      return;
+    }
+
+    error = null;
+    isSubmitting = true;
+
+    try {
+      await onSubmit({
+        postId,
+        quoteText: trimmedQuoteText,
+        pageNumber,
+        chapter: chapter.trim() || undefined,
+        note: note.trim() || undefined,
+        quoteId: existingQuote?.id,
+      });
+
+      if (!existingQuote) {
+        quoteText = '';
+        pageNumberInput = '';
+        chapter = '';
+        note = '';
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to save quote.';
+    } finally {
+      isSubmitting = false;
+    }
+  }
+</script>
+
+<form on:submit|preventDefault={handleSubmit} class="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+  <div class="space-y-1">
+    <label for="quote-text" class="text-sm font-medium text-gray-700">Quote text</label>
+    <textarea
+      id="quote-text"
+      rows="3"
+      bind:value={quoteText}
+      required
+      disabled={isSubmitting}
+      class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:bg-gray-100"
+      placeholder="Add the quote..."
+      data-testid="quote-form-text"
+    />
+  </div>
+
+  <div class="grid gap-3 sm:grid-cols-2">
+    <div class="space-y-1">
+      <label for="quote-page-number" class="text-sm font-medium text-gray-700">Page number (optional)</label>
+      <input
+        id="quote-page-number"
+        type="number"
+        min="1"
+        step="1"
+        inputmode="numeric"
+        bind:value={pageNumberInput}
+        disabled={isSubmitting}
+        class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:bg-gray-100"
+        data-testid="quote-form-page-number"
+      />
+    </div>
+    <div class="space-y-1">
+      <label for="quote-chapter" class="text-sm font-medium text-gray-700">Chapter (optional)</label>
+      <input
+        id="quote-chapter"
+        type="text"
+        bind:value={chapter}
+        disabled={isSubmitting}
+        class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:bg-gray-100"
+        placeholder="Chapter 7"
+        data-testid="quote-form-chapter"
+      />
+    </div>
+  </div>
+
+  <div class="space-y-1">
+    <label for="quote-note" class="text-sm font-medium text-gray-700">Note (optional)</label>
+    <textarea
+      id="quote-note"
+      rows="2"
+      bind:value={note}
+      disabled={isSubmitting}
+      class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:bg-gray-100"
+      placeholder="Why this quote stood out..."
+      data-testid="quote-form-note"
+    />
+  </div>
+
+  {#if error}
+    <p class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" data-testid="quote-form-error">
+      {error}
+    </p>
+  {/if}
+
+  <div class="flex items-center justify-end gap-2">
+    <button
+      type="button"
+      on:click={onCancel}
+      disabled={isSubmitting}
+      class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      Cancel
+    </button>
+    <button
+      type="submit"
+      disabled={isSubmitting}
+      class="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {#if isSubmitting}
+        Saving...
+      {:else if existingQuote}
+        Save Quote
+      {:else}
+        Add Quote
+      {/if}
+    </button>
+  </div>
+</form>

--- a/frontend/src/components/books/QuoteForm.test.ts
+++ b/frontend/src/components/books/QuoteForm.test.ts
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import QuoteForm from './QuoteForm.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('QuoteForm', () => {
+  it('validates required quote text', async () => {
+    const onSubmit = vi.fn();
+    render(QuoteForm, {
+      postId: 'post-1',
+      onSubmit,
+      onCancel: vi.fn(),
+    });
+
+    const form = screen.getByTestId('quote-form-text').closest('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Quote text is required.')).toBeInTheDocument();
+  });
+
+  it('validates page number as positive integer', async () => {
+    const onSubmit = vi.fn();
+    render(QuoteForm, {
+      postId: 'post-1',
+      onSubmit,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.input(screen.getByLabelText('Quote text'), {
+      target: { value: 'The sky above the port was the color of television.' },
+    });
+    await fireEvent.input(screen.getByLabelText('Page number (optional)'), {
+      target: { value: '0' },
+    });
+
+    const form = screen.getByTestId('quote-form-text').closest('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Page number must be a positive integer.')).toBeInTheDocument();
+  });
+
+  it('submits create payload', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(QuoteForm, {
+      postId: 'post-1',
+      onSubmit,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.input(screen.getByLabelText('Quote text'), {
+      target: { value: 'A person can change at the edge of a forest.' },
+    });
+    await fireEvent.input(screen.getByLabelText('Page number (optional)'), {
+      target: { value: '42' },
+    });
+    await fireEvent.input(screen.getByLabelText('Chapter (optional)'), {
+      target: { value: '5' },
+    });
+    await fireEvent.input(screen.getByLabelText('Note (optional)'), {
+      target: { value: 'Important turning point' },
+    });
+
+    const form = screen.getByTestId('quote-form-text').closest('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      postId: 'post-1',
+      quoteText: 'A person can change at the edge of a forest.',
+      pageNumber: 42,
+      chapter: '5',
+      note: 'Important turning point',
+      quoteId: undefined,
+    });
+  });
+
+  it('pre-fills fields for edit mode', () => {
+    render(QuoteForm, {
+      postId: 'post-1',
+      existingQuote: {
+        id: 'quote-1',
+        postId: 'post-1',
+        userId: 'user-1',
+        quoteText: 'Existing quote',
+        pageNumber: 88,
+        chapter: 'Epilogue',
+        note: 'Original note',
+        createdAt: '2026-01-01T12:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+        username: 'reader',
+        displayName: 'Reader One',
+      },
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('Quote text')).toHaveValue('Existing quote');
+    expect(screen.getByLabelText('Page number (optional)')).toHaveValue(88);
+    expect(screen.getByLabelText('Chapter (optional)')).toHaveValue('Epilogue');
+    expect(screen.getByLabelText('Note (optional)')).toHaveValue('Original note');
+    expect(screen.getByRole('button', { name: 'Save Quote' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `QuoteForm.svelte` with create/edit mode support, required quote validation, and positive-integer page validation
- add `QuoteCard.svelte` to render quote content/context/author/date and show owner/admin edit-delete controls
- wire inline edit flow in `QuoteCard` using `QuoteForm`, plus quote update/delete API calls and store updates
- add tests for QuoteCard rendering/permissions/edit-toggle and QuoteForm validation/create/edit-prefill behavior

## Testing
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/books/QuoteCard.test.ts src/components/books/QuoteForm.test.ts`

Closes #881