### PR TITLE
[Books] Integrate spoiler UI in comment composer for book section

### DIFF
--- a/frontend/src/components/comments/CommentForm.svelte
+++ b/frontend/src/components/comments/CommentForm.svelte
@@ -7,9 +7,11 @@
   import type { Comment } from '../../stores/commentStore';
   import { parseHighlightTimestamp } from '../../lib/highlights';
   import MentionTextarea from '../mentions/MentionTextarea.svelte';
+  import SpoilerToggle from '../books/SpoilerToggle.svelte';
 
   export let postId: string;
   export let allowTimestamp = false;
+  export let allowSpoiler = false;
   export let imageContext:
     | {
         id?: string;
@@ -23,6 +25,7 @@
   const dispatch = createEventDispatcher<{ submit: Comment }>();
 
   let content = '';
+  let containsSpoiler = false;
   let timestampInput = '';
   let timestampError: string | null = null;
   let mentionUsernames: string[] = [];
@@ -61,6 +64,7 @@
         postId,
         imageId: imageContext?.id,
         content: content.trim(),
+        ...(allowSpoiler ? { containsSpoiler } : {}),
         timestampSeconds,
         mentionUsernames,
       });
@@ -71,6 +75,7 @@
         postStore.incrementCommentCount(postId, 1);
       }
       content = '';
+      containsSpoiler = false;
       timestampInput = '';
       mentionUsernames = [];
       onClearImageContext?.();
@@ -124,6 +129,14 @@
     disabled={isSubmitting}
     className="w-full px-3 py-2 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:bg-gray-100"
   />
+  {#if allowSpoiler}
+    <SpoilerToggle
+      checked={containsSpoiler}
+      on:change={(event) => {
+        containsSpoiler = event.detail;
+      }}
+    />
+  {/if}
   {#if allowTimestamp}
     <div class="space-y-1">
       <label class="text-xs font-medium text-gray-600" for="comment-timestamp">

--- a/frontend/src/components/comments/ReplyForm.svelte
+++ b/frontend/src/components/comments/ReplyForm.svelte
@@ -7,14 +7,17 @@
   import type { Comment } from '../../stores/commentStore';
   import { parseHighlightTimestamp } from '../../lib/highlights';
   import MentionTextarea from '../mentions/MentionTextarea.svelte';
+  import SpoilerToggle from '../books/SpoilerToggle.svelte';
 
   export let postId: string;
   export let parentCommentId: string;
   export let allowTimestamp = false;
+  export let allowSpoiler = false;
 
   const dispatch = createEventDispatcher<{ submit: Comment; cancel: void }>();
 
   let content = '';
+  let containsSpoiler = false;
   let timestampInput = '';
   let timestampError: string | null = null;
   let mentionUsernames: string[] = [];
@@ -53,6 +56,7 @@
         postId,
         parentCommentId,
         content: content.trim(),
+        ...(allowSpoiler ? { containsSpoiler } : {}),
         timestampSeconds,
         mentionUsernames,
       });
@@ -63,6 +67,7 @@
         postStore.incrementCommentCount(postId, 1);
       }
       content = '';
+      containsSpoiler = false;
       timestampInput = '';
       mentionUsernames = [];
       dispatch('submit', reply);
@@ -94,6 +99,14 @@
     disabled={isSubmitting}
     className="w-full px-3 py-2 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:bg-gray-100"
   />
