### PR TITLE
[Podcasts] Add podcast save API client and podcastStore

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -352,6 +352,120 @@ describe('api client', () => {
     expect(url).toContain('section_type=movie');
   });
 
+  it('savePodcast calls podcast-save endpoint and maps fields', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/auth/csrf')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue({ token: 'csrf-token' }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({
+          id: 'podcast-save-1',
+          user_id: 'user-1',
+          post_id: 'post-1',
+          created_at: '2026-02-10T12:00:00Z',
+          deleted_at: null,
+        }),
+      });
+    });
+
+    const response = await api.savePodcast('post-1');
+
+    const call = findCall('/posts/post-1/podcast-save');
+    expect(call?.[1]?.body).toBeUndefined();
+    expect(response).toEqual({
+      id: 'podcast-save-1',
+      userId: 'user-1',
+      postId: 'post-1',
+      createdAt: '2026-02-10T12:00:00Z',
+      deletedAt: undefined,
+    });
+  });
+
+  it('getPostPodcastSaveInfo maps snake_case payload', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        save_count: 2,
+        users: [{ id: 'user-1', username: 'alice', profile_picture_url: '/alice.png' }],
+        viewer_saved: true,
+      }),
+    });
+
+    const response = await api.getPostPodcastSaveInfo('post-1');
+
+    expect(response).toEqual({
+      saveCount: 2,
+      users: [{ id: 'user-1', username: 'alice', displayName: 'alice', avatar: '/alice.png' }],
+      viewerSaved: true,
+    });
+  });
+
+  it('getSectionSavedPodcasts maps posts and cursor pagination', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        posts: [
+          {
+            id: 'post-1',
+            user_id: 'user-1',
+            section_id: 'section-podcast',
+            content: 'Podcast post',
+            created_at: '2026-02-10T10:00:00Z',
+          },
+        ],
+        has_more: true,
+        next_cursor: 'cursor-next',
+      }),
+    });
+
+    const response = await api.getSectionSavedPodcasts('section-podcast', 15, 'cursor-1');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/sections/section-podcast/podcast-saved');
+    expect(url).toContain('limit=15');
+    expect(url).toContain('cursor=cursor-1');
+    expect(response.hasMore).toBe(true);
+    expect(response.nextCursor).toBe('cursor-next');
+    expect(response.posts).toHaveLength(1);
+    expect(response.posts[0]?.id).toBe('post-1');
+    expect(response.posts[0]?.sectionId).toBe('section-podcast');
+    expect(response.posts[0]?.content).toBe('Podcast post');
+    expect(response.posts[0]?.createdAt).toBe('2026-02-10T10:00:00Z');
+  });
+
+  it('unsavePodcast issues DELETE to podcast-save endpoint', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith('/auth/csrf')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockResolvedValue({ token: 'csrf-token' }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 204,
+        json: vi.fn(),
+      });
+    });
+
+    await api.unsavePodcast('post-1');
+
+    const call = findCall('/posts/post-1/podcast-save');
+    expect(call).toBeDefined();
+    expect((call?.[1] as RequestInit).method).toBe('DELETE');
+  });
+
   it('getThreadComments builds query params', async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -112,6 +112,20 @@ interface ApiPostWatchlistInfo {
   viewer_categories?: string[];
 }
 
+interface ApiPodcastSave {
+  id: string;
+  user_id: string;
+  post_id: string;
+  created_at: string;
+  deleted_at?: string | null;
+}
+
+interface ApiPostPodcastSaveInfo {
+  save_count: number;
+  users: ApiReactionUser[];
+  viewer_saved: boolean;
+}
+
 interface ApiWatchLog {
   id: string;
   user_id: string;
@@ -329,6 +343,25 @@ function mapApiWatchlistUser(user: ApiReactionUser): WatchlistUser {
   };
 }
 
+function mapApiPodcastSave(save: ApiPodcastSave): PodcastSave {
+  return {
+    id: save.id,
+    userId: save.user_id,
+    postId: save.post_id,
+    createdAt: save.created_at,
+    deletedAt: save.deleted_at ?? undefined,
+  };
+}
+
+function mapApiPodcastSaveUser(user: ApiReactionUser): PodcastSaveUser {
+  return {
+    id: user.id,
+    username: user.username,
+    displayName: user.username,
+    avatar: user.profile_picture_url ?? undefined,
+  };
+}
+
 function mapApiWatchLogUser(user: ApiWatchLogUser): WatchLogUser {
   return {
     id: user.id,
@@ -534,6 +567,27 @@ export interface PostWatchlistInfo {
   users: WatchlistUser[];
   viewerSaved: boolean;
   viewerCategories: string[];
+}
+
+export interface PodcastSave {
+  id: string;
+  userId: string;
+  postId: string;
+  createdAt: string;
+  deletedAt?: string;
+}
+
+export interface PodcastSaveUser {
+  id: string;
+  username: string;
+  displayName: string;
+  avatar?: string;
+}
+
+export interface PostPodcastSaveInfo {
+  saveCount: number;
+  users: PodcastSaveUser[];
+  viewerSaved: boolean;
 }
 
 export interface WatchlistItemWithPost extends WatchlistItem {
@@ -1283,6 +1337,45 @@ class ApiClient {
       cook_logs: response.cook_logs ?? [],
       has_more: response.meta?.has_more ?? false,
       cursor: response.meta?.cursor ?? undefined,
+    };
+  }
+
+  async savePodcast(postId: string): Promise<PodcastSave> {
+    const response = await this.post<ApiPodcastSave>(`/posts/${postId}/podcast-save`);
+    return mapApiPodcastSave(response);
+  }
+
+  async unsavePodcast(postId: string): Promise<void> {
+    return this.delete(`/posts/${postId}/podcast-save`);
+  }
+
+  async getPostPodcastSaveInfo(postId: string): Promise<PostPodcastSaveInfo> {
+    const response = await this.get<ApiPostPodcastSaveInfo>(`/posts/${postId}/podcast-save-info`);
+    return {
+      saveCount: response.save_count ?? 0,
+      users: (response.users ?? []).map(mapApiPodcastSaveUser),
+      viewerSaved: response.viewer_saved ?? false,
+    };
+  }
+
+  async getSectionSavedPodcasts(
+    sectionId: string,
+    limit = 20,
+    cursor?: string
+  ): Promise<{ posts: Post[]; hasMore: boolean; nextCursor?: string }> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (cursor) {
+      params.set('cursor', cursor);
+    }
+    const response = await this.get<{
+      posts: ApiPost[];
+      has_more?: boolean;
+      next_cursor?: string | null;
+    }>(`/sections/${sectionId}/podcast-saved?${params.toString()}`);
+    return {
+      posts: (response.posts ?? []).map(mapApiPost),
+      hasMore: response.has_more ?? false,
+      nextCursor: response.next_cursor ?? undefined,
     };
   }
 

--- a/frontend/src/stores/__tests__/podcastStore.test.ts
+++ b/frontend/src/stores/__tests__/podcastStore.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { Post } from '../postStore';
+
+const apiSavePodcast = vi.hoisted(() => vi.fn());
+const apiUnsavePodcast = vi.hoisted(() => vi.fn());
+const apiGetPostPodcastSaveInfo = vi.hoisted(() => vi.fn());
+const apiGetSectionSavedPodcasts = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    savePodcast: apiSavePodcast,
+    unsavePodcast: apiUnsavePodcast,
+    getPostPodcastSaveInfo: apiGetPostPodcastSaveInfo,
+    getSectionSavedPodcasts: apiGetSectionSavedPodcasts,
+  },
+}));
+
+const { podcastStore } = await import('../podcastStore');
+
+function buildPost(id: string, sectionId = 'section-podcast'): Post {
+  return {
+    id,
+    userId: 'user-1',
+    sectionId,
+    content: `Podcast ${id}`,
+    createdAt: '2026-02-10T10:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  podcastStore.reset();
+  apiSavePodcast.mockReset();
+  apiUnsavePodcast.mockReset();
+  apiGetPostPodcastSaveInfo.mockReset();
+  apiGetSectionSavedPodcasts.mockReset();
+});
+
+describe('podcastStore', () => {
+  it('loadPostSaveInfo updates save info and saved post IDs', async () => {
+    apiGetPostPodcastSaveInfo.mockResolvedValue({
+      saveCount: 2,
+      users: [],
+      viewerSaved: true,
+    });
+
+    await podcastStore.loadPostSaveInfo('post-1');
+
+    const state = get(podcastStore);
+    expect(state.isLoadingSaveInfo).toBe(false);
+    expect(state.saveInfoByPostId['post-1']).toEqual({
+      saveCount: 2,
+      users: [],
+      viewerSaved: true,
+    });
+    expect(state.savedPostIds.has('post-1')).toBe(true);
+  });
+
+  it('toggleSave saves post when viewer has not saved it yet', async () => {
+    podcastStore.setPostSaveInfo('post-1', {
+      saveCount: 0,
+      users: [],
+      viewerSaved: false,
+    });
+    apiSavePodcast.mockResolvedValue({
+      id: 'save-1',
+      userId: 'user-1',
+      postId: 'post-1',
+      createdAt: '2026-02-10T10:00:00Z',
+    });
+    apiGetPostPodcastSaveInfo.mockResolvedValue({
+      saveCount: 1,
+      users: [],
+      viewerSaved: true,
+    });
+
+    await podcastStore.toggleSave('post-1');
+
+    const state = get(podcastStore);
+    expect(apiSavePodcast).toHaveBeenCalledWith('post-1');
+    expect(apiUnsavePodcast).not.toHaveBeenCalled();
+    expect(state.isTogglingSave).toBe(false);
+    expect(state.saveInfoByPostId['post-1']?.viewerSaved).toBe(true);
+    expect(state.savedPostIds.has('post-1')).toBe(true);
+  });
+
+  it('toggleSave unsaves post and removes it from saved list', async () => {
+    podcastStore.setPostSaveInfo('post-1', {
+      saveCount: 3,
+      users: [],
+      viewerSaved: true,
+    });
+    podcastStore.setSavedPosts([buildPost('post-1')], 'cursor-1', true, 'section-podcast');
+    apiUnsavePodcast.mockResolvedValue(undefined);
+    apiGetPostPodcastSaveInfo.mockResolvedValue({
+      saveCount: 2,
+      users: [],
+      viewerSaved: false,
+    });
+
+    await podcastStore.toggleSave('post-1');
+
+    const state = get(podcastStore);
+    expect(apiUnsavePodcast).toHaveBeenCalledWith('post-1');
+    expect(apiSavePodcast).not.toHaveBeenCalled();
+    expect(state.savedPostIds.has('post-1')).toBe(false);
+    expect(state.savedPosts).toHaveLength(0);
+  });
+
+  it('loadSavedPodcasts and loadMoreSavedPodcasts handle cursor pagination', async () => {
+    apiGetSectionSavedPodcasts
+      .mockResolvedValueOnce({
+        posts: [buildPost('post-1')],
+        hasMore: true,
+        nextCursor: 'cursor-next',
+      })
+      .mockResolvedValueOnce({
+        posts: [buildPost('post-1'), buildPost('post-2')],
+        hasMore: false,
+        nextCursor: undefined,
+      });
+
+    await podcastStore.loadSavedPodcasts('section-podcast', 1);
+    await podcastStore.loadMoreSavedPodcasts(2);
+
+    const state = get(podcastStore);
+    expect(apiGetSectionSavedPodcasts).toHaveBeenNthCalledWith(1, 'section-podcast', 1);
+    expect(apiGetSectionSavedPodcasts).toHaveBeenNthCalledWith(
+      2,
+      'section-podcast',
+      2,
+      'cursor-next'
+    );
+    expect(state.savedPosts.map((post) => post.id)).toEqual(['post-1', 'post-2']);
+    expect(state.hasMore).toBe(false);
+    expect(state.cursor).toBeNull();
+  });
+
+  it('sets error on load failure and reset clears store state', async () => {
+    apiGetSectionSavedPodcasts.mockRejectedValue(new Error('Failed to load saved podcasts'));
+
+    await podcastStore.loadSavedPodcasts('section-podcast');
+    let state = get(podcastStore);
+    expect(state.error).toBe('Failed to load saved podcasts');
+    expect(state.isLoadingSaved).toBe(false);
+
+    podcastStore.reset();
+    state = get(podcastStore);
+    expect(state.error).toBeNull();
+    expect(state.savedPosts).toHaveLength(0);
+    expect(state.savedPostIds.size).toBe(0);
+    expect(state.cursor).toBeNull();
+    expect(state.hasMore).toBe(false);
+    expect(state.sectionId).toBeNull();
+  });
+});

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -14,3 +14,4 @@ export * from './pwaStore';
 export * from './threadRouteStore';
 export * from './configStore';
 export * from './notificationStore';
