### PR TITLE
[Podcasts] Fix PodcastsTopContainer not updating immediately when saving links

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -2249,7 +2249,7 @@
 
       {#if isPodcastSection}
         <div class="mt-3">
-          <PodcastSaveButton postId={post.id} />
+          <PodcastSaveButton postId={post.id} {post} />
         </div>
       {/if}
 

--- a/frontend/src/stores/podcastStore.ts
+++ b/frontend/src/stores/podcastStore.ts
@@ -55,6 +55,17 @@ function dedupePosts(existing: Post[], nextPosts: Post[]): Post[] {
   return merged;
 }
 
+function upsertSavedPost(posts: Post[], post: Post): Post[] {
+  const existingIndex = posts.findIndex((item) => item.id === post.id);
+  if (existingIndex === -1) {
+    return [post, ...posts];
+  }
+
+  const nextPosts = [...posts];
+  nextPosts[existingIndex] = post;
+  return nextPosts;
+}
+
 function dedupeRecentPodcasts(
   existing: RecentPodcastItem[],
   nextItems: RecentPodcastItem[]
@@ -210,6 +221,17 @@ function createPodcastStore() {
           hasMore,
           isLoadingSaved: false,
           error: null,
+        };
+      }),
+    addSavedPost: (post: Post) =>
+      update((state) => {
+        const mergedPosts = upsertSavedPost(state.savedPosts, post);
+        const nextSavedIds = new Set(state.savedPostIds);
+        nextSavedIds.add(post.id);
+        return {
+          ...state,
+          savedPosts: mergedPosts,
+          savedPostIds: nextSavedIds,
         };
       }),
     removeSavedPost: (postId: string) =>


### PR DESCRIPTION
## Summary
- make podcast saves update `podcastStore.savedPosts` optimistically so the Saved tab reflects changes immediately
- pass the current `post` into `PodcastSaveButton` so newly saved podcasts can be inserted into the local saved list without waiting for a reload
- keep optimistic behavior safe by rolling back `savedPosts` and save info on API errors for both save and unsave flows
- add component tests covering immediate save/unsave list updates and rollback behavior

## Testing
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/PodcastSaveButton.test.ts src/stores/__tests__/podcastStore.test.ts src/components/__tests__/PodcastsTopContainer.test.ts`

Closes #982