### PR TITLE
[Books] Remove standalone Bookshelf navigation and route

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -57,14 +57,12 @@
   let sectionsLoadedForSession = false;
   let popstateHandler: (() => void) | null = null;
   let pendingSectionIdentifier: string | null = null;
-  let pendingSectionSubview: 'feed' = 'feed';
   let pendingThreadPostId: string | null = null;
   let pendingLegacyWatchlistRoute = false;
   let pendingLegacyBookshelfRoute = false;
   let pendingAdminPath = false;
   let sectionNotFound: string | null = null;
   let highlightCommentId: string | null = null;
-  let sectionSubview: 'feed' = 'feed';
   const LEGACY_BOOKSHELF_PATH = '/bookshelf';
 
   function isWatchlistSection(section: Pick<Section, 'type'> | null): boolean {
@@ -129,13 +127,11 @@
       unauthRoute = 'reset';
       resetToken = token;
       pendingSectionIdentifier = null;
-      pendingSectionSubview = 'feed';
       pendingThreadPostId = null;
       pendingLegacyWatchlistRoute = false;
       pendingLegacyBookshelfRoute = false;
       pendingAdminPath = false;
       highlightCommentId = null;
-      sectionSubview = 'feed';
       return;
     }
     if (isWatchlistPath(path)) {
@@ -143,7 +139,6 @@
       resetToken = null;
       threadRouteStore.clearTarget();
       pendingSectionIdentifier = null;
-      pendingSectionSubview = 'feed';
       pendingThreadPostId = null;
       pendingLegacyWatchlistRoute = false;
       pendingLegacyBookshelfRoute = false;
@@ -156,10 +151,8 @@
         (isWatchlistSection(get(activeSection)) ? get(activeSection) : null);
       if (preferredSection) {
         sectionStore.setActiveSection(preferredSection);
-        sectionSubview = 'feed';
         replacePath(buildFeedHref(getSectionSlug(preferredSection)));
       } else {
-        sectionSubview = 'feed';
         pendingLegacyWatchlistRoute = true;
       }
       return;
@@ -169,13 +162,11 @@
       resetToken = null;
       threadRouteStore.clearTarget();
       pendingSectionIdentifier = null;
-      pendingSectionSubview = 'feed';
       pendingThreadPostId = null;
       pendingLegacyWatchlistRoute = false;
       pendingLegacyBookshelfRoute = false;
       pendingAdminPath = false;
       highlightCommentId = null;
-      sectionSubview = 'feed';
       uiStore.setActiveView('feed');
       const availableSections = get(sections);
       const preferredBooksSection =
@@ -194,25 +185,21 @@
       uiStore.openProfile(profileUserId);
       threadRouteStore.clearTarget();
       pendingSectionIdentifier = null;
-      pendingSectionSubview = 'feed';
       pendingThreadPostId = null;
       pendingLegacyWatchlistRoute = false;
       pendingLegacyBookshelfRoute = false;
       pendingAdminPath = false;
       highlightCommentId = null;
-      sectionSubview = 'feed';
     } else {
       const standaloneThreadPostId = parseStandaloneThreadPostId(path);
       if (standaloneThreadPostId) {
         uiStore.setActiveView('thread');
         threadRouteStore.setTarget(standaloneThreadPostId, null);
         pendingSectionIdentifier = null;
-        pendingSectionSubview = 'feed';
         pendingThreadPostId = null;
         pendingLegacyWatchlistRoute = false;
         pendingLegacyBookshelfRoute = false;
         pendingAdminPath = false;
-        sectionSubview = 'feed';
         return;
       }
       const threadPostId = parseThreadPostId(path);
@@ -234,7 +221,6 @@
           pendingThreadPostId = threadPostId;
           threadRouteStore.setTarget(threadPostId, null);
         }
-        sectionSubview = 'feed';
       } else {
         threadRouteStore.clearTarget();
         highlightCommentId = null;
@@ -247,7 +233,6 @@
           if (match) {
             sectionStore.setActiveSection(match);
             const slug = getSectionSlug(match);
-            sectionSubview = 'feed';
             if (wantsSectionWatchlist) {
               replacePath(buildFeedHref(slug));
             } else if (sectionIdentifier !== slug) {
@@ -258,13 +243,10 @@
             }
           } else {
             sectionNotFound = sectionIdentifier;
-            sectionSubview = 'feed';
           }
           pendingSectionIdentifier = null;
-          pendingSectionSubview = 'feed';
         } else {
           pendingSectionIdentifier = sectionIdentifier;
-          pendingSectionSubview = 'feed';
         }
         pendingLegacyWatchlistRoute = false;
         pendingLegacyBookshelfRoute = false;
