### PR TITLE
[Books] Add Bookshelf route and navigation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import MusicLinksContainer from './components/MusicLinksContainer.svelte';
   import ThreadView from './components/ThreadView.svelte';
   import UserProfile from './components/UserProfile.svelte';
+  import Bookshelf from './components/books/Bookshelf.svelte';
   import Watchlist from './components/movies/Watchlist.svelte';
   import PodcastsTopContainer from './components/podcasts/PodcastsTopContainer.svelte';
   import Cookbook from './components/recipes/Cookbook.svelte';
@@ -38,6 +39,7 @@
     buildThreadHref,
     getHistoryState,
     isAdminPath,
+    isBookshelfPath,
     isSettingsPath,
     isWatchlistPath,
     parseSectionWatchlistSlug,
@@ -168,6 +170,20 @@
         sectionSubview = 'feed';
         pendingLegacyWatchlistRoute = true;
       }
+      return;
+    }
+    if (isBookshelfPath(path)) {
+      unauthRoute = 'login';
+      resetToken = null;
+      threadRouteStore.clearTarget();
+      pendingSectionIdentifier = null;
+      pendingSectionSubview = 'feed';
+      pendingThreadPostId = null;
+      pendingLegacyWatchlistRoute = false;
+      pendingAdminPath = false;
+      highlightCommentId = null;
+      sectionSubview = 'feed';
+      uiStore.setActiveView('bookshelf');
       return;
     }
     const profileUserId = parseProfileUserId(path);
@@ -414,6 +430,18 @@
     }
   }
 
