### PR TITLE
[Podcasts] Add recent podcasts section endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -206,10 +206,11 @@ func main() {
 	mux.HandleFunc("/api/v1/auth/password-reset/redeem", authHandler.RedeemPasswordResetToken)
 	mux.Handle("/api/v1/sections", requireAuth(http.HandlerFunc(sectionHandler.ListSections)))
 	sectionRouteHandler := newSectionRouteHandler(requireAuth, sectionRouteDeps{
-		listSections: sectionHandler.ListSections,
-		getSection:   sectionHandler.GetSection,
-		getFeed:      postHandler.GetFeed,
-		getLinks:     sectionHandler.GetSectionLinks,
+		listSections:      sectionHandler.ListSections,
+		getSection:        sectionHandler.GetSection,
+		getFeed:           postHandler.GetFeed,
+		getLinks:          sectionHandler.GetSectionLinks,
+		getRecentPodcasts: sectionHandler.GetRecentPodcasts,
 	})
 	mux.Handle("/api/v1/sections/", sectionRouteHandler)
 

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -217,10 +217,11 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 }
 
 type sectionRouteDeps struct {
-	listSections http.HandlerFunc
-	getSection   http.HandlerFunc
-	getFeed      http.HandlerFunc
-	getLinks     http.HandlerFunc
+	listSections      http.HandlerFunc
+	getSection        http.HandlerFunc
+	getFeed           http.HandlerFunc
+	getLinks          http.HandlerFunc
+	getRecentPodcasts http.HandlerFunc
 }
 
 type bookshelfRouteDeps struct {
@@ -240,6 +241,10 @@ type bookQuoteRouteDeps struct {
 
 func newSectionRouteHandler(requireAuth authMiddleware, deps sectionRouteDeps) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcasts/recent") {
+			requireAuth(http.HandlerFunc(deps.getRecentPodcasts)).ServeHTTP(w, r)
+			return
+		}
 		if strings.Contains(r.URL.Path, "/links") {
 			requireAuth(http.HandlerFunc(deps.getLinks)).ServeHTTP(w, r)
 			return

--- a/backend/internal/models/link.go
+++ b/backend/internal/models/link.go
@@ -23,3 +23,22 @@ type SectionLinksResponse struct {
 	HasMore    bool          `json:"has_more"`
 	NextCursor *string       `json:"next_cursor,omitempty"`
 }
+
+// RecentPodcastItem represents a recently shared podcast link in a section.
+type RecentPodcastItem struct {
+	PostID        uuid.UUID       `json:"post_id"`
+	LinkID        uuid.UUID       `json:"link_id"`
+	URL           string          `json:"url"`
+	Podcast       PodcastMetadata `json:"podcast"`
+	UserID        uuid.UUID       `json:"user_id"`
+	Username      string          `json:"username"`
+	PostCreatedAt time.Time       `json:"post_created_at"`
+	LinkCreatedAt time.Time       `json:"link_created_at"`
+}
+
+// SectionRecentPodcastsResponse represents a paginated response for recent podcast items.
+type SectionRecentPodcastsResponse struct {
+	Items      []RecentPodcastItem `json:"items"`
+	HasMore    bool                `json:"has_more"`
+	NextCursor *string             `json:"next_cursor,omitempty"`
+}

--- a/backend/internal/services/section.go
+++ b/backend/internal/services/section.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,6 +18,8 @@ import (
 type SectionService struct {
 	db *sql.DB
 }
+
+const recentPodcastCursorSeparator = "|"
 
 func NewSectionService(db *sql.DB) *SectionService {
 	return &SectionService{db: db}
@@ -200,4 +203,161 @@ func (s *SectionService) GetSectionLinks(ctx context.Context, sectionID uuid.UUI
 		HasMore:    hasMore,
 		NextCursor: nextCursor,
 	}, nil
+}
+
+func (s *SectionService) GetRecentPodcasts(ctx context.Context, sectionID uuid.UUID, cursor *string, limit int) (*models.SectionRecentPodcastsResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.sections").Start(ctx, "SectionService.GetRecentPodcasts")
+	span.SetAttributes(
+		attribute.String("section_id", sectionID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+	)
+	defer span.End()
+
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	var sectionType string
+	err := s.db.QueryRowContext(ctx, "SELECT type FROM sections WHERE id = $1", sectionID).Scan(&sectionType)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			notFoundErr := errors.New("section not found")
+			recordSpanError(span, notFoundErr)
+			return nil, notFoundErr
+		}
+		recordSpanError(span, err)
+		return nil, err
+	}
+	if sectionType != "podcast" {
+		invalidTypeErr := errors.New("section is not podcast")
+		recordSpanError(span, invalidTypeErr)
+		return nil, invalidTypeErr
+	}
+
+	query := `
+		SELECT
+			l.id, l.post_id, l.url, l.metadata,
+			p.user_id, u.username, p.created_at, l.created_at
+		FROM links l
+		JOIN posts p ON l.post_id = p.id
+		JOIN users u ON p.user_id = u.id
+		WHERE p.section_id = $1
+			AND p.deleted_at IS NULL
+			AND l.metadata IS NOT NULL
+			AND l.metadata ? 'podcast'
+	`
+
+	args := []interface{}{sectionID}
+	argIndex := 2
+	if cursor != nil && strings.TrimSpace(*cursor) != "" {
+		cursorTime, cursorLinkID, err := parseRecentPodcastCursor(strings.TrimSpace(*cursor))
+		if err != nil {
+			invalidCursorErr := errors.New("invalid cursor")
+			recordSpanError(span, invalidCursorErr)
+			return nil, invalidCursorErr
+		}
+		query += fmt.Sprintf(" AND (l.created_at < $%d OR (l.created_at = $%d AND l.id < $%d))", argIndex, argIndex, argIndex+1)
+		args = append(args, cursorTime, cursorLinkID)
+		argIndex += 2
+	}
+
+	query += fmt.Sprintf(" ORDER BY l.created_at DESC, l.id DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	items := make([]models.RecentPodcastItem, 0, limit+1)
+	for rows.Next() {
+		var (
+			linkID        uuid.UUID
+			postID        uuid.UUID
+			linkURL       string
+			metadataJSON  sql.NullString
+			userID        uuid.UUID
+			username      string
+			postCreatedAt time.Time
+			linkCreatedAt time.Time
+		)
+		if err := rows.Scan(&linkID, &postID, &linkURL, &metadataJSON, &userID, &username, &postCreatedAt, &linkCreatedAt); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		if !metadataJSON.Valid {
+			continue
+		}
+
+		metadata := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(metadataJSON.String), &metadata); err != nil {
+			continue
+		}
+		podcast, err := extractPodcastFromMetadata(metadata)
+		if err != nil || podcast == nil || strings.TrimSpace(podcast.Kind) == "" {
+			continue
+		}
+
+		items = append(items, models.RecentPodcastItem{
+			PostID:        postID,
+			LinkID:        linkID,
+			URL:           linkURL,
+			Podcast:       *podcast,
+			UserID:        userID,
+			Username:      username,
+			PostCreatedAt: postCreatedAt,
+			LinkCreatedAt: linkCreatedAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	hasMore := len(items) > limit
+	if hasMore {
+		items = items[:limit]
+	}
+
+	var nextCursor *string
+	if hasMore && len(items) > 0 {
+		cursorValue := buildRecentPodcastCursor(items[len(items)-1].LinkCreatedAt, items[len(items)-1].LinkID)
+		nextCursor = &cursorValue
+	}
+
+	if items == nil {
+		items = []models.RecentPodcastItem{}
+	}
+
+	return &models.SectionRecentPodcastsResponse{
+		Items:      items,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+func buildRecentPodcastCursor(createdAt time.Time, linkID uuid.UUID) string {
+	return createdAt.UTC().Format(time.RFC3339Nano) + recentPodcastCursorSeparator + linkID.String()
+}
+
+func parseRecentPodcastCursor(cursor string) (time.Time, uuid.UUID, error) {
+	parts := strings.Split(cursor, recentPodcastCursorSeparator)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, errors.New("invalid cursor")
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, uuid.Nil, errors.New("invalid cursor")
+	}
+	linkID, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, errors.New("invalid cursor")
+	}
+	return createdAt, linkID, nil
 }


### PR DESCRIPTION
## Summary
- add `GET /api/v1/sections/{sectionId}/podcasts/recent` via `SectionHandler.GetRecentPodcasts`
- implement `SectionService.GetRecentPodcasts` with section existence/type validation, podcast metadata parsing, and cursor pagination
- enforce deterministic newest-first ordering using `(link_created_at DESC, link_id DESC)` and cursor format `timestamp|link_id`
- wire route dispatch in section route handler and main server setup
- add backend tests for empty results, paginated deterministic behavior, invalid cursor handling, invalid section type handling, and route auth wiring

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run 'TestSectionServiceGetRecentPodcasts|TestSectionServiceGetSectionLinks' -count=1`
- `cd backend && go test ./internal/handlers -run 'TestGetRecentPodcasts|TestGetSectionLinks' -count=1`
- `cd backend && go test ./cmd/server -run 'TestSectionRouteHandler' -count=1`
- `cd backend && go test ./...`

Closes #894