### PR TITLE
[Podcasts] Add podcast fields to PostForm (kind selector + highlight episodes editor)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -275,7 +275,7 @@ function mapPodcastMetadataRequest(
     : undefined;
 
   if (!kind && !(highlightEpisodes && highlightEpisodes.length > 0)) {
-    return undefined;
+    return {};
   }
 
   return {


### PR DESCRIPTION
## Summary
- add podcast composer controls in `PostForm` for podcast sections with link previews:
  - kind selector (`Auto-detect`, `Show`, `Episode`)
  - show-only highlighted episodes editor (add/remove with title/url/note validation)
- block submission after backend uncertain-kind errors until the user manually selects a kind
- include podcast metadata in create-post payload for podcast links, including explicit empty `{}` metadata when kind is auto-detect so backend kind resolution can run
- extend PostForm podcast component tests for selector behavior, show-only episode editor, uncertain-kind gating, and payload serialization
- add API unit coverage to ensure explicit empty podcast metadata is preserved in `createPost` request mapping

## Testing
- `cd frontend && npm run test -- src/components/posts/__tests__/PostForm.test.ts`
- `cd frontend && npm run test -- src/services/__tests__/api.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run lint`

Closes #897