@@ -272,7 +254,6 @@
         uiStore.setActiveView(threadPostId ? 'thread' : 'feed');
       } else if (isSettingsPath(path)) {
         pendingSectionIdentifier = null;
-        pendingSectionSubview = 'feed';
         pendingThreadPostId = null;
         pendingLegacyWatchlistRoute = false;
         pendingLegacyBookshelfRoute = false;
@@ -280,15 +261,12 @@
         threadRouteStore.clearTarget();
         uiStore.setActiveView('settings');
         highlightCommentId = null;
-        sectionSubview = 'feed';
       } else if (isAdminPath(path)) {
         pendingSectionIdentifier = null;
-        pendingSectionSubview = 'feed';
         pendingThreadPostId = null;
         pendingLegacyWatchlistRoute = false;
         pendingLegacyBookshelfRoute = false;
         highlightCommentId = null;
-        sectionSubview = 'feed';
         if (get(authStore).isLoading) {
           pendingAdminPath = true;
           return;
@@ -306,14 +284,12 @@
         }
       } else {
         pendingSectionIdentifier = null;
-        pendingSectionSubview = 'feed';
         pendingThreadPostId = null;
         pendingLegacyWatchlistRoute = false;
         pendingLegacyBookshelfRoute = false;
         pendingAdminPath = false;
         uiStore.setActiveView('feed');
         highlightCommentId = null;
-        sectionSubview = 'feed';
       }
     }
     resetToken = null;
@@ -344,26 +320,22 @@
     if (match) {
       sectionStore.setActiveSection(match);
       if (pendingThreadPostId) {
-        sectionSubview = 'feed';
         threadRouteStore.setTarget(pendingThreadPostId, match.id);
         uiStore.setActiveView('thread');
         replacePath(buildThreadHref(getSectionSlug(match), pendingThreadPostId));
         pendingThreadPostId = null;
       } else if (!hasThreadTarget) {
-        sectionSubview = 'feed';
         uiStore.setActiveView('feed');
         replacePath(buildFeedHref(getSectionSlug(match)));
       }
     } else {
       sectionNotFound = pendingSectionIdentifier;
-      sectionSubview = 'feed';
       if (pendingThreadPostId) {
         threadRouteStore.clearTarget();
         pendingThreadPostId = null;
       }
     }
     pendingSectionIdentifier = null;
