### PR TITLE
[Movies] Fix Rotten Tomatoes scores not displaying in MovieCard

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -80,10 +80,10 @@
     director?: string;
     tmdbRating?: number;
     tmdb_rating?: number;
-    rottenTomatoesScore?: number;
-    rotten_tomatoes_score?: number;
-    metacriticScore?: number;
-    metacritic_score?: number;
+    rottenTomatoesScore?: number | string;
+    rotten_tomatoes_score?: number | string;
+    metacriticScore?: number | string;
+    metacritic_score?: number | string;
     trailerKey?: string;
     trailer_key?: string;
     tmdbId?: number;
@@ -629,6 +629,33 @@
     embedController = controller;
   };
 
+  function normalizeMoviePercentScore(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const direct = Number(trimmed);
+    if (Number.isFinite(direct)) {
+      return direct;
+    }
+
+    const match = trimmed.match(/^(-?\d+(?:\.\d+)?)\s*(?:%|\/\s*100)$/i);
+    if (!match?.[1]) {
+      return undefined;
+    }
+
+    const parsed = Number(match[1]);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
   function normalizeMovieMetadata(movie?: MovieMetadata): MovieCardMetadata | null {
     if (!movie) {
       return null;
@@ -652,18 +679,12 @@
         : typeof movie.tmdb_rating === 'number'
           ? movie.tmdb_rating
           : undefined;
-    const normalizedRottenTomatoesScore =
-      typeof movie.rottenTomatoesScore === 'number'
-        ? movie.rottenTomatoesScore
-        : typeof movie.rotten_tomatoes_score === 'number'
-          ? movie.rotten_tomatoes_score
-          : undefined;
-    const normalizedMetacriticScore =
-      typeof movie.metacriticScore === 'number'
-        ? movie.metacriticScore
-        : typeof movie.metacritic_score === 'number'
-          ? movie.metacritic_score
-          : undefined;
+    const normalizedRottenTomatoesScore = normalizeMoviePercentScore(
+      movie.rottenTomatoesScore ?? movie.rotten_tomatoes_score
+    );
+    const normalizedMetacriticScore = normalizeMoviePercentScore(
+      movie.metacriticScore ?? movie.metacritic_score
+    );
     const normalizedRuntime =
       typeof movie.runtime === 'number' && Number.isFinite(movie.runtime) ? movie.runtime : undefined;
     const normalizedGenres =

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -629,7 +629,7 @@
     embedController = controller;
   };
 
-  function normalizeMoviePercentScore(value: unknown): number | undefined {
+  function parseMoviePercentScore(value: unknown): number | undefined {
     if (typeof value === 'number' && Number.isFinite(value)) {
       return value;
     }
@@ -656,6 +656,16 @@
     return Number.isFinite(parsed) ? parsed : undefined;
   }
 
+  function normalizeMoviePercentScore(...values: unknown[]): number | undefined {
+    for (const value of values) {
+      const parsed = parseMoviePercentScore(value);
+      if (typeof parsed === 'number') {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
   function normalizeMovieMetadata(movie?: MovieMetadata): MovieCardMetadata | null {
     if (!movie) {
       return null;
@@ -680,10 +690,12 @@
           ? movie.tmdb_rating
           : undefined;
     const normalizedRottenTomatoesScore = normalizeMoviePercentScore(
-      movie.rottenTomatoesScore ?? movie.rotten_tomatoes_score
+      movie.rottenTomatoesScore,
+      movie.rotten_tomatoes_score
     );
     const normalizedMetacriticScore = normalizeMoviePercentScore(
-      movie.metacriticScore ?? movie.metacritic_score
+      movie.metacriticScore,
+      movie.metacritic_score
     );
     const normalizedRuntime =
       typeof movie.runtime === 'number' && Number.isFinite(movie.runtime) ? movie.runtime : undefined;

--- a/frontend/src/components/__tests__/MovieCard.test.ts
+++ b/frontend/src/components/__tests__/MovieCard.test.ts
@@ -14,8 +14,10 @@ type MovieMetadata = {
   cast?: { name: string; character: string }[];
   director?: string;
   tmdbRating?: number;
-  rottenTomatoesScore?: number;
-  metacriticScore?: number;
+  rottenTomatoesScore?: number | string;
+  rotten_tomatoes_score?: number | string;
+  metacriticScore?: number | string;
+  metacritic_score?: number | string;
   trailerKey?: string;
   tmdbId?: number;
   tmdbMediaType?: 'movie' | 'tv';
@@ -155,6 +157,36 @@ describe('MovieCard', () => {
       'text-rose-800',
       'bg-rose-100'
     );
+  });
+
+  it('normalizes snake_case formatted score strings for RT and Metacritic', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        rotten_tomatoes_score: '91%',
+        metacritic_score: '74/100',
+      },
+    });
+
+    expect(screen.getByTestId('movie-rating-rotten-tomatoes')).toHaveTextContent('🍅 91%');
+    expect(screen.getByTestId('movie-rating-rotten-tomatoes')).toHaveClass(
+      'text-emerald-800',
+      'bg-emerald-100'
+    );
+    expect(screen.getByTestId('movie-rating-metacritic')).toHaveTextContent('MC 74');
+  });
+
+  it('shows RT score when expanded is true', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        rottenTomatoesScore: 88,
+      },
+      expanded: true,
+    });
+
+    expect(screen.getByTestId('movie-rating-rotten-tomatoes')).toHaveTextContent('🍅 88%');
+    expect(screen.getByTestId('movie-expanded-content')).toBeInTheDocument();
   });
 
   it('renders season summary and expanded season list for series metadata', async () => {

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -36,6 +36,10 @@ type MovieMetadataForTest = {
   release_date?: string;
   director?: string;
   tmdb_rating?: number;
+  rottenTomatoesScore?: number | string;
+  rotten_tomatoes_score?: number | string;
+  metacriticScore?: number | string;
+  metacritic_score?: number | string;
   trailer_key?: string;
   cast?: Array<{ name: string; character: string }>;
 };
@@ -303,6 +307,42 @@ describe('PostCard', () => {
     expect(screen.getByTestId('movie-card')).toBeInTheDocument();
     expect(screen.getByTestId('movie-title')).toHaveTextContent('Interstellar');
     expect(screen.getByTestId('movie-meta-line')).toHaveTextContent('★ 8.6· 2h 49m');
+  });
+
+  it('falls back to valid snake_case score when camelCase score is invalid', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Movies',
+        type: 'movie',
+        icon: '🎬',
+        slug: 'movies',
+      },
+    ]);
+
+    const postWithMixedScoreFields: Post = {
+      ...basePost,
+      links: [
+        {
+          url: 'https://www.imdb.com/title/tt0133093/',
+          metadata: {
+            url: 'https://www.imdb.com/title/tt0133093/',
+            movie: {
+              title: 'The Matrix',
+              rottenTomatoesScore: 'N/A',
+              rotten_tomatoes_score: 91,
+              metacriticScore: 'N/A',
+              metacritic_score: 74,
+            },
+          },
+        },
+      ],
+    };
+
+    render(PostCard, { post: postWithMixedScoreFields });
+
+    expect(screen.getByTestId('movie-rating-rotten-tomatoes')).toHaveTextContent('🍅 91%');
+    expect(screen.getByTestId('movie-rating-metacritic')).toHaveTextContent('MC 74');
   });
 
   it('does not render movie components for non-movie sections', () => {

--- a/frontend/src/components/movies/MovieCard.svelte
+++ b/frontend/src/components/movies/MovieCard.svelte
@@ -42,10 +42,10 @@
     cast?: CastMember[];
     director?: string;
     tmdbRating?: number;
-    rottenTomatoesScore?: number;
-    rotten_tomatoes_score?: number;
-    metacriticScore?: number;
-    metacritic_score?: number;
+    rottenTomatoesScore?: number | string;
+    rotten_tomatoes_score?: number | string;
+    metacriticScore?: number | string;
+    metacritic_score?: number | string;
     trailerKey?: string;
     tmdbId?: number;
     tmdb_id?: number;
@@ -192,11 +192,36 @@
     return value.toFixed(1);
   }
 
-  function normalizePercentScore(value?: number): number | null {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
+  function normalizePercentScore(value: unknown): number | null {
+    let parsedValue: number | null = null;
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      parsedValue = value;
+    } else if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const direct = Number(trimmed);
+      if (Number.isFinite(direct)) {
+        parsedValue = direct;
+      } else {
+        const match = trimmed.match(/^(-?\d+(?:\.\d+)?)\s*(?:%|\/\s*100)$/i);
+        if (match?.[1]) {
+          const normalized = Number(match[1]);
+          if (Number.isFinite(normalized)) {
+            parsedValue = normalized;
+          }
+        }
+      }
+    }
+
+    if (parsedValue === null) {
       return null;
     }
-    const rounded = Math.round(value);
+
+    const rounded = Math.round(parsedValue);
     if (rounded < 0 || rounded > 100) {
       return null;
     }

--- a/frontend/src/components/movies/MovieCard.svelte
+++ b/frontend/src/components/movies/MovieCard.svelte
@@ -86,9 +86,10 @@
   $: runtimeLabel = formatRuntime(movie.runtime);
   $: tmdbRatingLabel = formatTMDBRating(movie.tmdbRating);
   $: rottenTomatoesScore = normalizePercentScore(
-    movie.rottenTomatoesScore ?? movie.rotten_tomatoes_score
+    movie.rottenTomatoesScore,
+    movie.rotten_tomatoes_score
   );
-  $: metacriticScore = normalizePercentScore(movie.metacriticScore ?? movie.metacritic_score);
+  $: metacriticScore = normalizePercentScore(movie.metacriticScore, movie.metacritic_score);
   $: visibleGenres = (movie.genres ?? []).filter(Boolean).slice(0, 3);
   $: remainingGenres = Math.max((movie.genres?.length ?? 0) - visibleGenres.length, 0);
   $: directorLabel = movie.director?.trim() || 'Unknown';
@@ -192,7 +193,7 @@
     return value.toFixed(1);
   }
 
