### PR TITLE
[Podcasts] Create PodcastSave service with section guard and audit logging

### DIFF
--- a/backend/internal/models/podcast_save.go
+++ b/backend/internal/models/podcast_save.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PodcastSave stores a user's save-for-later state for a podcast post.
+type PodcastSave struct {
+	ID        uuid.UUID  `json:"id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	PostID    uuid.UUID  `json:"post_id"`
+	CreatedAt time.Time  `json:"created_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+// PostPodcastSaveInfo represents save tooltip data for a podcast post.
+type PostPodcastSaveInfo struct {
+	SaveCount   int            `json:"save_count"`
+	Users       []ReactionUser `json:"users"`
+	ViewerSaved bool           `json:"viewer_saved"`
+}

--- a/backend/internal/services/podcast_save.go
+++ b/backend/internal/services/podcast_save.go
@@ -1,0 +1,465 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	defaultPodcastSaveListLimit = 20
+	maxPodcastSaveListLimit     = 100
+	podcastSaveCursorSeparator  = "|"
+	podcastSaveLegacyCursor     = "2006-01-02T15:04:05.000Z07:00"
+)
+
+type podcastSavePostService interface {
+	GetPostByID(ctx context.Context, postID uuid.UUID, userID uuid.UUID) (*models.Post, error)
+}
+
+// PodcastSaveService handles save-for-later operations for podcast posts.
+type PodcastSaveService struct {
+	db          *sql.DB
+	postService podcastSavePostService
+	audit       *AuditService
+}
+
+// NewPodcastSaveService creates a podcast save service with default dependencies.
+func NewPodcastSaveService(db *sql.DB) *PodcastSaveService {
+	return NewPodcastSaveServiceWithDependencies(db, NewPostService(db), NewAuditService(db))
+}
+
+// NewPodcastSaveServiceWithDependencies creates a podcast save service with explicit dependencies.
+func NewPodcastSaveServiceWithDependencies(
+	db *sql.DB,
+	postService podcastSavePostService,
+	auditService *AuditService,
+) *PodcastSaveService {
+	if postService == nil {
+		postService = NewPostService(db)
+	}
+	if auditService == nil {
+		auditService = NewAuditService(db)
+	}
+
+	return &PodcastSaveService{
+		db:          db,
+		postService: postService,
+		audit:       auditService,
+	}
+}
+
+// SavePodcast saves or restores a podcast post for a user.
+func (s *PodcastSaveService) SavePodcast(ctx context.Context, userID, postID uuid.UUID) (*models.PodcastSave, error) {
+	ctx, span := otel.Tracer("clubhouse.podcast_saves").Start(ctx, "PodcastSaveService.SavePodcast")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+	)
+	defer span.End()
+
+	if err := s.verifyPodcastPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	existing, err := s.getMostRecentPodcastSave(ctx, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if existing != nil {
+		if existing.DeletedAt == nil {
+			return existing, nil
+		}
+
+		restored, err := s.restorePodcastSave(ctx, existing.ID)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+
+		if err := s.logPodcastSaveAudit(ctx, "save_podcast", userID, map[string]interface{}{
+			"post_id": postID.String(),
+		}); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+
+		return restored, nil
+	}
+
+	created, err := s.createPodcastSave(ctx, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if err := s.logPodcastSaveAudit(ctx, "save_podcast", userID, map[string]interface{}{
+		"post_id": postID.String(),
+	}); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	return created, nil
+}
+
+// UnsavePodcast soft-deletes an active podcast save. It is idempotent.
+func (s *PodcastSaveService) UnsavePodcast(ctx context.Context, userID, postID uuid.UUID) error {
+	ctx, span := otel.Tracer("clubhouse.podcast_saves").Start(ctx, "PodcastSaveService.UnsavePodcast")
+	span.SetAttributes(
+		attribute.String("user_id", userID.String()),
+		attribute.String("post_id", postID.String()),
+	)
+	defer span.End()
+
+	if err := s.verifyPodcastPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE podcast_saves
+		SET deleted_at = now()
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`, userID, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return fmt.Errorf("failed to unsave podcast: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+	if rowsAffected == 0 {
+		return nil
+	}
+
+	if err := s.logPodcastSaveAudit(ctx, "unsave_podcast", userID, map[string]interface{}{
+		"post_id": postID.String(),
+	}); err != nil {
+		recordSpanError(span, err)
+		return err
+	}
+
+	return nil
+}
+
+// GetPostPodcastSaveInfo returns aggregate and viewer-specific save information for a podcast post.
+func (s *PodcastSaveService) GetPostPodcastSaveInfo(ctx context.Context, postID uuid.UUID, viewerID *uuid.UUID) (*models.PostPodcastSaveInfo, error) {
+	ctx, span := otel.Tracer("clubhouse.podcast_saves").Start(ctx, "PodcastSaveService.GetPostPodcastSaveInfo")
+	span.SetAttributes(
+		attribute.String("post_id", postID.String()),
+		attribute.Bool("has_viewer_id", viewerID != nil),
+	)
+	if viewerID != nil {
+		span.SetAttributes(attribute.String("viewer_id", viewerID.String()))
+	}
+	defer span.End()
+
+	if err := s.verifyPodcastPost(ctx, postID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	var saveCount int
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT user_id)
+		FROM podcast_saves
+		WHERE post_id = $1 AND deleted_at IS NULL
+	`, postID).Scan(&saveCount); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query podcast save count: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT u.id, u.username, u.profile_picture_url, MIN(ps.created_at) AS first_saved
+		FROM podcast_saves ps
+		JOIN users u ON ps.user_id = u.id
+		WHERE ps.post_id = $1 AND ps.deleted_at IS NULL
+		GROUP BY u.id, u.username, u.profile_picture_url
+		ORDER BY first_saved ASC
+	`, postID)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query podcast save users: %w", err)
+	}
+	defer rows.Close()
+
+	users := make([]models.ReactionUser, 0)
+	for rows.Next() {
+		var user models.ReactionUser
+		var firstSaved sql.NullTime
+		if err := rows.Scan(&user.ID, &user.Username, &user.ProfilePictureUrl, &firstSaved); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		users = append(users, user)
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate podcast save users: %w", err)
+	}
+
+	info := &models.PostPodcastSaveInfo{
+		SaveCount: saveCount,
+		Users:     users,
+	}
+
+	if viewerID != nil {
+		var viewerSaved bool
+		if err := s.db.QueryRowContext(ctx, `
+			SELECT EXISTS(
+				SELECT 1
+				FROM podcast_saves
+				WHERE post_id = $1 AND user_id = $2 AND deleted_at IS NULL
+			)
+		`, postID, *viewerID).Scan(&viewerSaved); err != nil {
+			recordSpanError(span, err)
+			return nil, fmt.Errorf("failed to query viewer podcast save state: %w", err)
+		}
+		info.ViewerSaved = viewerSaved
+	}
+
+	return info, nil
+}
+
+// ListSectionSavedPodcastPosts lists the viewer's saved podcast posts for one podcast section.
+func (s *PodcastSaveService) ListSectionSavedPodcastPosts(
+	ctx context.Context,
+	sectionID, viewerID uuid.UUID,
+	cursor *string,
+	limit int,
+) (*models.FeedResponse, error) {
+	ctx, span := otel.Tracer("clubhouse.podcast_saves").Start(ctx, "PodcastSaveService.ListSectionSavedPodcastPosts")
+	span.SetAttributes(
+		attribute.String("section_id", sectionID.String()),
+		attribute.String("viewer_id", viewerID.String()),
+		attribute.Int("limit", limit),
+		attribute.Bool("has_cursor", cursor != nil && strings.TrimSpace(*cursor) != ""),
+	)
+	defer span.End()
+
+	if err := s.verifyPodcastSection(ctx, sectionID); err != nil {
+		recordSpanError(span, err)
+		return nil, err
+	}
+
+	if limit <= 0 || limit > maxPodcastSaveListLimit {
+		limit = defaultPodcastSaveListLimit
+	}
+
+	query := `
+		SELECT ps.id, ps.post_id, ps.created_at
+		FROM podcast_saves ps
+		JOIN posts p ON p.id = ps.post_id AND p.deleted_at IS NULL
+		WHERE ps.user_id = $1 AND ps.deleted_at IS NULL AND p.section_id = $2
+	`
+	args := []interface{}{viewerID, sectionID}
+	argIndex := 3
+
+	if cursor != nil && strings.TrimSpace(*cursor) != "" {
+		cursorCreatedAt, cursorID, hasID, err := parsePodcastSaveCursor(strings.TrimSpace(*cursor))
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		if hasID {
+			query += fmt.Sprintf(" AND (ps.created_at < $%d OR (ps.created_at = $%d AND ps.id < $%d))", argIndex, argIndex, argIndex+1)
+			args = append(args, cursorCreatedAt, cursorID)
+			argIndex += 2
+		} else {
+			query += fmt.Sprintf(" AND ps.created_at < $%d", argIndex)
+			args = append(args, cursorCreatedAt)
+			argIndex++
+		}
+	}
+
+	query += fmt.Sprintf(" ORDER BY ps.created_at DESC, ps.id DESC LIMIT $%d", argIndex)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to query podcast saves: %w", err)
+	}
+	defer rows.Close()
+
+	type saveCursorRow struct {
+		ID        uuid.UUID
+		PostID    uuid.UUID
+		CreatedAt time.Time
+	}
+
+	saveRows := make([]saveCursorRow, 0, limit+1)
+	for rows.Next() {
+		var row saveCursorRow
+		if err := rows.Scan(&row.ID, &row.PostID, &row.CreatedAt); err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		saveRows = append(saveRows, row)
+	}
+	if err := rows.Err(); err != nil {
+		recordSpanError(span, err)
+		return nil, fmt.Errorf("failed to iterate podcast saves: %w", err)
+	}
+
+	hasMore := len(saveRows) > limit
+	if hasMore {
+		saveRows = saveRows[:limit]
+	}
+
+	posts := make([]*models.Post, 0, len(saveRows))
+	for _, saveRow := range saveRows {
+		post, err := s.postService.GetPostByID(ctx, saveRow.PostID, viewerID)
+		if err != nil {
+			recordSpanError(span, err)
+			return nil, err
+		}
+		posts = append(posts, post)
+	}
+
+	var nextCursor *string
+	if hasMore && len(saveRows) > 0 {
+		cursorValue := buildPodcastSaveCursor(saveRows[len(saveRows)-1].CreatedAt, saveRows[len(saveRows)-1].ID)
+		nextCursor = &cursorValue
+	}
+
+	return &models.FeedResponse{
+		Posts:      posts,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+func (s *PodcastSaveService) verifyPodcastSection(ctx context.Context, sectionID uuid.UUID) error {
+	var sectionType string
+	if err := s.db.QueryRowContext(ctx, "SELECT type FROM sections WHERE id = $1", sectionID).Scan(&sectionType); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("section not found")
+		}
+		return fmt.Errorf("failed to verify section: %w", err)
+	}
+
+	if sectionType != "podcast" {
+		return errors.New("section is not podcast")
+	}
+
+	return nil
+}
+
+func (s *PodcastSaveService) verifyPodcastPost(ctx context.Context, postID uuid.UUID) error {
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM posts p
+			JOIN sections s ON p.section_id = s.id
+			WHERE p.id = $1 AND p.deleted_at IS NULL AND s.type = 'podcast'
+		)
+	`, postID).Scan(&exists); err != nil {
+		return fmt.Errorf("failed to verify podcast post: %w", err)
+	}
+	if !exists {
+		return errors.New("podcast post not found")
+	}
+	return nil
+}
+
+func (s *PodcastSaveService) getMostRecentPodcastSave(ctx context.Context, userID, postID uuid.UUID) (*models.PodcastSave, error) {
+	var save models.PodcastSave
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, post_id, created_at, deleted_at
+		FROM podcast_saves
+		WHERE user_id = $1 AND post_id = $2
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+	`, userID, postID).Scan(&save.ID, &save.UserID, &save.PostID, &save.CreatedAt, &save.DeletedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load podcast save: %w", err)
+	}
+	return &save, nil
+}
+
+func (s *PodcastSaveService) restorePodcastSave(ctx context.Context, saveID uuid.UUID) (*models.PodcastSave, error) {
+	var save models.PodcastSave
+	if err := s.db.QueryRowContext(ctx, `
+		UPDATE podcast_saves
+		SET deleted_at = NULL
+		WHERE id = $1
+		RETURNING id, user_id, post_id, created_at, deleted_at
+	`, saveID).Scan(&save.ID, &save.UserID, &save.PostID, &save.CreatedAt, &save.DeletedAt); err != nil {
+		return nil, fmt.Errorf("failed to restore podcast save: %w", err)
+	}
+	return &save, nil
+}
+
+func (s *PodcastSaveService) createPodcastSave(ctx context.Context, userID, postID uuid.UUID) (*models.PodcastSave, error) {
+	var save models.PodcastSave
+	if err := s.db.QueryRowContext(ctx, `
+		INSERT INTO podcast_saves (id, user_id, post_id, created_at)
+		VALUES ($1, $2, $3, now())
+		RETURNING id, user_id, post_id, created_at, deleted_at
+	`, uuid.New(), userID, postID).Scan(&save.ID, &save.UserID, &save.PostID, &save.CreatedAt, &save.DeletedAt); err != nil {
+		return nil, fmt.Errorf("failed to create podcast save: %w", err)
+	}
+	return &save, nil
+}
+
+func (s *PodcastSaveService) logPodcastSaveAudit(ctx context.Context, action string, userID uuid.UUID, metadata map[string]interface{}) error {
+	if err := s.audit.LogAuditWithMetadata(ctx, action, uuid.Nil, userID, metadata); err != nil {
+		return fmt.Errorf("failed to create podcast save audit log: %w", err)
+	}
+	return nil
+}
+
+func parsePodcastSaveCursor(cursor string) (time.Time, uuid.UUID, bool, error) {
+	parts := strings.Split(cursor, podcastSaveCursorSeparator)
+	switch len(parts) {
+	case 1:
+		createdAt, err := parsePodcastSaveCursorTime(parts[0])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		return createdAt, uuid.Nil, false, nil
+	case 2:
+		createdAt, err := parsePodcastSaveCursorTime(parts[0])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		cursorID, err := uuid.Parse(parts[1])
+		if err != nil {
+			return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+		}
+		return createdAt, cursorID, true, nil
+	default:
+		return time.Time{}, uuid.Nil, false, errors.New("invalid cursor")
+	}
+}
+
+func parsePodcastSaveCursorTime(raw string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err == nil {
+		return parsed, nil
+	}
+	return time.Parse(podcastSaveLegacyCursor, raw)
+}
+
+func buildPodcastSaveCursor(createdAt time.Time, saveID uuid.UUID) string {
+	return fmt.Sprintf("%s%s%s", createdAt.UTC().Format(time.RFC3339Nano), podcastSaveCursorSeparator, saveID.String())
+}

--- a/backend/internal/services/podcast_save_test.go
+++ b/backend/internal/services/podcast_save_test.go
@@ -1,0 +1,284 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestPodcastSaveAndUnsaveIdempotentWithRestoreAndAudit(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "podcastsaveidempotent", "podcastsaveidempotent@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Podcast post"))
+
+	service := NewPodcastSaveService(db)
+
+	firstSave, err := service.SavePodcast(context.Background(), userID, postID)
+	if err != nil {
+		t.Fatalf("first SavePodcast failed: %v", err)
+	}
+
+	secondSave, err := service.SavePodcast(context.Background(), userID, postID)
+	if err != nil {
+		t.Fatalf("second SavePodcast failed: %v", err)
+	}
+	if secondSave.ID != firstSave.ID {
+		t.Fatalf("expected duplicate save to keep same save row, got %s and %s", firstSave.ID, secondSave.ID)
+	}
+
+	assertPodcastSaveCounts(t, db, userID, postID, 1, 1)
+	assertPodcastAuditCount(t, db, "save_podcast", userID, 1)
+
+	if err := service.UnsavePodcast(context.Background(), userID, postID); err != nil {
+		t.Fatalf("first UnsavePodcast failed: %v", err)
+	}
+	if err := service.UnsavePodcast(context.Background(), userID, postID); err != nil {
+		t.Fatalf("second UnsavePodcast should be idempotent, got: %v", err)
+	}
+
+	assertPodcastSaveCounts(t, db, userID, postID, 0, 1)
+	assertPodcastAuditCount(t, db, "unsave_podcast", userID, 1)
+
+	thirdSave, err := service.SavePodcast(context.Background(), userID, postID)
+	if err != nil {
+		t.Fatalf("third SavePodcast failed: %v", err)
+	}
+	if thirdSave.ID != firstSave.ID {
+		t.Fatalf("expected resave to restore same row %s, got %s", firstSave.ID, thirdSave.ID)
+	}
+
+	assertPodcastSaveCounts(t, db, userID, postID, 1, 1)
+	assertPodcastAuditCount(t, db, "save_podcast", userID, 2)
+
+	saveMetadata := mustQueryPodcastAuditMetadata(t, db, "save_podcast", userID)
+	if saveMetadata["post_id"] != postID.String() {
+		t.Fatalf("expected save_podcast metadata post_id %s, got %v", postID.String(), saveMetadata["post_id"])
+	}
+}
+
+func TestPodcastSaveRejectsNonPodcastPost(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "podcastsaveinvalid", "podcastsaveinvalid@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), sectionID, "Recipe post"))
+
+	service := NewPodcastSaveService(db)
+
+	_, err := service.SavePodcast(context.Background(), userID, postID)
+	if err == nil {
+		t.Fatal("expected SavePodcast to fail for non-podcast post")
+	}
+	if !strings.Contains(err.Error(), "podcast post not found") {
+		t.Fatalf("expected podcast post guard error, got %v", err)
+	}
+
+	err = service.UnsavePodcast(context.Background(), userID, postID)
+	if err == nil {
+		t.Fatal("expected UnsavePodcast to fail for non-podcast post")
+	}
+	if !strings.Contains(err.Error(), "podcast post not found") {
+		t.Fatalf("expected podcast post guard error, got %v", err)
+	}
+}
+
+func TestGetPostPodcastSaveInfoIncludesViewerAndAggregate(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := uuid.MustParse(testutil.CreateTestUser(t, db, "podcastinfousera", "podcastinfousera@test.com", false, true))
+	userB := uuid.MustParse(testutil.CreateTestUser(t, db, "podcastinfouserb", "podcastinfouserb@test.com", false, true))
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := uuid.MustParse(testutil.CreateTestPost(t, db, userA.String(), sectionID, "Podcast post"))
+
+	service := NewPodcastSaveService(db)
+	if _, err := service.SavePodcast(context.Background(), userA, postID); err != nil {
+		t.Fatalf("SavePodcast userA failed: %v", err)
+	}
+	if _, err := service.SavePodcast(context.Background(), userB, postID); err != nil {
+		t.Fatalf("SavePodcast userB failed: %v", err)
+	}
+
+	info, err := service.GetPostPodcastSaveInfo(context.Background(), postID, &userA)
+	if err != nil {
+		t.Fatalf("GetPostPodcastSaveInfo failed: %v", err)
+	}
+
+	if info.SaveCount != 2 {
+		t.Fatalf("expected save count 2, got %d", info.SaveCount)
+	}
+	if len(info.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(info.Users))
+	}
+	if !info.ViewerSaved {
+		t.Fatal("expected viewer_saved true")
+	}
+}
+
+func TestListSectionSavedPodcastPostsPaginatesAndGuardsSectionType(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := uuid.MustParse(testutil.CreateTestUser(t, db, "podcastlistuser", "podcastlistuser@test.com", false, true))
+	podcastSectionID := uuid.MustParse(testutil.CreateTestSection(t, db, "Podcasts", "podcast"))
+	otherPodcastSectionID := uuid.MustParse(testutil.CreateTestSection(t, db, "Other Podcasts", "podcast"))
+	recipeSectionID := uuid.MustParse(testutil.CreateTestSection(t, db, "Recipes", "recipe"))
+
+	postA := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), podcastSectionID.String(), "Podcast A"))
+	postB := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), podcastSectionID.String(), "Podcast B"))
+	postC := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), podcastSectionID.String(), "Podcast C"))
+	postOtherSection := uuid.MustParse(testutil.CreateTestPost(t, db, userID.String(), otherPodcastSectionID.String(), "Other section podcast"))
+
+	service := NewPodcastSaveService(db)
+	if _, err := service.SavePodcast(context.Background(), userID, postA); err != nil {
+		t.Fatalf("SavePodcast postA failed: %v", err)
+	}
+	if _, err := service.SavePodcast(context.Background(), userID, postB); err != nil {
+		t.Fatalf("SavePodcast postB failed: %v", err)
+	}
+	if _, err := service.SavePodcast(context.Background(), userID, postC); err != nil {
+		t.Fatalf("SavePodcast postC failed: %v", err)
+	}
+	if _, err := service.SavePodcast(context.Background(), userID, postOtherSection); err != nil {
+		t.Fatalf("SavePodcast postOtherSection failed: %v", err)
+	}
+
+	oldest := time.Now().UTC().Add(-3 * time.Hour)
+	middle := oldest.Add(1 * time.Hour)
+	newest := middle.Add(1 * time.Hour)
+	if _, err := db.ExecContext(context.Background(), `
+		UPDATE podcast_saves SET created_at = $1 WHERE user_id = $2 AND post_id = $3
+	`, oldest, userID, postA); err != nil {
+		t.Fatalf("failed to set created_at for postA: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		UPDATE podcast_saves SET created_at = $1 WHERE user_id = $2 AND post_id = $3
+	`, middle, userID, postB); err != nil {
+		t.Fatalf("failed to set created_at for postB: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		UPDATE podcast_saves SET created_at = $1 WHERE user_id = $2 AND post_id = $3
+	`, newest, userID, postC); err != nil {
+		t.Fatalf("failed to set created_at for postC: %v", err)
+	}
+
+	pageOne, err := service.ListSectionSavedPodcastPosts(context.Background(), podcastSectionID, userID, nil, 2)
+	if err != nil {
+		t.Fatalf("ListSectionSavedPodcastPosts page 1 failed: %v", err)
+	}
+	if len(pageOne.Posts) != 2 {
+		t.Fatalf("expected 2 posts in page 1, got %d", len(pageOne.Posts))
+	}
+	if !pageOne.HasMore {
+		t.Fatal("expected page 1 has_more true")
+	}
+	if pageOne.NextCursor == nil {
+		t.Fatal("expected non-nil next cursor on page 1")
+	}
+	if pageOne.Posts[0].ID != postC {
+		t.Fatalf("expected latest post first (%s), got %s", postC, pageOne.Posts[0].ID)
+	}
+	if pageOne.Posts[1].ID != postB {
+		t.Fatalf("expected second latest post second (%s), got %s", postB, pageOne.Posts[1].ID)
+	}
+
+	pageTwo, err := service.ListSectionSavedPodcastPosts(context.Background(), podcastSectionID, userID, pageOne.NextCursor, 2)
+	if err != nil {
+		t.Fatalf("ListSectionSavedPodcastPosts page 2 failed: %v", err)
+	}
+	if len(pageTwo.Posts) != 1 {
+		t.Fatalf("expected 1 post in page 2, got %d", len(pageTwo.Posts))
+	}
+	if pageTwo.HasMore {
+		t.Fatal("expected page 2 has_more false")
+	}
+	if pageTwo.NextCursor != nil {
+		t.Fatalf("expected nil next cursor on final page, got %v", *pageTwo.NextCursor)
+	}
+	if pageTwo.Posts[0].ID != postA {
+		t.Fatalf("expected oldest post on page 2 (%s), got %s", postA, pageTwo.Posts[0].ID)
+	}
+
+	_, err = service.ListSectionSavedPodcastPosts(context.Background(), recipeSectionID, userID, nil, 2)
+	if err == nil {
+		t.Fatal("expected non-podcast section listing to fail")
+	}
+	if !strings.Contains(err.Error(), "section is not podcast") {
+		t.Fatalf("expected non-podcast section error, got %v", err)
+	}
+}
+
+func assertPodcastSaveCounts(t *testing.T, db *sql.DB, userID, postID uuid.UUID, expectedActive, expectedTotal int) {
+	t.Helper()
+
+	var activeCount int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM podcast_saves
+		WHERE user_id = $1 AND post_id = $2 AND deleted_at IS NULL
+	`, userID, postID).Scan(&activeCount); err != nil {
+		t.Fatalf("failed to query active podcast save count: %v", err)
+	}
+	if activeCount != expectedActive {
+		t.Fatalf("expected %d active podcast saves, got %d", expectedActive, activeCount)
+	}
+
+	var totalCount int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM podcast_saves
+		WHERE user_id = $1 AND post_id = $2
+	`, userID, postID).Scan(&totalCount); err != nil {
+		t.Fatalf("failed to query total podcast save count: %v", err)
+	}
+	if totalCount != expectedTotal {
+		t.Fatalf("expected %d total podcast save rows, got %d", expectedTotal, totalCount)
+	}
+}
+
+func assertPodcastAuditCount(t *testing.T, db *sql.DB, action string, userID uuid.UUID, expected int) {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM audit_logs
+		WHERE action = $1 AND target_user_id = $2
+	`, action, userID).Scan(&count); err != nil {
+		t.Fatalf("failed to query %s audit count: %v", action, err)
+	}
+	if count != expected {
+		t.Fatalf("expected %d %s audit rows, got %d", expected, action, count)
+	}
+}
+
+func mustQueryPodcastAuditMetadata(t *testing.T, db *sql.DB, action string, userID uuid.UUID) map[string]interface{} {
+	t.Helper()
+
+	var metadataRaw []byte
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT metadata
+		FROM audit_logs
+		WHERE action = $1 AND target_user_id = $2
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, action, userID).Scan(&metadataRaw); err != nil {
+		t.Fatalf("failed to query %s audit metadata: %v", action, err)
+	}
+
+	metadata := map[string]interface{}{}
+	if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal %s audit metadata: %v", action, err)
+	}
+	return metadata
+}


### PR DESCRIPTION
## Summary
- add `PodcastSaveService` with podcast-only section/post guards, save/unsave operations, per-post save info, and section-scoped viewer saved listing
- implement idempotent save/unsave semantics with soft-delete/restore behavior for podcast saves
- add audit log writes for state changes (`save_podcast`, `unsave_podcast`) with `post_id` metadata
- add cursor parsing/building for deterministic section-saved pagination
- add `models.PodcastSave` and `models.PostPodcastSaveInfo`
- add service tests for idempotency, guard failures, aggregate/viewer save info, section pagination, and audit assertions

## Testing
- `cd backend && go build ./...`
- `cd backend && go test ./internal/services -run 'TestPodcastSave|TestGetPostPodcastSaveInfoIncludesViewerAndAggregate|TestListSectionSavedPodcastPostsPaginatesAndGuardsSectionType' -v`

Note: DB-backed integration tests are skipped locally when `CLUBHOUSE_TEST_DATABASE_URL` is not set.

Closes #892