+export * from './podcastStore';

--- a/frontend/src/stores/podcastStore.ts
+++ b/frontend/src/stores/podcastStore.ts
@@ -1,0 +1,240 @@
+import { derived, get, writable } from 'svelte/store';
+import { api, type PostPodcastSaveInfo } from '../services/api';
+import type { Post } from './postStore';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export interface PodcastStoreState {
+  saveInfoByPostId: Record<string, PostPodcastSaveInfo>;
+  savedPostIds: Set<string>;
+  savedPosts: Post[];
+  sectionId: string | null;
+  cursor: string | null;
+  hasMore: boolean;
+  isLoadingSaved: boolean;
+  isLoadingSaveInfo: boolean;
+  isTogglingSave: boolean;
+  error: string | null;
+}
+
+const initialState: PodcastStoreState = {
+  saveInfoByPostId: {},
+  savedPostIds: new Set(),
+  savedPosts: [],
+  sectionId: null,
+  cursor: null,
+  hasMore: false,
+  isLoadingSaved: false,
+  isLoadingSaveInfo: false,
+  isTogglingSave: false,
+  error: null,
+};
+
+function dedupePosts(existing: Post[], nextPosts: Post[]): Post[] {
+  const seen = new Set(existing.map((post) => post.id));
+  const merged = [...existing];
+  for (const post of nextPosts) {
+    if (seen.has(post.id)) {
+      continue;
+    }
+    seen.add(post.id);
+    merged.push(post);
+  }
+  return merged;
+}
+
+function buildSavedPostIds(state: PodcastStoreState, posts: Post[]): Set<string> {
+  const ids = new Set<string>();
+
+  for (const [postId, info] of Object.entries(state.saveInfoByPostId)) {
+    if (info.viewerSaved) {
+      ids.add(postId);
+    }
+  }
+
+  for (const post of posts) {
+    ids.add(post.id);
+  }
+
+  return ids;
+}
+
+function isPostSaved(state: PodcastStoreState, postId: string): boolean {
+  return state.saveInfoByPostId[postId]?.viewerSaved ?? state.savedPostIds.has(postId);
+}
+
+function createPodcastStore() {
+  const { subscribe, update, set } = writable<PodcastStoreState>({
+    ...initialState,
+    savedPostIds: new Set(),
+  });
+
+  return {
+    subscribe,
+    setLoadingSaved: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoadingSaved: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setLoadingSaveInfo: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isLoadingSaveInfo: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setTogglingSave: (isLoading: boolean) =>
+      update((state) => ({
+        ...state,
+        isTogglingSave: isLoading,
+        error: isLoading ? null : state.error,
+      })),
+    setError: (error: string | null) =>
+      update((state) => ({
+        ...state,
+        error,
+        isLoadingSaved: false,
+        isLoadingSaveInfo: false,
+        isTogglingSave: false,
+      })),
+    setPostSaveInfo: (postId: string, info: PostPodcastSaveInfo) =>
+      update((state) => {
+        const nextInfo = {
+          ...state.saveInfoByPostId,
+          [postId]: info,
+        };
+        const nextSavedIds = new Set(state.savedPostIds);
+        if (info.viewerSaved) {
+          nextSavedIds.add(postId);
+        } else {
+          nextSavedIds.delete(postId);
+        }
+
+        return {
+          ...state,
+          saveInfoByPostId: nextInfo,
+          savedPostIds: nextSavedIds,
+          isLoadingSaveInfo: false,
+          isTogglingSave: false,
+          error: null,
+        };
+      }),
+    setSavedPosts: (
+      posts: Post[],
+      cursor: string | null,
+      hasMore: boolean,
+      sectionId: string
+    ) =>
+      update((state) => ({
+        ...state,
+        savedPosts: posts,
+        savedPostIds: buildSavedPostIds(state, posts),
+        cursor,
+        hasMore,
+        sectionId,
+        isLoadingSaved: false,
+        error: null,
+      })),
+    appendSavedPosts: (posts: Post[], cursor: string | null, hasMore: boolean) =>
+      update((state) => {
+        const mergedPosts = dedupePosts(state.savedPosts, posts);
+        return {
+          ...state,
+          savedPosts: mergedPosts,
+          savedPostIds: buildSavedPostIds(state, mergedPosts),
+          cursor,
+          hasMore,
+          isLoadingSaved: false,
+          error: null,
+        };
+      }),
+    removeSavedPost: (postId: string) =>
+      update((state) => ({
+        ...state,
+        savedPosts: state.savedPosts.filter((post) => post.id !== postId),
+        savedPostIds: new Set([...state.savedPostIds].filter((id) => id !== postId)),
+      })),
+    loadPostSaveInfo: async (postId: string): Promise<void> => {
+      podcastStore.setLoadingSaveInfo(true);
+      try {
+        const info = await api.getPostPodcastSaveInfo(postId);
+        podcastStore.setPostSaveInfo(postId, info);
+      } catch (error) {
+        podcastStore.setError(
+          error instanceof Error ? error.message : 'Failed to load podcast save info'
+        );
+      }
+    },
+    toggleSave: async (postId: string): Promise<void> => {
+      const state = get(podcastStore);
+      const currentlySaved = isPostSaved(state, postId);
+      podcastStore.setTogglingSave(true);
+
+      try {
+        if (currentlySaved) {
+          await api.unsavePodcast(postId);
+        } else {
+          await api.savePodcast(postId);
+        }
+
+        const info = await api.getPostPodcastSaveInfo(postId);
+        podcastStore.setPostSaveInfo(postId, info);
+        if (!info.viewerSaved) {
+          podcastStore.removeSavedPost(postId);
+        }
+      } catch (error) {
+        podcastStore.setError(error instanceof Error ? error.message : 'Failed to update podcast save');
+      }
+    },
+    loadSavedPodcasts: async (sectionId: string, limit = DEFAULT_PAGE_SIZE): Promise<void> => {
+      podcastStore.setLoadingSaved(true);
+      try {
+        const response = await api.getSectionSavedPodcasts(sectionId, limit);
+        podcastStore.setSavedPosts(
+          response.posts ?? [],
+          response.nextCursor ?? null,
+          response.hasMore ?? false,
+          sectionId
+        );
+      } catch (error) {
+        podcastStore.setError(
+          error instanceof Error ? error.message : 'Failed to load saved podcasts'
+        );
+      }
+    },
+    loadMoreSavedPodcasts: async (limit = DEFAULT_PAGE_SIZE): Promise<void> => {
+      const state = get(podcastStore);
+      if (!state.sectionId || !state.cursor || !state.hasMore || state.isLoadingSaved) {
+        return;
+      }
+
+      podcastStore.setLoadingSaved(true);
+      try {
+        const response = await api.getSectionSavedPodcasts(state.sectionId, limit, state.cursor);
+        podcastStore.appendSavedPosts(
+          response.posts ?? [],
+          response.nextCursor ?? null,
+          response.hasMore ?? false
+        );
+      } catch (error) {
+        podcastStore.setError(
+          error instanceof Error ? error.message : 'Failed to load more saved podcasts'
+        );
+      }
+    },
+    isPostSaved: (postId: string): boolean => isPostSaved(get(podcastStore), postId),
+    reset: (): void =>
+      set({
+        ...initialState,
+        savedPostIds: new Set(),
+      }),
+  };
+}
+
+export const podcastStore = createPodcastStore();
+
+export const podcastSaveInfoByPostId = derived(podcastStore, ($store) => $store.saveInfoByPostId);
+
+export const savedPodcastPostIds = derived(podcastStore, ($store) => $store.savedPostIds);
+
+export const savedPodcastPosts = derived(podcastStore, ($store) => $store.savedPosts);


### PR DESCRIPTION
## Summary
- add typed podcast save API client methods in `frontend/src/services/api.ts`:
  - `savePodcast`
  - `unsavePodcast`
  - `getPostPodcastSaveInfo`
  - `getSectionSavedPodcasts` (cursor/limit pagination)
- add new `podcastStore` in `frontend/src/stores/podcastStore.ts` with:
  - per-post save info state
  - save toggle action
  - paginated section-saved list loading (`loadSavedPodcasts` / `loadMoreSavedPodcasts`)
  - loading/error/reset paths
- export the store from `frontend/src/stores/index.ts`
- add/extend tests for API mapping and podcast store behavior

## Testing
- `cd frontend && npm run test -- src/services/__tests__/api.test.ts src/stores/__tests__/podcastStore.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npx eslint src/services/api.ts src/services/__tests__/api.test.ts src/stores/podcastStore.ts src/stores/__tests__/podcastStore.test.ts`
- `cd frontend && npm run test`

Closes #899