-  function normalizePercentScore(value: unknown): number | null {
+  function parsePercentScore(value: unknown): number | null {
     let parsedValue: number | null = null;
 
     if (typeof value === 'number' && Number.isFinite(value)) {
@@ -226,6 +227,16 @@
       return null;
     }
     return rounded;
+  }
+
+  function normalizePercentScore(...values: unknown[]): number | null {
+    for (const value of values) {
+      const parsed = parsePercentScore(value);
+      if (typeof parsed === 'number') {
+        return parsed;
+      }
+    }
+    return null;
   }
 
   function getRottenTomatoesClasses(score: number): string {

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -256,6 +256,33 @@ describe('mapApiPost', () => {
     ]);
   });
 
+  it('normalizes formatted movie score strings in nested metadata', () => {
+    const post = mapApiPost({
+      id: 'post-movie-formatted-scores',
+      user_id: 'user-movie-formatted-scores',
+      section_id: 'section-movie',
+      content: 'Movie metadata with formatted scores',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-movie-formatted',
+          url: 'https://www.imdb.com/title/tt0133093/',
+          metadata: {
+            movie: {
+              title: 'The Matrix',
+              rotten_tomatoes_score: '88%',
+              metacritic_score: '73/100',
+            },
+          },
+        },
+      ],
+    });
+
+    const movie = post.links?.[0].metadata?.movie;
+    expect(movie?.rottenTomatoesScore).toBe(88);
+    expect(movie?.metacriticScore).toBe(73);
+  });
+
   it('handles missing user and links gracefully', () => {
     const post = mapApiPost({
       id: 'post-2',

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -129,7 +129,7 @@ function normalizeNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function normalizePercentScore(value: unknown): number | undefined {
+function parsePercentScore(value: unknown): number | undefined {
   const normalized = normalizeNumber(value);
   if (typeof normalized === 'number') {
     return normalized;
@@ -151,6 +151,16 @@ function normalizePercentScore(value: unknown): number | undefined {
 
   const parsed = Number(match[1]);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizePercentScore(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const parsed = parsePercentScore(value);
+    if (typeof parsed === 'number') {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 function normalizeStringArray(value: unknown): string[] | undefined {
@@ -358,9 +368,10 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
   const director = normalizeString(movie.director);
   const tmdbRating = normalizeNumber(movie.tmdb_rating ?? movie.tmdbRating);
   const rottenTomatoesScore = normalizePercentScore(
-    movie.rotten_tomatoes_score ?? movie.rottenTomatoesScore
+    movie.rotten_tomatoes_score,
+    movie.rottenTomatoesScore
   );
-  const metacriticScore = normalizePercentScore(movie.metacritic_score ?? movie.metacriticScore);
+  const metacriticScore = normalizePercentScore(movie.metacritic_score, movie.metacriticScore);
   const trailerKey = normalizeString(movie.trailer_key ?? movie.trailerKey);
   const tmdbId = normalizeNumber(movie.tmdb_id ?? movie.tmdbId);
   const tmdbMediaType = normalizeTMDBMediaType(

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -129,6 +129,30 @@ function normalizeNumber(value: unknown): number | undefined {
   return undefined;
 }
 
+function normalizePercentScore(value: unknown): number | undefined {
+  const normalized = normalizeNumber(value);
+  if (typeof normalized === 'number') {
+    return normalized;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const match = trimmed.match(/^(-?\d+(?:\.\d+)?)\s*(?:%|\/\s*100)$/i);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function normalizeStringArray(value: unknown): string[] | undefined {
   if (typeof value === 'string') {
     const normalized = normalizeString(value);
@@ -333,10 +357,10 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
   const releaseDate = normalizeString(movie.release_date ?? movie.releaseDate);
   const director = normalizeString(movie.director);
   const tmdbRating = normalizeNumber(movie.tmdb_rating ?? movie.tmdbRating);
-  const rottenTomatoesScore = normalizeNumber(
+  const rottenTomatoesScore = normalizePercentScore(
     movie.rotten_tomatoes_score ?? movie.rottenTomatoesScore
   );
-  const metacriticScore = normalizeNumber(movie.metacritic_score ?? movie.metacriticScore);
+  const metacriticScore = normalizePercentScore(movie.metacritic_score ?? movie.metacriticScore);
   const trailerKey = normalizeString(movie.trailer_key ?? movie.trailerKey);
   const tmdbId = normalizeNumber(movie.tmdb_id ?? movie.tmdbId);
   const tmdbMediaType = normalizeTMDBMediaType(


### PR DESCRIPTION
## Summary
- normalize movie score fields more defensively in frontend mapping and card normalization so legacy/API formatted values (e.g. `88%`, `73/100`) are rendered correctly
- ensure both `camelCase` and `snake_case` movie score fields are supported end-to-end into `MovieCard`
- keep Rotten Tomatoes badge threshold styling intact while preventing missing/invalid score formats from breaking layout
- add regression tests for formatted score normalization and RT rendering in both collapsed and expanded card states

## Validation
- `cd frontend && npm run check`
- `cd frontend && npm run lint`
- `cd frontend && npm run test -- src/components/__tests__/MovieCard.test.ts src/stores/__tests__/postMapper.test.ts`
- `task ci:prek`

Closes #949