### PR TITLE
[Books] Create QuoteList and integrate into book thread

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -25,6 +25,7 @@
   import RecipeStatsBar from './recipes/RecipeStatsBar.svelte';
   import BookCard from './books/BookCard.svelte';
   import BookStatsBar from './books/BookStatsBar.svelte';
+  import QuoteList from './books/QuoteList.svelte';
   import MovieCard from './movies/MovieCard.svelte';
   import MovieStatsBar from './movies/MovieStatsBar.svelte';
   import BandcampEmbed from '../lib/components/embeds/BandcampEmbed.svelte';
@@ -2164,6 +2165,11 @@
       {#if isBookSection && bookStatsForBar}
         <div class="mt-3">
           <BookStatsBar postId={post.id} bookStats={bookStatsForBar} />
+        </div>
+      {/if}
+      {#if isBookSection && isThreadView}
+        <div class="mt-3">
+          <QuoteList postId={post.id} currentUserId={$currentUser?.id ?? ''} isAdmin={$isAdmin} />
         </div>
       {/if}
       {#if isMovieSection && movieStatsForBar}

--- a/frontend/src/components/books/QuoteList.svelte
+++ b/frontend/src/components/books/QuoteList.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { get } from 'svelte/store';
+  import type { BookQuoteWithUser } from '../../services/api';
+  import { bookQuoteStore } from '../../stores/bookQuoteStore';
+  import QuoteCard from './QuoteCard.svelte';
+  import QuoteForm from './QuoteForm.svelte';
+
+  type QuoteFormSubmitPayload = {
+    postId: string;
+    quoteText: string;
+    pageNumber?: number;
+    chapter?: string;
+    note?: string;
+    quoteId?: string;
+  };
+
+  const PAGE_SIZE = 20;
+
+  export let postId: string;
+  export let currentUserId = '';
+  export let isAdmin = false;
+
+  let isExpanded = true;
+  let isAddFormOpen = false;
+  let lastLoadedPostID: string | null = null;
+  let hasLoadedInitialPage = false;
+
+  $: quoteState = $bookQuoteStore;
+  $: quotes = quoteState.quotes[postId] ?? [];
+  $: cursor = quoteState.cursors[postId] ?? null;
+  $: hasMore = quoteState.hasMore[postId] ?? false;
+  $: isLoading = quoteState.isLoading[postId] ?? false;
+  $: error = quoteState.errors[postId] ?? null;
+  $: sortedQuotes = sortQuotesByNewest(quotes);
+
+  $: if (postId && lastLoadedPostID !== postId) {
+    lastLoadedPostID = postId;
+    isAddFormOpen = false;
+    void loadInitialQuotes(postId);
+  }
+
+  function sortQuotesByNewest(items: BookQuoteWithUser[]): BookQuoteWithUser[] {
+    return [...items].sort((a, b) => {
+      const left = Date.parse(a.createdAt);
+      const right = Date.parse(b.createdAt);
+      const normalizedLeft = Number.isFinite(left) ? left : 0;
+      const normalizedRight = Number.isFinite(right) ? right : 0;
+      return normalizedRight - normalizedLeft;
+    });
+  }
+
+  async function loadInitialQuotes(targetPostID: string) {
+    hasLoadedInitialPage = false;
+    await bookQuoteStore.loadQuotesForPost(targetPostID, undefined, PAGE_SIZE);
+    if (lastLoadedPostID === targetPostID) {
+      hasLoadedInitialPage = true;
+    }
+  }
+
+  async function loadMoreQuotes() {
+    if (!hasMore || isLoading || !cursor) {
+      return;
+    }
+    await bookQuoteStore.loadQuotesForPost(postId, cursor, PAGE_SIZE);
+  }
+
+  async function handleAddQuote(payload: QuoteFormSubmitPayload) {
+    await bookQuoteStore.addQuote(postId, {
+      quoteText: payload.quoteText,
+      pageNumber: payload.pageNumber,
+      chapter: payload.chapter,
+      note: payload.note,
+    });
+
+    const latestState = get(bookQuoteStore);
+    const postError = latestState.errors[postId];
+    if (postError) {
+      throw new Error(postError);
+    }
+
+    isAddFormOpen = false;
+  }
+
+  function toggleExpanded() {
+    isExpanded = !isExpanded;
+  }
+</script>
+
+<section class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm" data-testid="quote-list">
+  <div class="flex items-center justify-between gap-3">
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 text-left text-sm font-semibold text-gray-900"
+      aria-expanded={isExpanded}
+      on:click={toggleExpanded}
+      data-testid="quote-list-toggle"
+    >
+      <span>Quotes</span>
+      <span
+        class="inline-flex min-w-6 items-center justify-center rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-semibold text-gray-700"
+        data-testid="quote-count-badge"
+      >
+        {sortedQuotes.length}
+      </span>
+      <span class="text-xs text-gray-500">{isExpanded ? '▾' : '▸'}</span>
+    </button>
+
+    {#if isExpanded}
+      <button
+        type="button"
+        class="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100"
+        on:click={() => {
+          isAddFormOpen = !isAddFormOpen;
+        }}
+        data-testid="quote-add-button"
+      >
+        {isAddFormOpen ? 'Close' : 'Add Quote'}
+      </button>
+    {/if}
+  </div>
+
+  {#if isExpanded}
+    <div class="mt-3 space-y-3">
+      {#if isAddFormOpen}
+        <QuoteForm postId={postId} onSubmit={handleAddQuote} onCancel={() => (isAddFormOpen = false)} />
+      {/if}
+
+      {#if error}
+        <p class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" data-testid="quote-list-error">
+          {error}
+        </p>
+      {/if}
+
+      {#if isLoading && !hasLoadedInitialPage}
+        <p class="text-sm text-gray-600">Loading quotes...</p>
+      {:else if hasLoadedInitialPage && sortedQuotes.length === 0}
+        <p class="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-3 py-3 text-sm text-gray-600">
+          No quotes yet. Be the first to share a passage!
+        </p>
+      {:else if sortedQuotes.length > 0}
+        <ul class="space-y-3" data-testid="quote-list-items">
+          {#each sortedQuotes as quote (quote.id)}
+            <li>
+              <QuoteCard {quote} {currentUserId} {isAdmin} />
+            </li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if hasMore}
+        <div class="flex justify-center">
+          <button
+            type="button"
+            class="text-xs font-medium text-gray-600 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+            on:click={loadMoreQuotes}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Loading...' : 'Load more quotes'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</section>

--- a/frontend/src/components/books/QuoteList.test.ts
+++ b/frontend/src/components/books/QuoteList.test.ts
@@ -1,0 +1,158 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiGetPostQuotes = vi.hoisted(() => vi.fn());
+const apiCreateBookQuote = vi.hoisted(() => vi.fn());
+const apiUpdateBookQuote = vi.hoisted(() => vi.fn());
+const apiDeleteBookQuote = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getPostQuotes: apiGetPostQuotes,
+    createBookQuote: apiCreateBookQuote,
+    updateBookQuote: apiUpdateBookQuote,
+    deleteBookQuote: apiDeleteBookQuote,
+  },
+}));
+
+const { bookQuoteStore } = await import('../../stores/bookQuoteStore');
+const { default: QuoteList } = await import('./QuoteList.svelte');
+
+function buildQuote(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'quote-1',
+    postId: 'post-1',
+    userId: 'user-1',
+    quoteText: 'Base quote',
+    pageNumber: 10,
+    chapter: '1',
+    note: 'Note',
+    createdAt: '2026-02-10T10:00:00Z',
+    updatedAt: '2026-02-10T10:00:00Z',
+    username: 'reader',
+    displayName: 'Reader',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  bookQuoteStore.reset();
+  apiGetPostQuotes.mockReset();
+  apiCreateBookQuote.mockReset();
+  apiUpdateBookQuote.mockReset();
+  apiDeleteBookQuote.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('QuoteList', () => {
+  it('renders quotes ordered by newest first', async () => {
+    const olderQuote = buildQuote({
+      id: 'quote-old',
+      quoteText: 'Older quote',
+      createdAt: '2026-02-09T10:00:00Z',
+    });
+    const newerQuote = buildQuote({
+      id: 'quote-new',
+      quoteText: 'Newer quote',
+      createdAt: '2026-02-10T12:00:00Z',
+    });
+    apiGetPostQuotes.mockResolvedValueOnce({
+      quotes: [olderQuote, newerQuote],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    render(QuoteList, {
+      postId: 'post-1',
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    await waitFor(() => {
+      expect(apiGetPostQuotes).toHaveBeenCalledWith('post-1', undefined, 20);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('quote-text')).toHaveLength(2);
+    });
+    const quoteTexts = screen.getAllByTestId('quote-text');
+    expect(quoteTexts[0]).toHaveTextContent('Newer quote');
+    expect(quoteTexts[1]).toHaveTextContent('Older quote');
+  });
+
+  it('opens the add quote form when Add Quote is clicked', async () => {
+    apiGetPostQuotes.mockResolvedValueOnce({
+      quotes: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    render(QuoteList, {
+      postId: 'post-1',
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    await waitFor(() => {
+      expect(apiGetPostQuotes).toHaveBeenCalledWith('post-1', undefined, 20);
+    });
+
+    await fireEvent.click(screen.getByTestId('quote-add-button'));
+    expect(screen.getByTestId('quote-form-text')).toBeInTheDocument();
+  });
+
+  it('shows empty state when a book has no quotes', async () => {
+    apiGetPostQuotes.mockResolvedValueOnce({
+      quotes: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    render(QuoteList, {
+      postId: 'post-1',
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No quotes yet. Be the first to share a passage!')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('loads additional quotes when pagination is available', async () => {
+    apiGetPostQuotes
+      .mockResolvedValueOnce({
+        quotes: [buildQuote({ id: 'quote-1', quoteText: 'First quote' })],
+        nextCursor: 'cursor-1',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        quotes: [buildQuote({ id: 'quote-2', quoteText: 'Second quote' })],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+    render(QuoteList, {
+      postId: 'post-1',
+      currentUserId: 'user-1',
+      isAdmin: false,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Load more quotes' })).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Load more quotes' }));
+
+    await waitFor(() => {
+      expect(apiGetPostQuotes).toHaveBeenNthCalledWith(2, 'post-1', 'cursor-1', 20);
+    });
+
+    expect(screen.getAllByTestId('quote-card')).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/books/index.ts
+++ b/frontend/src/components/books/index.ts
@@ -3,3 +3,4 @@ export { default as BookshelfSaveButton } from './BookshelfSaveButton.svelte';
 export { default as ReadButton } from './ReadButton.svelte';
 export { default as BookStatsBar } from './BookStatsBar.svelte';
 export { default as Bookshelf } from './Bookshelf.svelte';
+export { default as QuoteList } from './QuoteList.svelte';


### PR DESCRIPTION
## Summary
- add a new `QuoteList` books component with:
  - collapsible section (expanded by default)
  - Quotes header and count badge
  - top-level `Add Quote` button that opens inline `QuoteForm`
  - newest-first quote rendering with `QuoteCard`
  - paginated `Load more quotes` support
  - empty and error states
- integrate `QuoteList` into `PostCard` between `BookStatsBar` and comments, gated to book posts in thread view
- add tests for `QuoteList` list rendering/order, add-form toggle, empty state, and pagination
- extend `PostCard` tests to verify quote-list visibility for book thread posts and absence for non-book posts

## Validation
- `cd frontend && npm run test -- src/components/books/QuoteList.test.ts src/components/__tests__/PostCard.test.ts`
- `cd frontend && npm run check`

Closes #882