+  {#if allowSpoiler}
+    <SpoilerToggle
+      checked={containsSpoiler}
+      on:change={(event) => {
+        containsSpoiler = event.detail;
+      }}
+    />
+  {/if}
   {#if allowTimestamp}
     <div class="space-y-1">
       <label class="text-xs font-medium text-gray-600" for={`reply-timestamp-${parentCommentId}`}>

--- a/frontend/src/components/comments/__tests__/ReplyForm.test.ts
+++ b/frontend/src/components/comments/__tests__/ReplyForm.test.ts
@@ -108,4 +108,37 @@ describe('ReplyForm', () => {
 
     expect(incrementSpy).not.toHaveBeenCalled();
   });
+
+  it('shows spoiler toggle for book replies and sends spoiler flag', async () => {
+    mapApiComment.mockReturnValue({
+      id: 'reply-2',
+      postId: 'post-1',
+      parentCommentId: 'comment-1',
+      userId: 'user-1',
+      content: 'Spoiler reply',
+      containsSpoiler: true,
+      createdAt: 'now',
+    });
+    createComment.mockResolvedValue({ comment: { id: 'reply-2' } });
+
+    const { container } = render(ReplyForm, {
+      postId: 'post-1',
+      parentCommentId: 'comment-1',
+      allowSpoiler: true,
+    });
+
+    const textarea = screen.getByPlaceholderText('Write a reply...');
+    await fireEvent.input(textarea, { target: { value: 'Spoiler reply' } });
+    await fireEvent.click(screen.getByLabelText('Contains spoiler'));
+
+    const form = container.querySelector('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+
+    expect(createComment).toHaveBeenCalled();
+    expect(createComment.mock.calls[0][0]).toMatchObject({
+      parentCommentId: 'comment-1',
+      containsSpoiler: true,
+    });
+  });
 });

--- a/frontend/src/components/notifications/NotificationMenu.svelte
+++ b/frontend/src/components/notifications/NotificationMenu.svelte
@@ -105,6 +105,13 @@
     markAllNotificationsRead();
   }
 
+  function notificationPreview(notification: Notification): string | null {
+    if (notification.relatedCommentId && notification.containsSpoiler) {
+      return '[Spoiler]';
+    }
+    return notification.contentExcerpt ?? null;
+  }
+
 </script>
 
 <svelte:window on:click={closeMenu} />
@@ -186,8 +193,8 @@
                         className="text-xs text-gray-400"
                       />
                     </div>
