### PR TITLE
[Podcasts] Add save-for-later button to podcast posts

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -28,6 +28,7 @@
   import QuoteList from './books/QuoteList.svelte';
   import MovieCard from './movies/MovieCard.svelte';
   import MovieStatsBar from './movies/MovieStatsBar.svelte';
+  import PodcastSaveButton from './podcasts/PodcastSaveButton.svelte';
   import BandcampEmbed from '../lib/components/embeds/BandcampEmbed.svelte';
   import SoundCloudEmbed from '../lib/components/embeds/SoundCloudEmbed.svelte';
   import SpotifyEmbed from '../lib/components/embeds/SpotifyEmbed.svelte';
@@ -2243,6 +2244,12 @@
               </ul>
             </div>
           {/if}
+        </div>
+      {/if}
+
+      {#if isPodcastSection}
+        <div class="mt-3">
+          <PodcastSaveButton postId={post.id} />
         </div>
       {/if}
 

--- a/frontend/src/components/__tests__/PodcastSaveButton.test.ts
+++ b/frontend/src/components/__tests__/PodcastSaveButton.test.ts
@@ -1,0 +1,147 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PodcastSave } from '../../services/api';
+
+const apiSavePodcast = vi.hoisted(() => vi.fn());
+const apiUnsavePodcast = vi.hoisted(() => vi.fn());
+const apiGetPostPodcastSaveInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', () => ({
+  api: {
+    savePodcast: apiSavePodcast,
+    unsavePodcast: apiUnsavePodcast,
+    getPostPodcastSaveInfo: apiGetPostPodcastSaveInfo,
+  },
+}));
+
+const { podcastStore } = await import('../../stores/podcastStore');
+const { default: PodcastSaveButton } = await import('../podcasts/PodcastSaveButton.svelte');
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(() => {
+  podcastStore.reset();
+  apiSavePodcast.mockReset();
+  apiUnsavePodcast.mockReset();
+  apiGetPostPodcastSaveInfo.mockReset();
+
+  apiSavePodcast.mockResolvedValue({
+    id: 'save-1',
+    userId: 'user-1',
+    postId: 'post-1',
+    createdAt: '2026-02-10T10:00:00Z',
+  });
+  apiUnsavePodcast.mockResolvedValue(undefined);
+  apiGetPostPodcastSaveInfo.mockResolvedValue({
+    saveCount: 1,
+    users: [],
+    viewerSaved: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('PodcastSaveButton', () => {
+  it('renders unsaved state', () => {
+    render(PodcastSaveButton, { postId: 'post-1' });
+
+    expect(screen.getByText('Save for later')).toBeInTheDocument();
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('applies optimistic save state immediately and syncs after server response', async () => {
+    const deferredSave = createDeferred<PodcastSave>();
+    apiSavePodcast.mockReturnValueOnce(deferredSave.promise);
+    apiGetPostPodcastSaveInfo.mockResolvedValueOnce({
+      saveCount: 3,
+      users: [],
+      viewerSaved: true,
+    });
+
+    render(PodcastSaveButton, {
+      postId: 'post-1',
+      initialSaved: false,
+      initialSaveCount: 2,
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Save podcast for later' }));
+
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    expect(screen.getByTestId('podcast-save-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('podcast-save-spinner')).toBeInTheDocument();
+
+    deferredSave.resolve({
+      id: 'save-1',
+      userId: 'user-1',
+      postId: 'post-1',
+      createdAt: '2026-02-10T10:00:00Z',
+    });
+
+    await waitFor(() => {
+      expect(apiSavePodcast).toHaveBeenCalledWith('post-1');
+      expect(apiGetPostPodcastSaveInfo).toHaveBeenCalledWith('post-1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('podcast-save-spinner')).not.toBeInTheDocument();
+    });
+  });
+
+  it('supports unsaving previously saved podcast posts', async () => {
+    apiGetPostPodcastSaveInfo.mockResolvedValueOnce({
+      saveCount: 1,
+      users: [],
+      viewerSaved: false,
+    });
+
+    render(PodcastSaveButton, {
+      postId: 'post-1',
+      initialSaved: true,
+      initialSaveCount: 2,
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove podcast from saved for later' }));
+
+    expect(screen.getByText('Save for later')).toBeInTheDocument();
+    expect(screen.getByTestId('podcast-save-count')).toHaveTextContent('1');
+
+    await waitFor(() => {
+      expect(apiUnsavePodcast).toHaveBeenCalledWith('post-1');
+      expect(apiGetPostPodcastSaveInfo).toHaveBeenCalledWith('post-1');
+    });
+  });
+
+  it('rolls back optimistic state and shows an error when save fails', async () => {
+    const deferredSave = createDeferred<PodcastSave>();
+    apiSavePodcast.mockReturnValueOnce(deferredSave.promise);
+
+    render(PodcastSaveButton, {
+      postId: 'post-1',
+      initialSaved: false,
+      initialSaveCount: 0,
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Save podcast for later' }));
+
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    deferredSave.reject(new Error('Network broke'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('podcast-save-error')).toHaveTextContent('Network broke');
+    });
+
+    expect(screen.getByText('Save for later')).toBeInTheDocument();
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+    expect(apiGetPostPodcastSaveInfo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -660,6 +660,7 @@ describe('PostCard', () => {
     expect(screen.getByText('Pilot Episode')).toBeInTheDocument();
     expect(screen.getByText('Best place to start')).toBeInTheDocument();
     expect(screen.getAllByTestId('podcast-highlight-episode')).toHaveLength(2);
+    expect(screen.getByTestId('podcast-save-button')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Pilot Episode' })).toHaveAttribute(
       'href',
       'https://example.com/episodes/pilot'
@@ -745,6 +746,7 @@ describe('PostCard', () => {
 
     expect(screen.queryByTestId('podcast-metadata-block')).not.toBeInTheDocument();
     expect(screen.queryByTestId('podcast-kind-badge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('podcast-save-button')).not.toBeInTheDocument();
   });
 
   it('keeps recipe section rendering intact', () => {

--- a/frontend/src/components/podcasts/PodcastSaveButton.svelte
+++ b/frontend/src/components/podcasts/PodcastSaveButton.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import type { PostPodcastSaveInfo } from '../../services/api';
+  import { api } from '../../services/api';
+  import { podcastSaveInfoByPostId, podcastStore } from '../../stores/podcastStore';
+
+  export let postId: string;
+  export let initialSaved = false;
+  export let initialSaveCount = 0;
+
+  let isSaving = false;
+  let errorMessage: string | null = null;
+  let propSignature = '';
+  let fallbackInfo = buildSaveInfo(initialSaved, initialSaveCount);
+
+  $: nextSignature = `${postId}:${initialSaved}:${initialSaveCount}`;
+  $: if (nextSignature !== propSignature) {
+    propSignature = nextSignature;
+    fallbackInfo = buildSaveInfo(initialSaved, initialSaveCount);
+  }
+
+  $: storeInfo = $podcastSaveInfoByPostId[postId];
+  $: effectiveInfo = storeInfo ?? fallbackInfo;
+  $: isSaved = Boolean(effectiveInfo.viewerSaved);
+  $: displayedSaveCount = clampCount(effectiveInfo.saveCount);
+
+  function clampCount(value: number): number {
+    return Math.max(0, Number.isFinite(value) ? value : 0);
+  }
+
+  function buildSaveInfo(viewerSaved: boolean, saveCount: number): PostPodcastSaveInfo {
+    return {
+      saveCount: clampCount(saveCount),
+      users: [],
+      viewerSaved,
+    };
+  }
+
+  function normalizeSaveInfo(info: PostPodcastSaveInfo): PostPodcastSaveInfo {
+    return {
+      saveCount: clampCount(info.saveCount),
+      users: info.users ?? [],
+      viewerSaved: Boolean(info.viewerSaved),
+    };
+  }
+
+  function shiftSaveCount(count: number, wasSaved: boolean, willBeSaved: boolean): number {
+    if (!wasSaved && willBeSaved) {
+      return clampCount(count + 1);
+    }
+    if (wasSaved && !willBeSaved) {
+      return clampCount(count - 1);
+    }
+    return clampCount(count);
+  }
+
+  function applySaveInfo(info: PostPodcastSaveInfo) {
+    const normalized = normalizeSaveInfo(info);
+    fallbackInfo = normalized;
+    podcastStore.setPostSaveInfo(postId, normalized);
+  }
+
+  async function toggleSave() {
+    if (!postId || isSaving) {
+      return;
+    }
+
+    isSaving = true;
+    errorMessage = null;
+
+    const previous = normalizeSaveInfo(effectiveInfo);
+    const nextSaved = !previous.viewerSaved;
+    const optimistic: PostPodcastSaveInfo = {
+      ...previous,
+      viewerSaved: nextSaved,
+      saveCount: shiftSaveCount(previous.saveCount, previous.viewerSaved, nextSaved),
+    };
+
+    applySaveInfo(optimistic);
+
+    try {
+      if (nextSaved) {
+        await api.savePodcast(postId);
+      } else {
+        await api.unsavePodcast(postId);
+      }
+
+      const persisted = await api.getPostPodcastSaveInfo(postId);
+      applySaveInfo(persisted);
+      if (!persisted.viewerSaved) {
+        podcastStore.removeSavedPost(postId);
+      }
+    } catch (error) {
+      applySaveInfo(previous);
+      errorMessage = error instanceof Error ? error.message : 'Failed to update podcast save.';
+    } finally {
+      isSaving = false;
+    }
+  }
+</script>
+
+<div class="inline-flex flex-col gap-2" data-testid="podcast-save-button">
+  <button
+    type="button"
+    class={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+      isSaved
+        ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+        : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50'
+    }`}
+    on:click={toggleSave}
+    aria-label={isSaved ? 'Remove podcast from saved for later' : 'Save podcast for later'}
+    disabled={isSaving}
+  >
+    {#if isSaved}
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M16.707 6.707a1 1 0 0 0-1.414-1.414L8.5 12.086 5.707 9.293a1 1 0 0 0-1.414 1.414l3.5 3.5a1 1 0 0 0 1.414 0l7.5-7.5Z" />
+      </svg>
+      <span>Saved</span>
+    {:else}
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" aria-hidden="true">
+        <path d="M10 4v12M4 10h12" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+      </svg>
+      <span>Save for later</span>
+    {/if}
+
+    {#if displayedSaveCount > 0}
+      <span
+        class={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+          isSaved ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-700'
+        }`}
+        data-testid="podcast-save-count"
+      >
+        {displayedSaveCount}
+      </span>
+    {/if}
+
+    {#if isSaving}
+      <span
+        class="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent"
+        aria-hidden="true"
+        data-testid="podcast-save-spinner"
+      ></span>
+    {/if}
+  </button>
+
+  {#if errorMessage}
+    <p
+      class="text-xs font-medium text-red-600"
+      role="alert"
+      aria-live="assertive"
+      data-testid="podcast-save-error"
+    >
+      {errorMessage}
+    </p>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add a new `PodcastSaveButton` component for podcast posts with save/unsave UX
- implement optimistic save state updates with rollback and inline error feedback on API failure
- integrate podcast save action into `PostCard` for podcast sections
- add component tests for save, unsave, optimistic transition, and rollback behavior
- extend `PostCard` tests to verify podcast save button rendering behavior

## Testing
- `cd frontend && npm run test -- src/components/__tests__/PodcastSaveButton.test.ts src/components/__tests__/PostCard.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npm run lint`

Closes #900