+  $: if (
+    typeof window !== 'undefined' &&
+    isBookshelfPath(window.location.pathname) &&
+    $isAuthenticated
+  ) {
+    if ($activeView !== 'bookshelf') {
+      uiStore.setActiveView('bookshelf');
+    }
+    threadRouteStore.clearTarget();
+    sectionSubview = 'feed';
+  }
+
   $: if (sectionSubview === 'watchlist' && $activeSection && typeof window !== 'undefined') {
     const watchlistSlug = parseSectionWatchlistSlug(window.location.pathname);
     const isLegacyWatchlistRoute = isWatchlistPath(window.location.pathname);
@@ -428,6 +456,8 @@
   $: if (typeof document !== 'undefined') {
     if (sectionSubview === 'watchlist' && $activeSection && isWatchlistSection($activeSection)) {
       document.title = `${$activeSection.name} Watchlist - Clubhouse`;
+    } else if ($activeView === 'bookshelf') {
+      document.title = 'Bookshelf - Clubhouse';
     } else {
       document.title = 'Clubhouse';
     }
@@ -485,6 +515,8 @@
           {/if}
         {:else if $activeView === 'settings'}
           <Settings />
+        {:else if $activeView === 'bookshelf'}
+          <Bookshelf />
         {:else if sectionNotFound}
           <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <h1 class="text-xl font-semibold text-gray-900 mb-2">Section not found</h1>

--- a/frontend/src/__tests__/App.bookshelf.test.ts
+++ b/frontend/src/__tests__/App.bookshelf.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import * as stores from '../stores';
+import { movieStore } from '../stores/movieStore';
+import { bookStore } from '../stores/bookStore';
+
+const loadFeedMock = vi.hoisted(() => vi.fn());
+const loadMorePostsMock = vi.hoisted(() => vi.fn());
+const loadThreadTargetPostMock = vi.hoisted(() => vi.fn());
+const loadSectionLinksMock = vi.hoisted(() => vi.fn());
+const loadMoreSectionLinksMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../stores/feedStore', () => ({
+  loadFeed: loadFeedMock,
+  loadMorePosts: loadMorePostsMock,
+}));
+
+vi.mock('../stores/sectionLinksFeedStore', () => ({
+  loadSectionLinks: loadSectionLinksMock,
+  loadMoreSectionLinks: loadMoreSectionLinksMock,
+}));
+
+vi.mock('../stores/threadRouteStore', async () => {
+  const actual = await vi.importActual('../stores/threadRouteStore');
+  return {
+    ...actual,
+    loadThreadTargetPost: loadThreadTargetPostMock,
+  };
+});
+
+const { default: App } = await import('../App.svelte');
+
+const defaultUser = {
+  id: 'user-1',
+  username: 'bookfan',
+  email: 'bookfan@example.com',
+  isAdmin: false,
+  totpEnabled: false,
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(max-width: 1023px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  vi.spyOn(stores.authStore, 'checkSession').mockResolvedValue(false);
+  vi.spyOn(stores.websocketStore, 'init').mockImplementation(() => {});
+  vi.spyOn(stores.websocketStore, 'cleanup').mockImplementation(() => {});
+  vi.spyOn(stores.sectionStore, 'loadSections').mockResolvedValue();
+  vi.spyOn(stores.pwaStore, 'init').mockResolvedValue();
+  vi.spyOn(stores.configStore, 'load').mockResolvedValue();
+  vi.spyOn(stores, 'initNotifications').mockImplementation(() => {});
+  vi.spyOn(stores, 'cleanupNotifications').mockImplementation(() => {});
+  vi.spyOn(movieStore, 'loadWatchlist').mockResolvedValue();
+  vi.spyOn(movieStore, 'loadWatchlistCategories').mockResolvedValue();
+  vi.spyOn(bookStore, 'loadBookshelfCategories').mockResolvedValue();
+  vi.spyOn(bookStore, 'loadMyBookshelf').mockResolvedValue(undefined);
+  vi.spyOn(bookStore, 'loadAllBookshelf').mockResolvedValue(undefined);
+  loadFeedMock.mockResolvedValue(undefined);
+  loadMorePostsMock.mockResolvedValue(undefined);
+  loadThreadTargetPostMock.mockResolvedValue(undefined);
+  loadSectionLinksMock.mockResolvedValue(undefined);
+  loadMoreSectionLinksMock.mockResolvedValue(undefined);
+
+  stores.authStore.setUser(null);
+  stores.sectionStore.setSections([
+    { id: 'section-books', name: 'Books', type: 'book', icon: '📚', slug: 'books' },
+    { id: 'section-music', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+  ]);
+  stores.uiStore.setActiveView('feed');
+  stores.threadRouteStore.clearTarget();
+  movieStore.reset();
+  bookStore.reset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('App bookshelf routing', () => {
+  it('renders bookshelf route for authenticated users', async () => {
+    stores.authStore.setUser(defaultUser);
+    window.history.replaceState(null, '', '/bookshelf');
+
+    render(App);
+    window.dispatchEvent(new Event('popstate'));
+
+    await waitFor(() => {
+      expect(get(stores.activeView)).toBe('bookshelf');
+    });
+    expect(screen.getByTestId('bookshelf-tab-my')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/bookshelf');
+    expect(document.title).toBe('Bookshelf - Clubhouse');
+  });
+
+  it('renders login for unauthenticated users on bookshelf route', async () => {
+    window.history.replaceState(null, '', '/bookshelf');
+
+    render(App);
+    window.dispatchEvent(new Event('popstate'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', { name: 'Bookshelf' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/App.bookshelf.test.ts
+++ b/frontend/src/__tests__/App.bookshelf.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import * as stores from '../stores';
 import { movieStore } from '../stores/movieStore';
@@ -115,5 +115,23 @@ describe('App bookshelf routing', () => {
       expect(screen.getByRole('heading', { name: 'Sign in to Clubhouse' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('heading', { name: 'Bookshelf' })).not.toBeInTheDocument();
+  });
+
+  it('shows Bookshelf tab in Books section header and routes to /bookshelf', async () => {
+    stores.authStore.setUser(defaultUser);
+    window.history.replaceState(null, '', '/sections/books');
+
+    render(App);
+
+    const feedTab = await screen.findByTestId('section-tab-feed');
+    const bookshelfTab = screen.getByTestId('section-tab-bookshelf');
+    expect(feedTab).toHaveAttribute('aria-selected', 'true');
+
+    await fireEvent.click(bookshelfTab);
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/bookshelf');
+    });
+    expect(bookshelfTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('bookshelf-tab-my')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -12,11 +12,14 @@
   } from '../stores';
   import {
     buildAdminHref,
+    buildBookshelfHref,
     buildSectionHref,
     pushPath,
   } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
   import NotificationSettings from './NotificationSettings.svelte';
+
+  $: hasBooksSection = $sections.some((section) => section.type === 'book');
 
   function handleSectionClick(section: Section) {
     sectionStore.setActiveSection(section);
@@ -29,6 +32,12 @@
     uiStore.setActiveView('admin');
     threadRouteStore.clearTarget();
     pushPath(buildAdminHref());
+  }
+
+  function handleBookshelfClick() {
+    uiStore.setActiveView('bookshelf');
+    threadRouteStore.clearTarget();
+    pushPath(buildBookshelfHref());
   }
 
 </script>
@@ -54,6 +63,22 @@
           </button>
         </li>
       {/each}
+      {#if hasBooksSection}
+        <li>
+          <button
+            on:click={handleBookshelfClick}
+            class="w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
+              {$activeView === 'bookshelf'
+              ? 'bg-primary text-white'
+              : 'text-gray-700 hover:bg-gray-100'}"
+            aria-current={$activeView === 'bookshelf' ? 'page' : undefined}
+            data-testid="nav-bookshelf"
+          >
+            <span class="text-lg" aria-hidden="true">📚</span>
+            <span>Bookshelf</span>
+          </button>
+        </li>
+      {/if}
     </ul>
 
   </div>

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, cleanup } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import { authStore, notificationStore, sectionStore, uiStore } from '../../stores';
 
 const { default: Nav } = await import('../Nav.svelte');
@@ -75,5 +76,26 @@ describe('Nav', () => {
     render(Nav);
 
     expect(screen.queryByRole('button', { name: 'My Movies' })).not.toBeInTheDocument();
+  });
+
+  it('renders bookshelf entry for book communities and navigates to /bookshelf', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    render(Nav);
+
+    const bookshelfButton = screen.getByRole('button', { name: 'Bookshelf' });
+    await fireEvent.click(bookshelfButton);
+
+    expect(get(uiStore).activeView).toBe('bookshelf');
+    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/bookshelf');
+  });
+
+  it('does not render bookshelf entry when there is no books section', () => {
+    sectionStore.setSections([
+      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
+      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
+    ]);
+    render(Nav);
+
+    expect(screen.queryByRole('button', { name: 'Bookshelf' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAdminHref,
+  buildBookshelfHref,
   buildFeedHref,
   buildSectionWatchlistHref,
   buildSectionHref,
@@ -9,6 +10,7 @@ import {
   buildWatchlistHref,
   buildThreadHref,
   isAdminPath,
+  isBookshelfPath,
   isSettingsPath,
   isWatchlistPath,
   parseSectionWatchlistSlug,
@@ -72,6 +74,13 @@ describe('routeNavigation', () => {
     expect(isWatchlistPath('/watchlist')).toBe(true);
     expect(isWatchlistPath('/watchlist/favorites')).toBe(true);
     expect(isWatchlistPath('/sections/movies')).toBe(false);
+  });
+
+  it('builds bookshelf hrefs and recognizes bookshelf paths', () => {
+    expect(buildBookshelfHref()).toBe('/bookshelf');
+    expect(isBookshelfPath('/bookshelf')).toBe(true);
+    expect(isBookshelfPath('/bookshelf/all')).toBe(true);
+    expect(isBookshelfPath('/sections/books')).toBe(false);
   });
 
   it('builds and parses section watchlist hrefs', () => {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -4,6 +4,7 @@ const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
 const WATCHLIST_PATH = '/watchlist';
+const BOOKSHELF_PATH = '/bookshelf';
 const WATCHLIST_SEGMENT = WATCHLIST_PATH.slice(1);
 
 export type SearchHistoryState = {
@@ -104,6 +105,10 @@ export function buildWatchlistHref(): string {
   return WATCHLIST_PATH;
 }
 
+export function buildBookshelfHref(): string {
+  return BOOKSHELF_PATH;
+}
+
 export function isAdminPath(pathname: string): boolean {
   return pathname === ADMIN_PATH || pathname.startsWith(`${ADMIN_PATH}/`);
 }
@@ -114,6 +119,10 @@ export function isSettingsPath(pathname: string): boolean {
 
 export function isWatchlistPath(pathname: string): boolean {
   return pathname === WATCHLIST_PATH || pathname.startsWith(`${WATCHLIST_PATH}/`);
+}
+
+export function isBookshelfPath(pathname: string): boolean {
+  return pathname === BOOKSHELF_PATH || pathname.startsWith(`${BOOKSHELF_PATH}/`);
 }
 
 export function buildFeedHref(sectionSlug?: string | null): string {

--- a/frontend/src/stores/__tests__/uiStore.test.ts
+++ b/frontend/src/stores/__tests__/uiStore.test.ts
@@ -33,6 +33,11 @@ describe('uiStore', () => {
     expect(get(uiStore).activeView).toBe('admin');
   });
 
+  it('setActiveView supports bookshelf view', () => {
+    uiStore.setActiveView('bookshelf');
+    expect(get(uiStore).activeView).toBe('bookshelf');
+  });
+
   it('openProfile sets profile view and active user', () => {
     uiStore.openProfile('user-42');
     const state = get(uiStore);

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -3,7 +3,7 @@ import { writable, derived } from 'svelte/store';
 interface UIState {
   sidebarOpen: boolean;
   isMobile: boolean;
-  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread';
+  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread' | 'bookshelf';
   activeProfileUserId: string | null;
 }
 
@@ -25,7 +25,7 @@ function createUIStore() {
         isMobile,
         sidebarOpen: isMobile ? false : state.sidebarOpen,
       })),
-    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread') =>
+    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread' | 'bookshelf') =>
       update((state) => ({
         ...state,
         activeView,


### PR DESCRIPTION
## Summary
- add `/bookshelf` route helpers (`buildBookshelfHref`, `isBookshelfPath`) and route-navigation test coverage
- wire App route handling so authenticated users can open the Bookshelf view from `/bookshelf` and get a dedicated page title
- add a sidebar `Bookshelf` navigation entry (shown when a books section exists) and related Nav tests
- add App bookshelf routing tests (authenticated and unauthenticated) and extend `uiStore` coverage for the new `bookshelf` view

Closes #874