-    pendingSectionSubview = 'feed';
   }
 
   $: if (pendingLegacyWatchlistRoute && $sections.length > 0) {
@@ -371,11 +343,9 @@
     pendingLegacyWatchlistRoute = false;
     if (preferred) {
       sectionStore.setActiveSection(preferred);
-      sectionSubview = 'feed';
       uiStore.setActiveView('feed');
       replacePath(buildFeedHref(getSectionSlug(preferred)));
     } else {
-      sectionSubview = 'feed';
       const fallbackSection = $activeSection ?? $sections[0] ?? null;
       replacePath(buildFeedHref(fallbackSection ? getSectionSlug(fallbackSection) : null));
     }
@@ -386,11 +356,9 @@
     pendingLegacyBookshelfRoute = false;
     if (preferred) {
       sectionStore.setActiveSection(preferred);
-      sectionSubview = 'feed';
       uiStore.setActiveView('feed');
       replacePath(buildFeedHref(getSectionSlug(preferred)));
     } else {
-      sectionSubview = 'feed';
       const fallbackSection = $activeSection ?? $sections[0] ?? null;
       replacePath(buildFeedHref(fallbackSection ? getSectionSlug(fallbackSection) : null));
     }
@@ -432,7 +400,6 @@
       if ($activeSection?.id !== preferredSection.id) {
         sectionStore.setActiveSection(preferredSection);
       }
-      sectionSubview = 'feed';
       if ($activeView !== 'feed') {
         uiStore.setActiveView('feed');
       }

--- a/frontend/src/__tests__/App.bookshelf.test.ts
+++ b/frontend/src/__tests__/App.bookshelf.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 });
 
 describe('App bookshelf routing', () => {
-  it('renders bookshelf route for authenticated users', async () => {
+  it('does not treat /bookshelf as a standalone bookshelf view for authenticated users', async () => {
     stores.authStore.setUser(defaultUser);
     window.history.replaceState(null, '', '/bookshelf');
 
@@ -98,14 +98,13 @@ describe('App bookshelf routing', () => {
     window.dispatchEvent(new Event('popstate'));
 
     await waitFor(() => {
-      expect(get(stores.activeView)).toBe('bookshelf');
+      expect(get(stores.activeView)).toBe('feed');
     });
-    expect(screen.getByTestId('bookshelf-tab-my')).toBeInTheDocument();
-    expect(window.location.pathname).toBe('/bookshelf');
-    expect(document.title).toBe('Bookshelf - Clubhouse');
+    expect(screen.queryByTestId('section-tab-bookshelf')).not.toBeInTheDocument();
+    expect(document.title).toBe('Clubhouse');
   });
 
-  it('renders login for unauthenticated users on bookshelf route', async () => {
+  it('renders login for unauthenticated users on legacy bookshelf route', async () => {
     window.history.replaceState(null, '', '/bookshelf');
 
     render(App);
@@ -117,21 +116,18 @@ describe('App bookshelf routing', () => {
     expect(screen.queryByRole('heading', { name: 'Bookshelf' })).not.toBeInTheDocument();
   });
 
-  it('shows Bookshelf tab in Books section header and routes to /bookshelf', async () => {
+  it('renders Bookshelf inline in books section without a standalone tab', async () => {
     stores.authStore.setUser(defaultUser);
     window.history.replaceState(null, '', '/sections/books');
 
     render(App);
 
-    const feedTab = await screen.findByTestId('section-tab-feed');
-    const bookshelfTab = screen.getByTestId('section-tab-bookshelf');
-    expect(feedTab).toHaveAttribute('aria-selected', 'true');
+    await fireEvent.click(await screen.findByRole('button', { name: 'Books' }));
 
-    await fireEvent.click(bookshelfTab);
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/bookshelf');
+      expect(screen.getByTestId('bookshelf')).toBeInTheDocument();
     });
-    expect(bookshelfTab).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByTestId('bookshelf-tab-my')).toBeInTheDocument();
+    expect(screen.queryByTestId('section-tab-bookshelf')).not.toBeInTheDocument();
+    expect(window.location.pathname).toBe('/sections/books');
   });
 });

--- a/frontend/src/components/Nav.svelte
+++ b/frontend/src/components/Nav.svelte
@@ -10,16 +10,9 @@
     threadRouteStore,
     unreadRegistrationCount,
   } from '../stores';
-  import {
-    buildAdminHref,
-    buildBookshelfHref,
-    buildSectionHref,
-    pushPath,
-  } from '../services/routeNavigation';
+  import { buildAdminHref, buildSectionHref, pushPath } from '../services/routeNavigation';
   import type { Section } from '../stores/sectionStore';
   import NotificationSettings from './NotificationSettings.svelte';
-
-  $: hasBooksSection = $sections.some((section) => section.type === 'book');
 
   function handleSectionClick(section: Section) {
     sectionStore.setActiveSection(section);
@@ -33,13 +26,6 @@
     threadRouteStore.clearTarget();
     pushPath(buildAdminHref());
   }
-
-  function handleBookshelfClick() {
-    uiStore.setActiveView('bookshelf');
-    threadRouteStore.clearTarget();
-    pushPath(buildBookshelfHref());
-  }
-
 </script>
 
 <nav class="flex flex-col h-full" aria-label="Main navigation">
@@ -56,31 +42,16 @@
               {$activeView === 'feed' && $activeSection?.id === section.id
               ? 'bg-primary text-white'
               : 'text-gray-700 hover:bg-gray-100'}"
-            aria-current={$activeView === 'feed' && $activeSection?.id === section.id ? 'page' : undefined}
+            aria-current={$activeView === 'feed' && $activeSection?.id === section.id
+              ? 'page'
+              : undefined}
           >
             <span class="text-lg" aria-hidden="true">{section.icon}</span>
             <span>{section.name}</span>
           </button>
         </li>
       {/each}
-      {#if hasBooksSection}
-        <li>
-          <button
-            on:click={handleBookshelfClick}
-            class="w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
-              {$activeView === 'bookshelf'
-              ? 'bg-primary text-white'
-              : 'text-gray-700 hover:bg-gray-100'}"
-            aria-current={$activeView === 'bookshelf' ? 'page' : undefined}
-            data-testid="nav-bookshelf"
-          >
-            <span class="text-lg" aria-hidden="true">📚</span>
-            <span>Bookshelf</span>
-          </button>
-        </li>
-      {/if}
     </ul>
-
   </div>
 
   {#if $isAuthenticated}
@@ -96,9 +67,7 @@
       <button
         on:click={handleAdminClick}
         class="mt-3 w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-lg transition-colors
-          {$activeView === 'admin'
-          ? 'bg-amber-500 text-white'
-          : 'text-gray-700 hover:bg-amber-50'}"
+          {$activeView === 'admin' ? 'bg-amber-500 text-white' : 'text-gray-700 hover:bg-amber-50'}"
         aria-current={$activeView === 'admin' ? 'page' : undefined}
       >
         <span class="text-lg" aria-hidden="true">🛡️</span>

--- a/frontend/src/components/__tests__/Nav.test.ts
+++ b/frontend/src/components/__tests__/Nav.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, cleanup } from '@testing-library/svelte';
-import { get } from 'svelte/store';
 import { authStore, notificationStore, sectionStore, uiStore } from '../../stores';
 
 const { default: Nav } = await import('../Nav.svelte');
@@ -18,12 +17,7 @@ beforeEach(() => {
     isAdmin: true,
     totpEnabled: false,
   });
-  notificationStore.setNotifications(
-    [],
-    null,
-    false,
-    0
-  );
+  notificationStore.setNotifications([], null, false, 0);
 });
 
 afterEach(() => {
@@ -78,22 +72,7 @@ describe('Nav', () => {
     expect(screen.queryByRole('button', { name: 'My Movies' })).not.toBeInTheDocument();
   });
 
-  it('renders bookshelf entry for book communities and navigates to /bookshelf', async () => {
-    const pushStateSpy = vi.spyOn(window.history, 'pushState');
-    render(Nav);
-
-    const bookshelfButton = screen.getByRole('button', { name: 'Bookshelf' });
-    await fireEvent.click(bookshelfButton);
-
-    expect(get(uiStore).activeView).toBe('bookshelf');
-    expect(pushStateSpy).toHaveBeenCalledWith(null, '', '/bookshelf');
-  });
-
-  it('does not render bookshelf entry when there is no books section', () => {
-    sectionStore.setSections([
-      { id: 'section-1', name: 'Music', type: 'music', icon: '🎵', slug: 'music' },
-      { id: 'section-2', name: 'Movies', type: 'movie', icon: '🎬', slug: 'movies' },
-    ]);
+  it('does not render a standalone Bookshelf navigation entry', () => {
     render(Nav);
 
     expect(screen.queryByRole('button', { name: 'Bookshelf' })).not.toBeInTheDocument();

--- a/frontend/src/services/__tests__/routeNavigation.test.ts
+++ b/frontend/src/services/__tests__/routeNavigation.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAdminHref,
-  buildBookshelfHref,
   buildFeedHref,
   buildSectionWatchlistHref,
   buildSectionHref,
@@ -10,7 +9,6 @@ import {
   buildWatchlistHref,
   buildThreadHref,
   isAdminPath,
-  isBookshelfPath,
   isSettingsPath,
   isWatchlistPath,
   parseSectionWatchlistSlug,
@@ -74,13 +72,6 @@ describe('routeNavigation', () => {
     expect(isWatchlistPath('/watchlist')).toBe(true);
     expect(isWatchlistPath('/watchlist/favorites')).toBe(true);
     expect(isWatchlistPath('/sections/movies')).toBe(false);
-  });
-
-  it('builds bookshelf hrefs and recognizes bookshelf paths', () => {
-    expect(buildBookshelfHref()).toBe('/bookshelf');
-    expect(isBookshelfPath('/bookshelf')).toBe(true);
-    expect(isBookshelfPath('/bookshelf/all')).toBe(true);
-    expect(isBookshelfPath('/sections/books')).toBe(false);
   });
 
   it('builds and parses section watchlist hrefs', () => {

--- a/frontend/src/services/routeNavigation.ts
+++ b/frontend/src/services/routeNavigation.ts
@@ -4,7 +4,6 @@ const THREAD_PATH_SEGMENT = '/posts/';
 const ADMIN_PATH = '/admin';
 const SETTINGS_PATH = '/settings';
 const WATCHLIST_PATH = '/watchlist';
-const BOOKSHELF_PATH = '/bookshelf';
 const WATCHLIST_SEGMENT = WATCHLIST_PATH.slice(1);
 
 export type SearchHistoryState = {
@@ -105,10 +104,6 @@ export function buildWatchlistHref(): string {
   return WATCHLIST_PATH;
 }
 
-export function buildBookshelfHref(): string {
-  return BOOKSHELF_PATH;
-}
-
 export function isAdminPath(pathname: string): boolean {
   return pathname === ADMIN_PATH || pathname.startsWith(`${ADMIN_PATH}/`);
 }
@@ -119,10 +114,6 @@ export function isSettingsPath(pathname: string): boolean {
 
 export function isWatchlistPath(pathname: string): boolean {
   return pathname === WATCHLIST_PATH || pathname.startsWith(`${WATCHLIST_PATH}/`);
-}
-
-export function isBookshelfPath(pathname: string): boolean {
-  return pathname === BOOKSHELF_PATH || pathname.startsWith(`${BOOKSHELF_PATH}/`);
 }
 
 export function buildFeedHref(sectionSlug?: string | null): string {
@@ -154,9 +145,5 @@ export function updateHistoryState(nextState: Partial<AppHistoryState>): void {
   if ('fromSearch' in nextState && nextState.fromSearch === undefined) {
     delete merged.fromSearch;
   }
-  window.history.replaceState(
-    merged,
-    '',
-    window.location.pathname + window.location.search
-  );
+  window.history.replaceState(merged, '', window.location.pathname + window.location.search);
 }

--- a/frontend/src/stores/__tests__/uiStore.test.ts
+++ b/frontend/src/stores/__tests__/uiStore.test.ts
@@ -33,11 +33,6 @@ describe('uiStore', () => {
     expect(get(uiStore).activeView).toBe('admin');
   });
 
-  it('setActiveView supports bookshelf view', () => {
-    uiStore.setActiveView('bookshelf');
-    expect(get(uiStore).activeView).toBe('bookshelf');
-  });
-
   it('openProfile sets profile view and active user', () => {
     uiStore.openProfile('user-42');
     const state = get(uiStore);

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -3,7 +3,7 @@ import { writable, derived } from 'svelte/store';
 interface UIState {
   sidebarOpen: boolean;
   isMobile: boolean;
-  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread' | 'bookshelf';
+  activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread';
   activeProfileUserId: string | null;
 }
 
@@ -25,7 +25,7 @@ function createUIStore() {
         isMobile,
         sidebarOpen: isMobile ? false : state.sidebarOpen,
       })),
-    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread' | 'bookshelf') =>
+    setActiveView: (activeView: 'feed' | 'admin' | 'profile' | 'settings' | 'thread') =>
       update((state) => ({
         ...state,
         activeView,
@@ -43,7 +43,4 @@ function createUIStore() {
 export const uiStore = createUIStore();
 
 export const activeView = derived(uiStore, ($uiStore) => $uiStore.activeView);
-export const activeProfileUserId = derived(
-  uiStore,
-  ($uiStore) => $uiStore.activeProfileUserId
-);
+export const activeProfileUserId = derived(uiStore, ($uiStore) => $uiStore.activeProfileUserId);


### PR DESCRIPTION
## Summary
- remove standalone `Bookshelf` entry from sidebar navigation
- remove standalone `/bookshelf` routing state from frontend navigation helpers and app view state
- render `Bookshelf` inline at the top of the books section feed (same placement pattern as other section-specific top components)
- keep legacy `/bookshelf` handling from opening a standalone view and route it through normal feed state

## Tests
- `cd frontend && npm run check`
- `cd frontend && npm run test`

Closes #979 