### PR TITLE
[Podcasts] Add integration and E2E coverage for podcast workflows

### DIFF
--- a/backend/internal/handlers/post_podcast_create_test.go
+++ b/backend/internal/handlers/post_podcast_create_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func TestCreatePostHandlerPodcastShowWithHighlightedEpisodes(t *testing.T) {
 		t.Fatalf("failed to marshal request body: %v", err)
 	}
 
-	handler := NewPostHandler(db, nil, nil)
+	handler := newPostHandlerForPodcastCreateTests(db)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateshow", false))
@@ -133,7 +134,7 @@ func TestCreatePostHandlerPodcastEpisode(t *testing.T) {
 		t.Fatalf("failed to marshal request body: %v", err)
 	}
 
-	handler := NewPostHandler(db, nil, nil)
+	handler := newPostHandlerForPodcastCreateTests(db)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateepisode", false))
@@ -189,7 +190,7 @@ func TestCreatePostHandlerPodcastKindSelectionRequired(t *testing.T) {
 		t.Fatalf("failed to marshal request body: %v", err)
 	}
 
-	handler := NewPostHandler(db, nil, nil)
+	handler := newPostHandlerForPodcastCreateTests(db)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateuncertain", false))
@@ -224,4 +225,10 @@ func disableLinkMetadataForCreatePostPodcastTests(t *testing.T) {
 			t.Fatalf("failed to restore link metadata config: %v", err)
 		}
 	})
+}
+
+func newPostHandlerForPodcastCreateTests(db *sql.DB) *PostHandler {
+	handler := NewPostHandler(db, nil, nil)
+	handler.rateLimiter = &stubContentRateLimiter{allowed: true}
+	return handler
 }

