### PR TITLE
[Movies] Fix Rotten Tomatoes URL parsing to TMDB metadata

### DIFF
--- a/backend/internal/services/links/movie_parser.go
+++ b/backend/internal/services/links/movie_parser.go
@@ -25,7 +25,7 @@ const (
 var (
 	imdbIDPattern           = regexp.MustCompile(`^tt\d+$`)
 	leadingDigitsRegexp     = regexp.MustCompile(`^(\d+)`)
-	trailingRTYearPattern   = regexp.MustCompile(`(?:^|[_-])(19\d{2}|20\d{2})$`)
+	trailingRTYearPattern   = regexp.MustCompile(`[_-](19\d{2}|20\d{2})$`)
 	rtDelimiterStripPattern = regexp.MustCompile(`[_-]+`)
 )
 

--- a/backend/internal/services/links/movie_parser.go
+++ b/backend/internal/services/links/movie_parser.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/sanderginn/clubhouse/internal/models"
 	"github.com/sanderginn/clubhouse/internal/observability"
@@ -22,8 +23,10 @@ const (
 )
 
 var (
-	imdbIDPattern       = regexp.MustCompile(`^tt\d+$`)
-	leadingDigitsRegexp = regexp.MustCompile(`^(\d+)`)
+	imdbIDPattern           = regexp.MustCompile(`^tt\d+$`)
+	leadingDigitsRegexp     = regexp.MustCompile(`^(\d+)`)
+	trailingRTYearPattern   = regexp.MustCompile(`(?:^|[_-])(19\d{2}|20\d{2})$`)
+	rtDelimiterStripPattern = regexp.MustCompile(`[_-]+`)
 )
 
 type MovieData = models.MovieData
@@ -63,6 +66,12 @@ func ParseMovieMetadata(ctx context.Context, rawURL string, client *TMDBClient, 
 			return nil, nil
 		}
 		return parseLetterboxdMovieMetadata(ctx, client, omdbClient, slug)
+	case isRottenTomatoesHost(host):
+		mediaType, slug, ok := parseRottenTomatoesPath(segments)
+		if !ok {
+			return nil, nil
+		}
+		return parseRottenTomatoesMovieMetadata(ctx, client, omdbClient, mediaType, slug)
 	default:
 		return nil, nil
 	}
