### PR TITLE
[Movies/Series] Fix Rotten Tomatoes scores still not displaying

### DIFF
--- a/backend/internal/services/links/metadata_test.go
+++ b/backend/internal/services/links/metadata_test.go
@@ -201,6 +201,108 @@ func TestFetchMetadataMovieSectionPassesOMDBClientWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestFetchMetadataMovieSectionFallbacksWhenRequestFails(t *testing.T) {
+	originalNewTMDBClientFromEnvFunc := newTMDBClientFromEnvFunc
+	originalNewOMDBClientFromEnvFunc := newOMDBClientFromEnvFunc
+	originalParseMovieMetadataFunc := parseMovieMetadataFunc
+	resetOMDBClientFromEnvCacheForTests()
+	t.Cleanup(func() {
+		newTMDBClientFromEnvFunc = originalNewTMDBClientFromEnvFunc
+		newOMDBClientFromEnvFunc = originalNewOMDBClientFromEnvFunc
+		parseMovieMetadataFunc = originalParseMovieMetadataFunc
+		resetOMDBClientFromEnvCacheForTests()
+	})
+
+	newTMDBClientFromEnvFunc = func() (*TMDBClient, error) {
+		return &TMDBClient{}, nil
+	}
+	parseMovieMetadataFunc = func(ctx context.Context, rawURL string, client *TMDBClient, omdbClient *OMDBClient) (*MovieData, error) {
+		return &MovieData{
+			Title:               "The Matrix",
+			TMDBID:              603,
+			TMDBMediaType:       "movie",
+			RottenTomatoesScore: intPtr(88),
+		}, nil
+	}
+
+	fetcher := NewFetcher(&http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, errors.New("network unreachable")
+		}),
+	})
+	fetcher.resolver = fakeResolver{
+		addrs: map[string][]net.IPAddr{
+			"www.rottentomatoes.com": {{IP: net.ParseIP("151.101.65.91")}},
+		},
+	}
+
+	ctx := WithMetadataSectionType(context.Background(), "movie")
+	metadata, err := fetcher.Fetch(ctx, "https://www.rottentomatoes.com/m/the_matrix")
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+
+	movie, ok := metadata["movie"].(*MovieData)
+	if !ok || movie == nil {
+		t.Fatalf("expected movie metadata fallback")
+	}
+	if movie.Title != "The Matrix" {
+		t.Fatalf("movie title = %q, want The Matrix", movie.Title)
+	}
+	if movie.RottenTomatoesScore == nil || *movie.RottenTomatoesScore != 88 {
+		t.Fatalf("rotten tomatoes score = %+v, want 88", movie.RottenTomatoesScore)
+	}
+	if provider, ok := metadata["provider"].(string); !ok || provider == "" {
+		t.Fatalf("expected provider to be set")
+	}
+}
+
+func TestFetchMetadataMovieSectionFallbacksOnHTTPStatusError(t *testing.T) {
+	originalNewTMDBClientFromEnvFunc := newTMDBClientFromEnvFunc
+	originalNewOMDBClientFromEnvFunc := newOMDBClientFromEnvFunc
+	originalParseMovieMetadataFunc := parseMovieMetadataFunc
+	resetOMDBClientFromEnvCacheForTests()
+	t.Cleanup(func() {
+		newTMDBClientFromEnvFunc = originalNewTMDBClientFromEnvFunc
+		newOMDBClientFromEnvFunc = originalNewOMDBClientFromEnvFunc
+		parseMovieMetadataFunc = originalParseMovieMetadataFunc
+		resetOMDBClientFromEnvCacheForTests()
+	})
+
+	newTMDBClientFromEnvFunc = func() (*TMDBClient, error) {
+		return &TMDBClient{}, nil
+	}
+	parseMovieMetadataFunc = func(ctx context.Context, rawURL string, client *TMDBClient, omdbClient *OMDBClient) (*MovieData, error) {
+		return &MovieData{Title: "The Matrix"}, nil
+	}
+
+	fetcher := NewFetcher(&http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Status:     "403 Forbidden",
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+				Body:       io.NopCloser(strings.NewReader("forbidden")),
+				Request:    r,
+			}, nil
+		}),
+	})
+	fetcher.resolver = fakeResolver{
+		addrs: map[string][]net.IPAddr{
+			"www.rottentomatoes.com": {{IP: net.ParseIP("151.101.1.91")}},
+		},
+	}
+
+	ctx := WithMetadataSectionType(context.Background(), "movie")
+	metadata, err := fetcher.Fetch(ctx, "https://www.rottentomatoes.com/m/the_matrix")
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if _, ok := metadata["movie"]; !ok {
+		t.Fatalf("expected movie metadata fallback")
+	}
+}
+
 func TestFetchMetadataGeneralSectionSkipsMovieMetadata(t *testing.T) {
 	originalNewTMDBClientFromEnvFunc := newTMDBClientFromEnvFunc
 	originalNewOMDBClientFromEnvFunc := newOMDBClientFromEnvFunc


### PR DESCRIPTION
## Summary
- precompute movie metadata extraction for movie/series links and reuse it even when page fetch fails
- add fallback behavior so Rotten Tomatoes/TMDB/IMDB links still return movie metadata (including RT score) when fetch fails with network/status errors
- add backend regression tests for movie metadata fallback on request/status failures
- extend Rotten Tomatoes parser coverage to assert OMDb Rotten Tomatoes score enrichment from RT URLs

## Validation
- `cd backend && go test ./internal/services/links`
- `cd backend && go test ./internal/services/links -run 'TestFetchMetadataMovieSectionFallbacksWhenRequestFails|TestFetchMetadataMovieSectionFallbacksOnHTTPStatusError|TestParseMovieMetadataRottenTomatoesMovieURL|TestParseMovieMetadataEnrichesWithOMDBRatings' -v`
- `cd frontend && npm run check`
- `cd frontend && npm run lint`
- `cd frontend && npm run test -- src/components/__tests__/MovieCard.test.ts src/components/__tests__/PostCard.test.ts src/stores/__tests__/postMapper.test.ts`
- `task ci:prek`

Closes #977