### PR TITLE
[Podcasts] Add podcast save handlers and register routes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -184,6 +184,7 @@ func main() {
 	pushHandler := handlers.NewPushHandler(dbConn, pushService)
 	uploadHandler := handlers.NewUploadHandler()
 	savedRecipeHandler := handlers.NewSavedRecipeHandler(dbConn, redisConn)
+	podcastSaveHandler := handlers.NewPodcastSaveHandler(dbConn)
 	watchlistHandler := handlers.NewWatchlistHandler(dbConn, redisConn)
 	requireAuth := middleware.RequireAuth(redisConn, dbConn)
 	requireCSRF := middleware.RequireCSRF(redisConn)
@@ -211,6 +212,7 @@ func main() {
 		getFeed:           postHandler.GetFeed,
 		getLinks:          sectionHandler.GetSectionLinks,
 		getRecentPodcasts: sectionHandler.GetRecentPodcasts,
+		getPodcastSaved:   podcastSaveHandler.ListSectionSavedPodcastPosts,
 	})
 	mux.Handle("/api/v1/sections/", sectionRouteHandler)
 
@@ -330,6 +332,9 @@ func main() {
 		saveRecipe:              savedRecipeHandler.SaveRecipe,
 		unsaveRecipe:            savedRecipeHandler.UnsaveRecipe,
 		getPostSaves:            savedRecipeHandler.GetPostSaves,
+		savePodcast:             podcastSaveHandler.SavePodcast,
+		unsavePodcast:           podcastSaveHandler.UnsavePodcast,
+		getPostPodcastSaveInfo:  podcastSaveHandler.GetPostPodcastSaveInfo,
 		addToWatchlist:          watchlistHandler.AddToWatchlist,
 		removeFromWatchlist:     watchlistHandler.RemoveFromWatchlist,
 		getPostWatchlistInfo:    watchlistHandler.GetPostWatchlistInfo,

--- a/backend/cmd/server/routes.go
+++ b/backend/cmd/server/routes.go
@@ -23,6 +23,9 @@ type postRouteDeps struct {
 	saveRecipe              http.HandlerFunc
 	unsaveRecipe            http.HandlerFunc
 	getPostSaves            http.HandlerFunc
+	savePodcast             http.HandlerFunc
+	unsavePodcast           http.HandlerFunc
+	getPostPodcastSaveInfo  http.HandlerFunc
 	addToWatchlist          http.HandlerFunc
 	removeFromWatchlist     http.HandlerFunc
 	getPostWatchlistInfo    http.HandlerFunc
@@ -100,6 +103,21 @@ func newPostRouteHandler(requireAuth authMiddleware, requireAuthCSRF authMiddlew
 		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/saves") {
 			// GET /api/v1/posts/{id}/saves
 			requireAuth(http.HandlerFunc(deps.getPostSaves)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcast-save") {
+			// POST /api/v1/posts/{id}/podcast-save
+			requireAuthCSRF(http.HandlerFunc(deps.savePodcast)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodDelete && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcast-save") {
+			// DELETE /api/v1/posts/{id}/podcast-save
+			requireAuthCSRF(http.HandlerFunc(deps.unsavePodcast)).ServeHTTP(w, r)
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcast-save-info") {
+			// GET /api/v1/posts/{id}/podcast-save-info
+			requireAuth(http.HandlerFunc(deps.getPostPodcastSaveInfo)).ServeHTTP(w, r)
 			return
 		}
 		if r.Method == http.MethodPost && strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/watchlist") {
@@ -222,6 +240,7 @@ type sectionRouteDeps struct {
 	getFeed           http.HandlerFunc
 	getLinks          http.HandlerFunc
 	getRecentPodcasts http.HandlerFunc
+	getPodcastSaved   http.HandlerFunc
 }
 
 type bookshelfRouteDeps struct {
@@ -241,6 +260,10 @@ type bookQuoteRouteDeps struct {
 
 func newSectionRouteHandler(requireAuth authMiddleware, deps sectionRouteDeps) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcast-saved") {
+			requireAuth(http.HandlerFunc(deps.getPodcastSaved)).ServeHTTP(w, r)
+			return
+		}
 		if strings.HasSuffix(strings.TrimSuffix(r.URL.Path, "/"), "/podcasts/recent") {
 			requireAuth(http.HandlerFunc(deps.getRecentPodcasts)).ServeHTTP(w, r)
 			return

--- a/backend/internal/handlers/podcast_save.go
+++ b/backend/internal/handlers/podcast_save.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/middleware"
+	"github.com/sanderginn/clubhouse/internal/observability"
+	"github.com/sanderginn/clubhouse/internal/services"
+)
+
+const (
+	defaultPodcastSavedListLimit = 20
+	maxPodcastSavedListLimit     = 100
+)
+
+// PodcastSaveHandler handles podcast save-for-later endpoints.
+type PodcastSaveHandler struct {
+	podcastSaveService *services.PodcastSaveService
+}
+
+// NewPodcastSaveHandler creates a new podcast save handler.
+func NewPodcastSaveHandler(db *sql.DB) *PodcastSaveHandler {
+	return &PodcastSaveHandler{
+		podcastSaveService: services.NewPodcastSaveService(db),
+	}
+}
+
+// SavePodcast handles POST /api/v1/posts/{postID}/podcast-save.
+func (h *PodcastSaveHandler) SavePodcast(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	save, err := h.podcastSaveService.SavePodcast(r.Context(), userID, postID)
+	if err != nil {
+		switch err.Error() {
+		case "podcast post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "SAVE_PODCAST_FAILED", "Failed to save podcast")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "podcast saved",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(save); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode save podcast response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// UnsavePodcast handles DELETE /api/v1/posts/{postID}/podcast-save.
+func (h *PodcastSaveHandler) UnsavePodcast(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only DELETE requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	if err := h.podcastSaveService.UnsavePodcast(r.Context(), userID, postID); err != nil {
+		switch err.Error() {
+		case "podcast post not found":
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "UNSAVE_PODCAST_FAILED", "Failed to unsave podcast")
+		}
+		return
+	}
+
+	observability.LogInfo(r.Context(), "podcast unsaved",
+		"user_id", userID.String(),
+		"post_id", postID.String(),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPostPodcastSaveInfo handles GET /api/v1/posts/{postID}/podcast-save-info.
+func (h *PodcastSaveHandler) GetPostPodcastSaveInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	postID, err := extractPostIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_POST_ID", "Invalid post ID format")
+		return
+	}
+
+	info, err := h.podcastSaveService.GetPostPodcastSaveInfo(r.Context(), postID, &userID)
+	if err != nil {
+		if err.Error() == "podcast post not found" {
+			writeError(r.Context(), w, http.StatusNotFound, "POST_NOT_FOUND", "Post not found")
+			return
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, "GET_PODCAST_SAVE_INFO_FAILED", "Failed to get podcast save info")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode post podcast save info response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+// ListSectionSavedPodcastPosts handles GET /api/v1/sections/{sectionID}/podcast-saved.
+func (h *PodcastSaveHandler) ListSectionSavedPodcastPosts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(r.Context(), w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only GET requests are allowed")
+		return
+	}
+
+	userID, err := middleware.GetUserIDFromContext(r.Context())
+	if err != nil {
+		writeError(r.Context(), w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing or invalid user ID")
+		return
+	}
+
+	sectionID, err := extractSectionIDFromPath(r.URL.Path)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_SECTION_ID", "Invalid section ID format")
+		return
+	}
+
+	cursor, limit, err := parsePodcastSavedListQuery(r)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, "INVALID_LIMIT", err.Error())
+		return
+	}
+
+	feed, err := h.podcastSaveService.ListSectionSavedPodcastPosts(r.Context(), sectionID, userID, cursor, limit)
+	if err != nil {
+		switch err.Error() {
+		case "section not found":
+			writeError(r.Context(), w, http.StatusNotFound, "SECTION_NOT_FOUND", "Section not found")
+		case "section is not podcast":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_SECTION_TYPE", "Section must be a podcast section")
+		case "invalid cursor":
+			writeError(r.Context(), w, http.StatusBadRequest, "INVALID_CURSOR", "Invalid cursor format")
+		default:
+			writeError(r.Context(), w, http.StatusInternalServerError, "GET_PODCAST_SAVED_FAILED", "Failed to get saved podcasts")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(feed); err != nil {
+		observability.LogError(r.Context(), observability.ErrorLog{
+			Message:    "failed to encode section saved podcast response",
+			Code:       "ENCODE_FAILED",
+			StatusCode: http.StatusOK,
+			Err:        err,
+		})
+	}
+}
+
+func parsePodcastSavedListQuery(r *http.Request) (*string, int, error) {
+	limit := defaultPodcastSavedListLimit
+	if rawLimit := strings.TrimSpace(r.URL.Query().Get("limit")); rawLimit != "" {
+		parsed, err := strconv.Atoi(rawLimit)
+		if err != nil || parsed <= 0 {
+			return nil, 0, errors.New("limit must be a positive integer")
+		}
+		limit = parsed
+	}
+	if limit > maxPodcastSavedListLimit {
+		limit = maxPodcastSavedListLimit
+	}
+
+	var cursor *string
+	if cursorParam := strings.TrimSpace(r.URL.Query().Get("cursor")); cursorParam != "" {
+		cursor = &cursorParam
+	}
+
+	return cursor, limit, nil
+}
+
+func extractSectionIDFromPath(path string) (uuid.UUID, error) {
+	pathParts := strings.Split(path, "/")
+	for i, part := range pathParts {
+		if part == "sections" && i+1 < len(pathParts) {
+			return uuid.Parse(pathParts[i+1])
+		}
+	}
+	return uuid.Nil, errors.New("section ID not found in path")
+}

--- a/backend/internal/handlers/podcast_save_test.go
+++ b/backend/internal/handlers/podcast_save_test.go
@@ -1,0 +1,358 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestSavePodcastHandlerSuccess(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "savepodcasthandler", "savepodcasthandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Podcast post")
+
+	handler := NewPodcastSaveHandler(db)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+postID+"/podcast-save", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "savepodcasthandler", false))
+	rr := httptest.NewRecorder()
+
+	handler.SavePodcast(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.PodcastSave
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.PostID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, response.PostID.String())
+	}
+	if response.UserID.String() != userID {
+		t.Fatalf("expected user_id %s, got %s", userID, response.UserID.String())
+	}
+}
+
+func TestUnsavePodcastHandlerNoContent(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "unsavepodcasthandler", "unsavepodcasthandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Podcast post")
+
+	service := services.NewPodcastSaveService(db)
+	if _, err := service.SavePodcast(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("SavePodcast failed: %v", err)
+	}
+
+	handler := NewPodcastSaveHandler(db)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/posts/"+postID+"/podcast-save", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "unsavepodcasthandler", false))
+	rr := httptest.NewRecorder()
+
+	handler.UnsavePodcast(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGetPostPodcastSaveInfoHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userA := testutil.CreateTestUser(t, db, "podcastsaveinfoa", "podcastsaveinfoa@test.com", false, true)
+	userB := testutil.CreateTestUser(t, db, "podcastsaveinfob", "podcastsaveinfob@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := testutil.CreateTestPost(t, db, userA, sectionID, "Podcast post")
+
+	service := services.NewPodcastSaveService(db)
+	if _, err := service.SavePodcast(reqContext(), uuid.MustParse(userA), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("SavePodcast userA failed: %v", err)
+	}
+	if _, err := service.SavePodcast(reqContext(), uuid.MustParse(userB), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("SavePodcast userB failed: %v", err)
+	}
+
+	handler := NewPodcastSaveHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+postID+"/podcast-save-info", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userA), "podcastsaveinfoa", false))
+	rr := httptest.NewRecorder()
+
+	handler.GetPostPodcastSaveInfo(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.PostPodcastSaveInfo
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.SaveCount != 2 {
+		t.Fatalf("expected save_count 2, got %d", response.SaveCount)
+	}
+	if !response.ViewerSaved {
+		t.Fatalf("expected viewer_saved true")
+	}
+}
+
+func TestListSectionSavedPodcastPostsHandler(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "listsavedpodcasthandler", "listsavedpodcasthandler@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	postID := testutil.CreateTestPost(t, db, userID, sectionID, "Podcast post")
+
+	service := services.NewPodcastSaveService(db)
+	if _, err := service.SavePodcast(reqContext(), uuid.MustParse(userID), uuid.MustParse(postID)); err != nil {
+		t.Fatalf("SavePodcast failed: %v", err)
+	}
+
+	handler := NewPodcastSaveHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sections/"+sectionID+"/podcast-saved", nil)
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "listsavedpodcasthandler", false))
+	rr := httptest.NewRecorder()
+
+	handler.ListSectionSavedPodcastPosts(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+
+	var response models.FeedResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(response.Posts))
+	}
+	if response.Posts[0].ID.String() != postID {
+		t.Fatalf("expected post_id %s, got %s", postID, response.Posts[0].ID.String())
+	}
+}
+
+func TestPodcastSaveHandlersRequireAuth(t *testing.T) {
+	handler := &PodcastSaveHandler{}
+	postID := uuid.New().String()
+	sectionID := uuid.New().String()
+
+	tests := []struct {
+		name     string
+		fn       func(http.ResponseWriter, *http.Request)
+		method   string
+		path     string
+		wantCode int
+	}{
+		{
+			name:     "save podcast",
+			fn:       handler.SavePodcast,
+			method:   http.MethodPost,
+			path:     "/api/v1/posts/" + postID + "/podcast-save",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "unsave podcast",
+			fn:       handler.UnsavePodcast,
+			method:   http.MethodDelete,
+			path:     "/api/v1/posts/" + postID + "/podcast-save",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "get post podcast save info",
+			fn:       handler.GetPostPodcastSaveInfo,
+			method:   http.MethodGet,
+			path:     "/api/v1/posts/" + postID + "/podcast-save-info",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "list section saved podcasts",
+			fn:       handler.ListSectionSavedPodcastPosts,
+			method:   http.MethodGet,
+			path:     "/api/v1/sections/" + sectionID + "/podcast-saved",
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rr := httptest.NewRecorder()
+
+			tc.fn(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("expected status %d, got %d. Body: %s", tc.wantCode, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestPodcastSaveHandlersMethodValidation(t *testing.T) {
+	handler := &PodcastSaveHandler{}
+	postID := uuid.New().String()
+	sectionID := uuid.New().String()
+
+	tests := []struct {
+		name   string
+		fn     func(http.ResponseWriter, *http.Request)
+		method string
+		path   string
+	}{
+		{
+			name:   "save podcast",
+			fn:     handler.SavePodcast,
+			method: http.MethodGet,
+			path:   "/api/v1/posts/" + postID + "/podcast-save",
+		},
+		{
+			name:   "unsave podcast",
+			fn:     handler.UnsavePodcast,
+			method: http.MethodPost,
+			path:   "/api/v1/posts/" + postID + "/podcast-save",
+		},
+		{
+			name:   "get post podcast save info",
+			fn:     handler.GetPostPodcastSaveInfo,
+			method: http.MethodPost,
+			path:   "/api/v1/posts/" + postID + "/podcast-save-info",
+		},
+		{
+			name:   "list section saved podcasts",
+			fn:     handler.ListSectionSavedPodcastPosts,
+			method: http.MethodPost,
+			path:   "/api/v1/sections/" + sectionID + "/podcast-saved",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rr := httptest.NewRecorder()
+
+			tc.fn(rr, req)
+
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected status 405, got %d. Body: %s", rr.Code, rr.Body.String())
+			}
+
+			var response models.ErrorResponse
+			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if response.Code != "METHOD_NOT_ALLOWED" {
+				t.Fatalf("expected METHOD_NOT_ALLOWED, got %s", response.Code)
+			}
+		})
+	}
+}
+
+func TestPodcastSaveValidationErrors(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+
+	userID := testutil.CreateTestUser(t, db, "podcastsavevalidation", "podcastsavevalidation@test.com", false, true)
+	recipeSectionID := testutil.CreateTestSection(t, db, "Recipes", "recipe")
+	recipePostID := testutil.CreateTestPost(t, db, userID, recipeSectionID, "Recipe post")
+	podcastSectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+
+	handler := NewPodcastSaveHandler(db)
+	ctx := createTestUserContext(reqContext(), uuid.MustParse(userID), "podcastsavevalidation", false)
+
+	invalidPostReq := httptest.NewRequest(http.MethodPost, "/api/v1/posts/not-a-uuid/podcast-save", nil)
+	invalidPostReq = invalidPostReq.WithContext(ctx)
+	invalidPostRR := httptest.NewRecorder()
+	handler.SavePodcast(invalidPostRR, invalidPostReq)
+
+	if invalidPostRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid post id status 400, got %d. Body: %s", invalidPostRR.Code, invalidPostRR.Body.String())
+	}
+
+	var invalidPostResp models.ErrorResponse
+	if err := json.NewDecoder(invalidPostRR.Body).Decode(&invalidPostResp); err != nil {
+		t.Fatalf("failed to decode invalid post id response: %v", err)
+	}
+	if invalidPostResp.Code != "INVALID_POST_ID" {
+		t.Fatalf("expected INVALID_POST_ID, got %s", invalidPostResp.Code)
+	}
+
+	nonPodcastReq := httptest.NewRequest(http.MethodPost, "/api/v1/posts/"+recipePostID+"/podcast-save", nil)
+	nonPodcastReq = nonPodcastReq.WithContext(ctx)
+	nonPodcastRR := httptest.NewRecorder()
+	handler.SavePodcast(nonPodcastRR, nonPodcastReq)
+
+	if nonPodcastRR.Code != http.StatusNotFound {
+		t.Fatalf("expected non-podcast status 404, got %d. Body: %s", nonPodcastRR.Code, nonPodcastRR.Body.String())
+	}
+
+	var nonPodcastResp models.ErrorResponse
+	if err := json.NewDecoder(nonPodcastRR.Body).Decode(&nonPodcastResp); err != nil {
+		t.Fatalf("failed to decode non-podcast response: %v", err)
+	}
+	if nonPodcastResp.Code != "POST_NOT_FOUND" {
+		t.Fatalf("expected POST_NOT_FOUND, got %s", nonPodcastResp.Code)
+	}
+
+	invalidSectionReq := httptest.NewRequest(http.MethodGet, "/api/v1/sections/not-a-uuid/podcast-saved", nil)
+	invalidSectionReq = invalidSectionReq.WithContext(ctx)
+	invalidSectionRR := httptest.NewRecorder()
+	handler.ListSectionSavedPodcastPosts(invalidSectionRR, invalidSectionReq)
+
+	if invalidSectionRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid section id status 400, got %d. Body: %s", invalidSectionRR.Code, invalidSectionRR.Body.String())
+	}
+
+	var invalidSectionResp models.ErrorResponse
+	if err := json.NewDecoder(invalidSectionRR.Body).Decode(&invalidSectionResp); err != nil {
+		t.Fatalf("failed to decode invalid section id response: %v", err)
+	}
+	if invalidSectionResp.Code != "INVALID_SECTION_ID" {
+		t.Fatalf("expected INVALID_SECTION_ID, got %s", invalidSectionResp.Code)
+	}
+
+	nonPodcastSectionReq := httptest.NewRequest(http.MethodGet, "/api/v1/sections/"+recipeSectionID+"/podcast-saved", nil)
+	nonPodcastSectionReq = nonPodcastSectionReq.WithContext(ctx)
+	nonPodcastSectionRR := httptest.NewRecorder()
+	handler.ListSectionSavedPodcastPosts(nonPodcastSectionRR, nonPodcastSectionReq)
+
+	if nonPodcastSectionRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected non-podcast section status 400, got %d. Body: %s", nonPodcastSectionRR.Code, nonPodcastSectionRR.Body.String())
+	}
+
+	var nonPodcastSectionResp models.ErrorResponse
+	if err := json.NewDecoder(nonPodcastSectionRR.Body).Decode(&nonPodcastSectionResp); err != nil {
+		t.Fatalf("failed to decode non-podcast section response: %v", err)
+	}
+	if nonPodcastSectionResp.Code != "INVALID_SECTION_TYPE" {
+		t.Fatalf("expected INVALID_SECTION_TYPE, got %s", nonPodcastSectionResp.Code)
+	}
+
+	badCursorReq := httptest.NewRequest(http.MethodGet, "/api/v1/sections/"+podcastSectionID+"/podcast-saved?cursor=bad-cursor", nil)
+	badCursorReq = badCursorReq.WithContext(ctx)
+	badCursorRR := httptest.NewRecorder()
+	handler.ListSectionSavedPodcastPosts(badCursorRR, badCursorReq)
+
+	if badCursorRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid cursor status 400, got %d. Body: %s", badCursorRR.Code, badCursorRR.Body.String())
+	}
+
+	var badCursorResp models.ErrorResponse
+	if err := json.NewDecoder(badCursorRR.Body).Decode(&badCursorResp); err != nil {
+		t.Fatalf("failed to decode invalid cursor response: %v", err)
+	}
+	if badCursorResp.Code != "INVALID_CURSOR" {
+		t.Fatalf("expected INVALID_CURSOR, got %s", badCursorResp.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add `PodcastSaveHandler` with endpoints for save, unsave, post save info, and section saved podcasts
- wire new post and section podcast save routes through `newPostRouteHandler` and `newSectionRouteHandler`
- register `PodcastSaveHandler` in server bootstrap and connect dependencies in `main.go`
- add handler tests for auth/method checks, invalid IDs, and service/domain error mappings
- add route tests to verify auth/CSRF behavior for all new podcast save endpoints

## Testing
- `cd backend && go test ./internal/handlers -run 'PodcastSave|Watchlist|Section' -count=1`
- `cd backend && go test ./cmd/server -run 'PostRouteHandler.*Podcast|SectionRouteHandler.*Podcast|SectionRouteHandlerRecentPodcastsRequiresAuth' -count=1`
- `cd backend && go test ./internal/handlers ./cmd/server -count=1`
- `cd backend && go test ./... -count=1`

Closes #893