### PR TITLE
[Podcasts] Extend frontend API/post mapper for podcast metadata and detection errors

### DIFF
--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -283,6 +283,81 @@ describe('mapApiPost', () => {
     expect(movie?.metacriticScore).toBe(73);
   });
 
+  it('maps podcast metadata from link podcast payload', () => {
+    const post = mapApiPost({
+      id: 'post-podcast-metadata',
+      user_id: 'user-podcast-metadata',
+      section_id: 'section-podcast',
+      content: 'Podcast metadata',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-podcast',
+          url: 'https://podcasts.apple.com/us/podcast/example/id123456789',
+          metadata: {
+            title: 'Example Show',
+          },
+          podcast: {
+            kind: 'show',
+            highlight_episodes: [
+              {
+                title: 'Episode 1',
+                url: 'https://example.com/episode-1',
+                note: 'Start here',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const podcast = post.links?.[0].metadata?.podcast;
+    expect(podcast?.kind).toBe('show');
+    expect(podcast?.highlightEpisodes).toEqual([
+      {
+        title: 'Episode 1',
+        url: 'https://example.com/episode-1',
+        note: 'Start here',
+      },
+    ]);
+    expect(post.links?.[0].metadata?.title).toBe('Example Show');
+  });
+
+  it('maps podcast metadata from nested metadata payload', () => {
+    const post = mapApiPost({
+      id: 'post-podcast-nested-metadata',
+      user_id: 'user-podcast-nested',
+      section_id: 'section-podcast',
+      content: 'Podcast metadata nested',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-podcast-nested',
+          url: 'https://open.spotify.com/show/abc123',
+          metadata: {
+            podcast: {
+              kind: 'episode',
+              highlightEpisodes: [
+                {
+                  title: 'Episode 2',
+                  url: 'https://example.com/episode-2',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    const podcast = post.links?.[0].metadata?.podcast;
+    expect(podcast?.kind).toBe('episode');
+    expect(podcast?.highlightEpisodes).toEqual([
+      {
+        title: 'Episode 2',
+        url: 'https://example.com/episode-2',
+      },
+    ]);
+  });
+
   it('handles missing user and links gracefully', () => {
     const post = mapApiPost({
       id: 'post-2',

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -28,6 +28,7 @@ export interface LinkMetadata {
   type?: string;
   recipe?: RecipeMetadata;
   movie?: MovieMetadata;
+  podcast?: PodcastMetadata;
 }
 
 export interface EmbedData {
@@ -93,6 +94,23 @@ export interface MovieMetadata {
   seasons?: MovieSeason[];
 }
 
+export interface PodcastHighlightEpisode {
+  title: string;
+  url: string;
+  note?: string;
+}
+
+export interface PodcastMetadata {
+  kind?: 'show' | 'episode';
+  highlightEpisodes?: PodcastHighlightEpisode[];
+}
+
+export interface PodcastMetadataInput {
+  kind?: string;
+  highlightEpisodes?: PodcastHighlightEpisode[];
+  highlight_episodes?: PodcastHighlightEpisode[];
+}
+
 export interface PostImage {
   id: string;
   url: string;
@@ -156,7 +174,7 @@ export interface Post {
 export interface CreatePostRequest {
   sectionId: string;
   content: string;
-  links?: { url: string; highlights?: Highlight[] }[];
+  links?: { url: string; highlights?: Highlight[]; podcast?: PodcastMetadataInput }[];
   images?: { url: string; caption?: string; altText?: string }[];
   mentionUsernames?: string[];
 }


### PR DESCRIPTION
## Summary
- add podcast metadata frontend types and include `podcast` in link metadata mapping
- normalize podcast metadata in `postMapper` from both backend response shapes (`link.podcast` and nested `metadata.podcast`)
- extend API create/update link payload typing to include podcast metadata and serialize to backend-compatible `highlight_episodes`
- add explicit API error shaping for `PODCAST_KIND_SELECTION_REQUIRED` with a frontend-friendly message and typed flag
- add unit tests for API payload/error handling and post mapper podcast normalization

## Testing
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/services/__tests__/api.test.ts src/stores/__tests__/postMapper.test.ts`
- `cd frontend && npx eslint src/services/api.ts src/stores/postMapper.ts src/stores/postStore.ts src/services/__tests__/api.test.ts src/stores/__tests__/postMapper.test.ts`

Closes #896