@@ -81,6 +90,11 @@ func isTMDBHost(host string) bool {
 func isLetterboxdHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	return host == "letterboxd.com" || strings.HasSuffix(host, ".letterboxd.com")
+}
+
+func isRottenTomatoesHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "rottentomatoes.com" || strings.HasSuffix(host, ".rottentomatoes.com")
 }
 
 func splitURLPath(path string) []string {
@@ -151,6 +165,30 @@ func parseLetterboxdSlug(segments []string) (string, bool) {
 	return slug, true
 }
 
+func parseRottenTomatoesPath(segments []string) (string, string, bool) {
+	if len(segments) < 2 {
+		return "", "", false
+	}
+
+	category := strings.ToLower(strings.TrimSpace(segments[0]))
+	var mediaType string
+	switch category {
+	case "m":
+		mediaType = "movie"
+	case "tv":
+		mediaType = "tv"
+	default:
+		return "", "", false
+	}
+
+	slug := strings.TrimSpace(segments[1])
+	if slug == "" {
+		return "", "", false
+	}
+
+	return mediaType, slug, true
+}
+
 func parseIMDbMovieMetadata(ctx context.Context, client *TMDBClient, omdbClient *OMDBClient, imdbID string) (*MovieData, error) {
 	result, err := client.FindByIMDBID(ctx, imdbID)
 	if err != nil {
@@ -207,6 +245,38 @@ func parseLetterboxdMovieMetadata(ctx context.Context, client *TMDBClient, omdbC
 	return parseTMDBMovieMetadata(ctx, client, omdbClient, "movie", results[0].ID)
 }
 
+func parseRottenTomatoesMovieMetadata(ctx context.Context, client *TMDBClient, omdbClient *OMDBClient, mediaType, slug string) (*MovieData, error) {
+	titleQuery, releaseYear := rottenTomatoesSlugToTitle(slug)
+	if titleQuery == "" {
+		return nil, nil
+	}
+
+	switch mediaType {
+	case "movie":
+		results, err := client.SearchMovie(ctx, titleQuery)
+		if err != nil {
+			return nil, fmt.Errorf("search tmdb movie for rotten tomatoes slug %s: %w", slug, err)
+		}
+		match, ok := selectBestMovieSearchResult(titleQuery, releaseYear, results)
+		if !ok {
+			return nil, nil
+		}
+		return parseTMDBMovieMetadata(ctx, client, omdbClient, "movie", match.ID)
+	case "tv":
+		results, err := client.SearchTV(ctx, titleQuery)
+		if err != nil {
+			return nil, fmt.Errorf("search tmdb tv for rotten tomatoes slug %s: %w", slug, err)
+		}
+		match, ok := selectBestTVSearchResult(titleQuery, releaseYear, results)
+		if !ok {
+			return nil, nil
+		}
+		return parseTMDBMovieMetadata(ctx, client, omdbClient, "tv", match.ID)
+	default:
+		return nil, nil
+	}
+}
+
 func letterboxdSlugToTitle(slug string) string {
 	slug = strings.ToLower(strings.TrimSpace(slug))
 	slug = strings.Trim(slug, "/")
@@ -216,6 +286,147 @@ func letterboxdSlugToTitle(slug string) string {
 
 	title := strings.ReplaceAll(slug, "-", " ")
 	return strings.Join(strings.Fields(title), " ")
+}
+
+func rottenTomatoesSlugToTitle(slug string) (string, int) {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	slug = strings.Trim(slug, "/")
+	if slug == "" {
+		return "", 0
+	}
+
+	year := 0
+	if match := trailingRTYearPattern.FindStringSubmatch(slug); len(match) == 2 {
+		if parsedYear, err := strconv.Atoi(match[1]); err == nil {
+			year = parsedYear
+		}
+		slug = strings.TrimSuffix(slug, match[0])
+	}
+
+	title := rtDelimiterStripPattern.ReplaceAllString(slug, " ")
+	title = strings.Join(strings.Fields(title), " ")
+	return title, year
+}
+
+func selectBestMovieSearchResult(query string, year int, results []MovieSearchResult) (MovieSearchResult, bool) {
+	bestIndex := -1
+	bestScore := 0
+	bestVoteAverage := -1.0
+
+	for i, result := range results {
+		score := scoreTMDBTitleMatch(query, result.Title, year, yearFromDate(result.ReleaseDate))
+		if score < 40 {
+			continue
+		}
+
+		if score > bestScore || (score == bestScore && result.VoteAverage > bestVoteAverage) {
+			bestIndex = i
+			bestScore = score
+			bestVoteAverage = result.VoteAverage
+		}
+	}
+
+	if bestIndex < 0 {
+		return MovieSearchResult{}, false
+	}
+	return results[bestIndex], true
+}
+
+func selectBestTVSearchResult(query string, year int, results []TVSearchResult) (TVSearchResult, bool) {
+	bestIndex := -1
+	bestScore := 0
+	bestVoteAverage := -1.0
+
+	for i, result := range results {
+		score := scoreTMDBTitleMatch(query, result.Name, year, yearFromDate(result.FirstAirDate))
+		if score < 40 {
+			continue
+		}
+
+		if score > bestScore || (score == bestScore && result.VoteAverage > bestVoteAverage) {
+			bestIndex = i
+			bestScore = score
+			bestVoteAverage = result.VoteAverage
+		}
+	}
+
+	if bestIndex < 0 {
+		return TVSearchResult{}, false
+	}
+	return results[bestIndex], true
+}
+
+func scoreTMDBTitleMatch(query, candidate string, expectedYear, candidateYear int) int {
+	queryNormalized := normalizeTMDBMatchValue(query)
+	candidateNormalized := normalizeTMDBMatchValue(candidate)
+	if queryNormalized == "" || candidateNormalized == "" {
+		return 0
+	}
+
+	score := 0
+	if queryNormalized == candidateNormalized {
+		score += 100
+	}
+	if strings.HasPrefix(candidateNormalized, queryNormalized) || strings.HasPrefix(queryNormalized, candidateNormalized) {
+		score += 20
+	}
+	if strings.Contains(candidateNormalized, queryNormalized) || strings.Contains(queryNormalized, candidateNormalized) {
+		score += 15
+	}
+
+	queryTokens := strings.Fields(queryNormalized)
+	candidateTokens := strings.Fields(candidateNormalized)
+	if len(queryTokens) > 0 {
+		candidateTokenSet := make(map[string]struct{}, len(candidateTokens))
+		for _, token := range candidateTokens {
+			candidateTokenSet[token] = struct{}{}
+		}
+
+		matches := 0
+		for _, token := range queryTokens {
+			if _, ok := candidateTokenSet[token]; ok {
+				matches++
+			}
+		}
+		score += (matches * 60) / len(queryTokens)
+	}
+
+	if expectedYear > 0 && candidateYear > 0 {
+		if expectedYear == candidateYear {
+			score += 15
+		} else {
+			score -= 10
+		}
+	}
+
+	return score
+}
+
+func normalizeTMDBMatchValue(value string) string {
+	normalized := strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsLetter(r):
+			return unicode.ToLower(r)
+		case unicode.IsDigit(r):
+			return r
+		default:
+			return ' '
+		}
+	}, value)
+	return strings.Join(strings.Fields(normalized), " ")
+}
+
+func yearFromDate(value string) int {
+	parts := strings.Split(strings.TrimSpace(value), "-")
+	if len(parts) == 0 || len(parts[0]) != 4 {
+		return 0
+	}
+
+	year, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0
+	}
+	return year
 }
 
 func movieDataFromMovieDetails(details *MovieDetails, mediaType string) *MovieData {

--- a/backend/internal/services/links/movie_parser_test.go
+++ b/backend/internal/services/links/movie_parser_test.go
@@ -301,6 +301,181 @@ func TestParseMovieMetadataLetterboxdURL(t *testing.T) {
 	}
 }
 