-                    {#if notification.contentExcerpt}
-                      <p class="mt-1 text-xs text-gray-500">{notification.contentExcerpt}</p>
+                    {#if notificationPreview(notification)}
+                      <p class="mt-1 text-xs text-gray-500">{notificationPreview(notification)}</p>
                     {/if}
                   </div>
                 </div>

--- a/frontend/src/components/notifications/__tests__/NotificationMenu.test.ts
+++ b/frontend/src/components/notifications/__tests__/NotificationMenu.test.ts
@@ -201,4 +201,31 @@ describe('NotificationMenu', () => {
     expect(storeRefs.markNotificationRead).toHaveBeenCalledWith('notif-4');
     expect(routeRefs.pushPath).toHaveBeenCalledWith('/admin');
   });
+
+  it('shows [Spoiler] preview for spoiler comment notifications', async () => {
+    storeRefs.notificationStore.set({
+      ...baseState,
+      notifications: [
+        {
+          id: 'notif-5',
+          type: 'new_comment',
+          relatedPostId: 'post-1',
+          relatedCommentId: 'comment-1',
+          containsSpoiler: true,
+          contentExcerpt: 'Bruce Willis was dead the whole time.',
+          createdAt: '2026-02-01T00:00:00Z',
+          readAt: null,
+        },
+      ],
+      unreadCount: 1,
+    });
+
+    render(NotificationMenu);
+
+    await fireEvent.click(screen.getByLabelText('Toggle notifications'));
+    await tick();
+
+    expect(screen.getByText('[Spoiler]')).toBeInTheDocument();
+    expect(screen.queryByText('Bruce Willis was dead the whole time.')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -273,6 +273,7 @@ describe('api client', () => {
       parentCommentId: 'comment-1',
       imageId: 'image-1',
       content: 'Reply',
+      containsSpoiler: true,
       links: [{ url: 'https://example.com' }],
     });
 
@@ -281,6 +282,7 @@ describe('api client', () => {
     expect(body.post_id).toBe('post-1');
     expect(body.parent_comment_id).toBe('comment-1');
     expect(body.image_id).toBe('image-1');
+    expect(body.contains_spoiler).toBe(true);
   });
 
   it('getFeed builds query params', async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1114,6 +1114,7 @@ class ApiClient {
       parent_comment_id: data.parentCommentId,
       image_id: data.imageId,
       content: data.content,
+      contains_spoiler: data.containsSpoiler,
       timestamp_seconds: data.timestampSeconds,
       links: data.links,
       mention_usernames: data.mentionUsernames ?? [],
@@ -1136,10 +1137,16 @@ class ApiClient {
 
   async updateComment(
     commentId: string,
-    data: { content: string; links?: { url: string }[] | null; mentionUsernames?: string[] }
+    data: {
+      content: string;
+      containsSpoiler?: boolean;
+      links?: { url: string }[] | null;
+      mentionUsernames?: string[];
+    }
   ): Promise<{ comment: Comment }> {
     const response = await this.patch<{ comment: ApiComment }>(`/comments/${commentId}`, {
       content: data.content,
+      contains_spoiler: data.containsSpoiler,
       links: data.links ?? undefined,
       mention_usernames: data.mentionUsernames ?? [],
     });

--- a/frontend/src/stores/__tests__/commentMapper.test.ts
+++ b/frontend/src/stores/__tests__/commentMapper.test.ts
@@ -8,6 +8,7 @@ const apiComment = {
   parent_comment_id: null,
   image_id: 'image-1',
   content: 'Hello',
+  contains_spoiler: true,
   created_at: '2025-01-01T00:00:00Z',
   user: {
     id: 'user-1',
@@ -53,6 +54,7 @@ describe('mapApiComment', () => {
     expect(comment.replies).toHaveLength(1);
     expect(comment.replies?.[0].parentCommentId).toBe('comment-1');
     expect(comment.imageId).toBe('image-1');
+    expect(comment.containsSpoiler).toBe(true);
   });
 
   it('maps API comment without metadata', () => {

--- a/frontend/src/stores/__tests__/notificationStore.test.ts
+++ b/frontend/src/stores/__tests__/notificationStore.test.ts
@@ -193,6 +193,8 @@ describe('notificationStore', () => {
     handleRealtimeNotification({
       id: 'notif-10',
       type: 'mention',
+      related_comment_id: 'comment-10',
+      contains_spoiler: true,
       created_at: '2026-01-05T00:00:00Z',
       read_at: null,
     });
@@ -200,6 +202,7 @@ describe('notificationStore', () => {
     const state = get(notificationStore);
     expect(state.notifications).toHaveLength(1);
     expect(state.notifications[0]?.id).toBe('notif-10');
+    expect(state.notifications[0]?.containsSpoiler).toBe(true);
     expect(state.unreadCount).toBe(1);
   });
 

--- a/frontend/src/stores/commentMapper.ts
+++ b/frontend/src/stores/commentMapper.ts
@@ -9,6 +9,7 @@ export interface ApiComment {
   parent_comment_id?: string | null;
   image_id?: string | null;
   content: string;
+  contains_spoiler?: boolean | null;
   timestamp_seconds?: number | null;
   timestamp_display?: string | null;
   links?: ApiLink[];
@@ -28,6 +29,7 @@ export function mapApiComment(apiComment: ApiComment): Comment {
     parentCommentId: apiComment.parent_comment_id ?? undefined,
     imageId: apiComment.image_id ?? undefined,
     content: apiComment.content,
+    containsSpoiler: typeof apiComment.contains_spoiler === 'boolean' ? apiComment.contains_spoiler : undefined,
     timestampSeconds: typeof apiComment.timestamp_seconds === 'number' ? apiComment.timestamp_seconds : undefined,
     timestampDisplay:
       typeof apiComment.timestamp_display === 'string' ? apiComment.timestamp_display : undefined,

--- a/frontend/src/stores/commentStore.ts
+++ b/frontend/src/stores/commentStore.ts
@@ -8,6 +8,7 @@ export interface Comment {
   parentCommentId?: string;
   imageId?: string;
   content: string;
+  containsSpoiler?: boolean;
   timestampSeconds?: number;
   timestampDisplay?: string;
   links?: Link[];
@@ -28,6 +29,7 @@ export interface CreateCommentRequest {
   parentCommentId?: string;
   imageId?: string;
   content: string;
+  containsSpoiler?: boolean;
   timestampSeconds?: number;
   links?: { url: string }[];
   mentionUsernames?: string[];

--- a/frontend/src/stores/notificationMapper.ts
+++ b/frontend/src/stores/notificationMapper.ts
@@ -13,6 +13,7 @@ export interface ApiNotification {
   related_post_id?: string | null;
   related_comment_id?: string | null;
   related_user_id?: string | null;
+  contains_spoiler?: boolean | null;
   related_user?: ApiNotificationUser | null;
   content_excerpt?: string | null;
   read_at?: string | null;
@@ -25,6 +26,13 @@ function readString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return undefined;
 }
 
 function mapRelatedUser(raw: unknown): Notification['relatedUser'] | undefined {
@@ -56,6 +64,10 @@ export function mapApiNotification(apiNotification: ApiNotification): Notificati
     relatedPostId: apiNotification.related_post_id ?? null,
     relatedCommentId: apiNotification.related_comment_id ?? null,
     relatedUserId: apiNotification.related_user_id ?? null,
+    containsSpoiler:
+      typeof apiNotification.contains_spoiler === 'boolean'
+        ? apiNotification.contains_spoiler
+        : undefined,
     relatedUser: apiNotification.related_user
       ? {
           id: apiNotification.related_user.id,
@@ -99,6 +111,7 @@ export function mapNotificationPayload(payload: unknown): Notification | null {
     relatedPostId: readString(record.related_post_id ?? record.relatedPostId) ?? null,
     relatedCommentId: readString(record.related_comment_id ?? record.relatedCommentId) ?? null,
     relatedUserId: readString(record.related_user_id ?? record.relatedUserId) ?? null,
+    containsSpoiler: readBoolean(record.contains_spoiler ?? record.containsSpoiler),
     relatedUser,
     contentExcerpt: readString(record.content_excerpt ?? record.contentExcerpt) ?? null,
     readAt: readString(record.read_at ?? record.readAt) ?? null,

--- a/frontend/src/stores/notificationStore.ts
+++ b/frontend/src/stores/notificationStore.ts
@@ -11,6 +11,7 @@ export interface Notification {
   relatedPostId?: string | null;
   relatedCommentId?: string | null;
   relatedUserId?: string | null;
+  containsSpoiler?: boolean;
   relatedUser?: {
     id: string;
     username: string;


### PR DESCRIPTION
## Summary
- add `containsSpoiler` support to frontend comment models/mappers and comment API create/update payloads (`contains_spoiler`)
- integrate `SpoilerToggle` into both comment and reply composers for book sections only
- integrate `SpoilerWrapper` for spoiler-marked comments/replies in book section comment threads
- support spoiler toggle prefill + update payload when editing existing spoiler comments
- update notification mapping/rendering to show `[Spoiler]` preview for spoiler-marked comment notifications instead of excerpt text

## Tests
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/comments/__tests__/CommentForm.test.ts src/components/comments/__tests__/ReplyForm.test.ts src/components/comments/__tests__/CommentThread.test.ts src/components/notifications/__tests__/NotificationMenu.test.ts src/stores/__tests__/commentMapper.test.ts src/stores/__tests__/notificationStore.test.ts src/services/__tests__/api.test.ts`
- `cd frontend && npm run test`
- `cd frontend && npm run lint`
- `cd frontend && npm run test`
- `cd . && task ci:prek`

Closes #886