--- a/backend/internal/handlers/post_podcast_create_test.go
+++ b/backend/internal/handlers/post_podcast_create_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sanderginn/clubhouse/internal/models"
+	"github.com/sanderginn/clubhouse/internal/services"
+	"github.com/sanderginn/clubhouse/internal/testutil"
+)
+
+func TestCreatePostHandlerPodcastShowWithHighlightedEpisodes(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	disableLinkMetadataForCreatePostPodcastTests(t)
+
+	userID := testutil.CreateTestUser(t, db, "podcastcreateshow", "podcastcreateshow@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+	note := "Start here"
+
+	reqBody := models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Podcast show post",
+		Links: []models.LinkRequest{
+			{
+				URL: "https://example.com/show",
+				Podcast: &models.PodcastMetadata{
+					Kind: "show",
+					HighlightEpisodes: []models.PodcastHighlightEpisode{
+						{
+							Title: "Episode 1",
+							URL:   "https://example.com/show/episode-1",
+							Note:  &note,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	handler := NewPostHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateshow", false))
+	rr := httptest.NewRecorder()
+
+	handler.CreatePost(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+
+	var response models.CreatePostResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Post.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(response.Post.Links))
+	}
+	if response.Post.Links[0].Podcast == nil {
+		t.Fatal("expected podcast metadata in response link")
+	}
+	if response.Post.Links[0].Podcast.Kind != "show" {
+		t.Fatalf("expected podcast kind show, got %q", response.Post.Links[0].Podcast.Kind)
+	}
+	if len(response.Post.Links[0].Podcast.HighlightEpisodes) != 1 {
+		t.Fatalf("expected 1 highlighted episode, got %d", len(response.Post.Links[0].Podcast.HighlightEpisodes))
+	}
+
+	var metadataBytes []byte
+	if err := db.QueryRow(`SELECT metadata FROM links WHERE post_id = $1`, response.Post.ID).Scan(&metadataBytes); err != nil {
+		t.Fatalf("failed to query stored link metadata: %v", err)
+	}
+
+	var metadata map[string]any
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	rawPodcast, ok := metadata["podcast"]
+	if !ok {
+		t.Fatal("expected podcast metadata in stored payload")
+	}
+	encodedPodcast, err := json.Marshal(rawPodcast)
+	if err != nil {
+		t.Fatalf("failed to marshal stored podcast metadata: %v", err)
+	}
+	var storedPodcast models.PodcastMetadata
+	if err := json.Unmarshal(encodedPodcast, &storedPodcast); err != nil {
+		t.Fatalf("failed to unmarshal stored podcast metadata: %v", err)
+	}
+	if storedPodcast.Kind != "show" {
+		t.Fatalf("expected stored podcast kind show, got %q", storedPodcast.Kind)
+	}
+	if len(storedPodcast.HighlightEpisodes) != 1 {
+		t.Fatalf("expected 1 stored highlighted episode, got %d", len(storedPodcast.HighlightEpisodes))
+	}
+}
+
+func TestCreatePostHandlerPodcastEpisode(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	disableLinkMetadataForCreatePostPodcastTests(t)
+
+	userID := testutil.CreateTestUser(t, db, "podcastcreateepisode", "podcastcreateepisode@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+
+	reqBody := models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Podcast episode post",
+		Links: []models.LinkRequest{
+			{
+				URL: "https://example.com/episode",
+				Podcast: &models.PodcastMetadata{
+					Kind: "episode",
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	handler := NewPostHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateepisode", false))
+	rr := httptest.NewRecorder()
+
+	handler.CreatePost(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+
+	var response models.CreatePostResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Post.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(response.Post.Links))
+	}
+	if response.Post.Links[0].Podcast == nil {
+		t.Fatal("expected podcast metadata in response link")
+	}
+	if response.Post.Links[0].Podcast.Kind != "episode" {
+		t.Fatalf("expected podcast kind episode, got %q", response.Post.Links[0].Podcast.Kind)
+	}
+	if len(response.Post.Links[0].Podcast.HighlightEpisodes) != 0 {
+		t.Fatalf("expected no highlighted episodes, got %d", len(response.Post.Links[0].Podcast.HighlightEpisodes))
+	}
+}
+
+func TestCreatePostHandlerPodcastKindSelectionRequired(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	t.Cleanup(func() { testutil.CleanupTables(t, db) })
+	disableLinkMetadataForCreatePostPodcastTests(t)
+
+	userID := testutil.CreateTestUser(t, db, "podcastcreateuncertain", "podcastcreateuncertain@test.com", false, true)
+	sectionID := testutil.CreateTestSection(t, db, "Podcasts", "podcast")
+
+	reqBody := models.CreatePostRequest{
+		SectionID: sectionID,
+		Content:   "Podcast uncertain kind",
+		Links: []models.LinkRequest{
+			{
+				URL: "https://example.com/listen",
+				Podcast: &models.PodcastMetadata{
+					Kind: "",
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	handler := NewPostHandler(db, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/posts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(createTestUserContext(req.Context(), uuid.MustParse(userID), "podcastcreateuncertain", false))
+	rr := httptest.NewRecorder()
+
+	handler.CreatePost(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+
+	var response models.ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if response.Code != "PODCAST_KIND_SELECTION_REQUIRED" {
+		t.Fatalf("expected code PODCAST_KIND_SELECTION_REQUIRED, got %q", response.Code)
+	}
+}
+
+func disableLinkMetadataForCreatePostPodcastTests(t *testing.T) {
+	t.Helper()
+
+	config := services.GetConfigService()
+	current := config.GetConfig().LinkMetadataEnabled
+	disabled := false
+	if _, err := config.UpdateConfig(context.Background(), &disabled, nil, nil); err != nil {
+		t.Fatalf("failed to disable link metadata: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := config.UpdateConfig(context.Background(), &current, nil, nil); err != nil {
+			t.Fatalf("failed to restore link metadata config: %v", err)
+		}
+	})
+}

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -13,6 +13,22 @@ async function login(page: Page) {
 }
 
 const sectionName = process.env.E2E_SECTION || 'Music';
+const podcastSectionName = process.env.E2E_PODCAST_SECTION || 'Podcasts';
+
+async function openSection(page: Page, name: string) {
+  const nav = page.getByRole('navigation', { name: 'Main navigation' });
+  const sectionButton = nav.getByRole('button', { name });
+  await expect(sectionButton).toBeVisible();
+  await sectionButton.click();
+  await expect(page.getByLabel('Post content')).toBeVisible();
+}
+
+async function addPostLink(page: Page, url: string) {
+  await page.getByRole('button', { name: 'Add link' }).click();
+  const linkInput = page.getByLabel('Link URL');
+  await linkInput.fill(url);
+  await linkInput.press('Enter');
+}
 
 test('unauthenticated users see login form', async ({ page }) => {
   await page.goto('/');
@@ -28,20 +44,13 @@ test('login flow (happy path)', async ({ page }) => {
 
 test('sections and feed render after login', async ({ page }) => {
   await login(page);
-  const nav = page.getByRole('navigation', { name: 'Main navigation' });
-  const sectionButton = nav.getByRole('button', { name: sectionName });
-  await expect(sectionButton).toBeVisible();
-  await sectionButton.click();
-  await expect(page.getByLabel('Post content')).toBeVisible();
+  await openSection(page, sectionName);
   await expect(page.getByRole('button', { name: 'Post' })).toBeVisible();
 });
 
 test('create text-only post', async ({ page }) => {
   await login(page);
-  const nav = page.getByRole('navigation', { name: 'Main navigation' });
-  const sectionButton = nav.getByRole('button', { name: sectionName });
-  await expect(sectionButton).toBeVisible();
-  await sectionButton.click();
+  await openSection(page, sectionName);
 
   const content = `E2E post ${Date.now()}`;
   await page.getByLabel('Post content').fill(content);
@@ -52,18 +61,12 @@ test('create text-only post', async ({ page }) => {
 
 test('create post with highlights', async ({ page }) => {
   await login(page);
-  const nav = page.getByRole('navigation', { name: 'Main navigation' });
-  const sectionButton = nav.getByRole('button', { name: sectionName });
-  await expect(sectionButton).toBeVisible();
-  await sectionButton.click();
+  await openSection(page, sectionName);
 
   const content = `E2E highlight post ${Date.now()}`;
   await page.getByLabel('Post content').fill(content);
 
-  await page.getByRole('button', { name: 'Add link' }).click();
-  const linkInput = page.getByLabel('Link URL');
-  await linkInput.fill('https://example.com');
-  await linkInput.press('Enter');
+  await addPostLink(page, 'https://example.com');
 
   const timestampInput = page.getByLabel('Timestamp (mm:ss)');
   await expect(timestampInput).toBeVisible();
@@ -80,19 +83,93 @@ test('create post with highlights', async ({ page }) => {
 
 test('music link appears in the recent links container', async ({ page }) => {
   await login(page);
-  const nav = page.getByRole('navigation', { name: 'Main navigation' });
-  const sectionButton = nav.getByRole('button', { name: sectionName });
-  await expect(sectionButton).toBeVisible();
-  await sectionButton.click();
+  await openSection(page, sectionName);
 
   const linkUrl = `https://example.com/music-${Date.now()}`;
-  await page.getByRole('button', { name: 'Add link' }).click();
-  const linkInput = page.getByLabel('Link URL');
-  await linkInput.fill(linkUrl);
-  await linkInput.press('Enter');
+  await addPostLink(page, linkUrl);
 
   await page.getByRole('button', { name: 'Post' }).click();
 
   await expect(page.getByRole('button', { name: /Recent Music Links/i })).toBeVisible();
   await expect(page.locator(`a[href=\"${linkUrl}\"]`)).toBeVisible();
+});
+
+test('podcast workflow: create show post, save and unsave, and switch top widget modes', async ({ page }) => {
+  await login(page);
+  await openSection(page, podcastSectionName);
+
+  const showContent = `E2E podcast show ${Date.now()}`;
+  const highlightTitle = `Highlight ${Date.now()}`;
+  await page.getByLabel('Post content').fill(showContent);
+  await addPostLink(page, `https://example.com/podcast-show-${Date.now()}`);
+  await page.getByLabel('Podcast kind').selectOption('show');
+  await page.getByLabel('Highlight episode title').fill(highlightTitle);
+  await page.getByLabel('Highlight episode url').fill(`https://example.com/episodes/${Date.now()}`);
+  await page.getByLabel('Highlight episode note').fill('Start here');
+  await page.getByRole('button', { name: 'Add highlighted episode' }).click();
+  await page.getByRole('button', { name: 'Post' }).click();
+
+  const showCard = page.locator('article').filter({ hasText: showContent }).first();
+  await expect(showCard).toBeVisible();
+  await expect(showCard.getByTestId('podcast-kind-badge')).toContainText('Show');
+  await expect(showCard.getByTestId('podcast-highlight-episodes')).toContainText(highlightTitle);
+
+  const saveButton = showCard.getByRole('button', { name: 'Save podcast for later' });
+  await expect(saveButton).toBeVisible();
+  await saveButton.click();
+  await expect(showCard.getByRole('button', { name: 'Remove podcast from saved for later' })).toBeVisible();
+
+  if (sectionName !== podcastSectionName) {
+    await openSection(page, sectionName);
+    await openSection(page, podcastSectionName);
+  }
+
+  await expect(page.getByTestId('podcasts-top-container')).toBeVisible();
+  await page.getByTestId('podcasts-mode-saved').click();
+  await expect(page.getByTestId('podcasts-saved-list')).toContainText(showContent);
+
+  const savedCardButton = page
+    .getByTestId('podcasts-saved-list')
+    .locator('button')
+    .filter({ hasText: showContent })
+    .first();
+  await savedCardButton.click();
+
+  const threadSaveButton = page.getByRole('button', { name: 'Remove podcast from saved for later' }).first();
+  await expect(threadSaveButton).toBeVisible();
+  await threadSaveButton.click();
+  await expect(page.getByRole('button', { name: 'Save podcast for later' }).first()).toBeVisible();
+
+  await page.getByTestId('podcasts-mode-recent').click();
+  await expect(page.getByTestId('podcasts-recent-list')).toBeVisible();
+});
+
+test('podcast workflow: explicit episode post and uncertain kind validation flow', async ({ page }) => {
+  await login(page);
+  await openSection(page, podcastSectionName);
+
+  const uncertainContent = `E2E uncertain podcast ${Date.now()}`;
+  await page.getByLabel('Post content').fill(uncertainContent);
+  await addPostLink(page, `https://example.com/listen-${Date.now()}`);
+  await page.getByRole('button', { name: 'Post' }).click();
+
+  const uncertainMessage =
+    'Could not determine whether this podcast link is a show or an episode. Please select one and try again.';
+  await expect(page.getByText(uncertainMessage)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Post' })).toBeDisabled();
+
+  await page.getByLabel('Podcast kind').selectOption('show');
+  await expect(page.getByRole('button', { name: 'Post' })).toBeEnabled();
+  await page.getByRole('button', { name: 'Post' }).click();
+  await expect(page.getByText(uncertainContent)).toBeVisible();
+
+  const episodeContent = `E2E podcast episode ${Date.now()}`;
+  await page.getByLabel('Post content').fill(episodeContent);
+  await addPostLink(page, 'https://open.spotify.com/episode/4rOoJ6Egrf8K2IrywzwOMk');
+  await page.getByLabel('Podcast kind').selectOption('episode');
+  await page.getByRole('button', { name: 'Post' }).click();
+
+  const episodeCard = page.locator('article').filter({ hasText: episodeContent }).first();
+  await expect(episodeCard).toBeVisible();
+  await expect(episodeCard.getByTestId('podcast-kind-badge')).toContainText('Episode');
 });


### PR DESCRIPTION
## Summary
- add backend handler integration tests for podcast post creation paths:
  - show post with highlighted episodes
  - explicit episode post
  - uncertain classification returning `PODCAST_KIND_SELECTION_REQUIRED`
- extend `PostForm` podcast tests with explicit episode payload coverage
- expand Playwright coverage for podcast workflows:
  - create show post with highlighted episode
  - save/unsave flow
  - podcasts top widget recent/saved mode switching
  - uncertain classification recovery via explicit kind selection
  - explicit episode post creation
- refactor existing E2E section navigation/link entry into shared helpers to reduce duplication

## Validation
- `cd backend && go test ./internal/handlers -run 'TestCreatePostHandlerPodcast' -v`
- `cd frontend && npm run test -- src/components/posts/__tests__/PostForm.test.ts src/components/__tests__/PodcastsTopContainer.test.ts`
- `cd frontend && npm run check`
- `cd frontend && npx playwright test e2e/app.spec.ts --list`

## Notes
- database-backed backend handler tests are environment-gated and will skip when `CLUBHOUSE_TEST_DATABASE_URL` is not set.

Closes #902