+func TestParseMovieMetadataRottenTomatoesMovieURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/movie":
+			if got := strings.TrimSpace(r.URL.Query().Get("query")); got != "the matrix" {
+				t.Fatalf("query = %q, want the matrix", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":603,"title":"The Matrix","release_date":"1999-03-30","vote_average":8.2}]}`))
+		case "/movie/603":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":603,
+				"title":"The Matrix",
+				"overview":"Reality is not what it seems.",
+				"poster_path":"/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
+				"backdrop_path":"/icmmSD4vTTDKOq2vvdulafOGw93.jpg",
+				"runtime":136,
+				"genres":[{"id":28,"name":"Action"}],
+				"release_date":"1999-03-30",
+				"vote_average":8.2,
+				"credits":{"cast":[],"crew":[]},
+				"videos":{"results":[]}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.rottentomatoes.com/m/the_matrix", client, nil)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "The Matrix" {
+		t.Fatalf("Title = %q, want The Matrix", metadata.Title)
+	}
+	if metadata.TMDBID != 603 {
+		t.Fatalf("TMDBID = %d, want 603", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "movie" {
+		t.Fatalf("TMDBMediaType = %q, want movie", metadata.TMDBMediaType)
+	}
+}
+
+func TestParseMovieMetadataRottenTomatoesTVURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/tv":
+			if got := strings.TrimSpace(r.URL.Query().Get("query")); got != "game of thrones" {
+				t.Fatalf("query = %q, want game of thrones", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":1399,"name":"Game of Thrones","first_air_date":"2011-04-17","vote_average":8.5}]}`))
+		case "/tv/1399":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":1399,
+				"name":"Game of Thrones",
+				"overview":"Noble families fight for control.",
+				"poster_path":"/1XS1oqL89opfnbLl8WnZY1O1uJx.jpg",
+				"backdrop_path":"/suopoADq0k8YZr4dQXcU6pToj6s.jpg",
+				"runtime":57,
+				"genres":[{"id":18,"name":"Drama"}],
+				"first_air_date":"2011-04-17",
+				"vote_average":8.5,
+				"credits":{"cast":[],"crew":[]},
+				"videos":{"results":[]}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.rottentomatoes.com/tv/game_of_thrones/s01", client, nil)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "Game of Thrones" {
+		t.Fatalf("Title = %q, want Game of Thrones", metadata.Title)
+	}
+	if metadata.TMDBID != 1399 {
+		t.Fatalf("TMDBID = %d, want 1399", metadata.TMDBID)
+	}
+	if metadata.TMDBMediaType != "tv" {
+		t.Fatalf("TMDBMediaType = %q, want tv", metadata.TMDBMediaType)
+	}
+}
+
+func TestParseMovieMetadataRottenTomatoesMovieURLPrefersYearMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/movie":
+			if got := strings.TrimSpace(r.URL.Query().Get("query")); got != "it" {
+				t.Fatalf("query = %q, want it", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"results":[
+					{"id":1562,"title":"It","release_date":"1990-11-18","vote_average":6.8},
+					{"id":346364,"title":"It","release_date":"2017-09-06","vote_average":7.2}
+				]
+			}`))
+		case "/movie/346364":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":346364,
+				"title":"It",
+				"overview":"You'll float too.",
+				"poster_path":"/9E2y5Q7WlCVNEhP5GiVTjhEhx1o.jpg",
+				"backdrop_path":"/tcheoA2nPATCm2vvXw2hVQoaEFD.jpg",
+				"runtime":135,
+				"genres":[{"id":27,"name":"Horror"}],
+				"release_date":"2017-09-06",
+				"vote_average":7.2,
+				"credits":{"cast":[],"crew":[]},
+				"videos":{"results":[]}
+			}`))
+		case "/movie/1562":
+			t.Fatalf("selected wrong movie id from ambiguous Rotten Tomatoes slug")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.rottentomatoes.com/m/it_2017", client, nil)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.TMDBID != 346364 {
+		t.Fatalf("TMDBID = %d, want 346364", metadata.TMDBID)
+	}
+}
+
+func TestParseMovieMetadataRottenTomatoesMovieURLNoCloseMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/movie":
+			if got := strings.TrimSpace(r.URL.Query().Get("query")); got != "zzzzzz" {
+				t.Fatalf("query = %q, want zzzzzz", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":603,"title":"The Matrix","release_date":"1999-03-30","vote_average":8.2}]}`))
+		case "/movie/603":
+			t.Fatalf("expected no details fetch when Rotten Tomatoes search has no close match")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestTMDBClient(t, server.URL)
+	metadata, err := ParseMovieMetadata(context.Background(), "https://www.rottentomatoes.com/m/zzzzzz", client, nil)
+	if err != nil {
+		t.Fatalf("ParseMovieMetadata error: %v", err)
+	}
+	if metadata != nil {
+		t.Fatalf("expected nil metadata, got %+v", metadata)
+	}
+}
+
 func TestParseMovieMetadataNoMatchingURL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected request: %s", r.URL.String())


### PR DESCRIPTION
## Summary
- add Rotten Tomatoes host and URL pattern support in movie metadata parsing for both `/m/{slug}` and `/tv/{slug}` links
- convert Rotten Tomatoes slugs into TMDB search queries, including optional trailing year extraction from slugs like `it_2017`
- implement best-match selection for TMDB search results using normalized title similarity and year-aware scoring, with graceful nil return when no close match exists
- keep existing IMDb, TMDB direct URL, and Letterboxd parsing behavior unchanged
- add backend tests for Rotten Tomatoes movie and TV URL parsing, ambiguous year matching, and no-close-match behavior

## Validation
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services/links -run 'TestParseMovieMetadata' -v`

Closes #948