### PR TITLE
[Movies] Make TMDB link more prominent in MovieCard

### DIFF
--- a/frontend/src/components/__tests__/MovieCard.test.ts
+++ b/frontend/src/components/__tests__/MovieCard.test.ts
@@ -106,10 +106,16 @@ describe('MovieCard', () => {
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('Drama');
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('Adventure');
     expect(screen.getByTestId('movie-genres')).toHaveTextContent('+1');
-    expect(screen.getByTestId('movie-tmdb-link')).toHaveAttribute(
-      'href',
-      'https://www.themoviedb.org/movie/157336'
+    const tmdbLink = screen.getByTestId('movie-tmdb-link');
+    expect(tmdbLink).toHaveAttribute('href', 'https://www.themoviedb.org/movie/157336');
+    expect(tmdbLink).toHaveClass(
+      'rounded-md',
+      'border',
+      'bg-slate-50',
+      'text-sm',
+      'focus-visible:outline'
     );
+    expect(screen.getByRole('link', { name: /view interstellar on tmdb/i })).toBe(tmdbLink);
     expect(screen.queryByTestId('movie-expanded-content')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/movies/MovieCard.svelte
+++ b/frontend/src/components/movies/MovieCard.svelte
@@ -567,10 +567,17 @@
               href={tmdbUrl}
               target="_blank"
               rel="noopener noreferrer"
-              class="mt-1 inline-flex text-xs font-medium text-slate-500 underline-offset-2 hover:text-slate-700 hover:underline"
+              class="mt-2 inline-flex items-center gap-2 rounded-md border border-slate-300 bg-slate-50 px-2.5 py-1.5 text-sm font-semibold text-slate-800 transition-colors hover:border-slate-400 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
+              aria-label={`View ${title} on TMDB (opens in a new tab)`}
               data-testid="movie-tmdb-link"
             >
-              View on TMDB
+              <span
+                class="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-sky-800"
+                aria-hidden="true"
+              >
+                TMDB
+              </span>
+              <span>View on TMDB</span>
             </a>
           {/if}
         </div>


### PR DESCRIPTION
## Summary
- update the MovieCard TMDB link to a more prominent button-style call-to-action
- add stronger hover and focus-visible states for mouse and keyboard users
- include an explicit accessible link label indicating it opens in a new tab
- update MovieCard tests to assert CTA prominence classes and accessible link name

## Validation
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/MovieCard.test.ts`
- `cd frontend && npm run lint && npm run check && npm run test`

Closes #950