### PR TITLE
[Podcasts] Fix saved podcast state not persisting after page refresh

### DIFF
--- a/frontend/src/components/__tests__/PodcastSaveButton.test.ts
+++ b/frontend/src/components/__tests__/PodcastSaveButton.test.ts
@@ -65,6 +65,19 @@ afterEach(() => {
 });
 
 describe('PodcastSaveButton', () => {
+  it('renders saved state from store-backed saved post IDs on initial render', () => {
+    podcastStore.setSavedPosts([buildPost('post-1')], null, false, 'section-podcast');
+
+    render(PodcastSaveButton, {
+      postId: 'post-1',
+      initialSaved: false,
+      initialSaveCount: 0,
+    });
+
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    expect(screen.getByTestId('podcast-save-count')).toHaveTextContent('1');
+  });
+
   it('renders unsaved state', () => {
     render(PodcastSaveButton, { postId: 'post-1' });
 

--- a/frontend/src/components/podcasts/PodcastSaveButton.svelte
+++ b/frontend/src/components/podcasts/PodcastSaveButton.svelte
@@ -2,7 +2,11 @@
   import type { PostPodcastSaveInfo } from '../../services/api';
   import { api } from '../../services/api';
   import type { Post } from '../../stores/postStore';
-  import { podcastSaveInfoByPostId, podcastStore } from '../../stores/podcastStore';
+  import {
+    podcastSaveInfoByPostId,
+    podcastStore,
+    savedPodcastPostIds,
+  } from '../../stores/podcastStore';
 
   export let postId: string;
   export let post: Post | null = null;
@@ -21,7 +25,10 @@
   }
 
   $: storeInfo = $podcastSaveInfoByPostId[postId];
-  $: effectiveInfo = storeInfo ?? fallbackInfo;
+  $: storeSaved = $savedPodcastPostIds.has(postId);
+  $: fallbackSaved = fallbackInfo.viewerSaved || storeSaved;
+  $: fallbackCount = fallbackSaved ? Math.max(1, fallbackInfo.saveCount) : fallbackInfo.saveCount;
+  $: effectiveInfo = storeInfo ?? buildSaveInfo(fallbackSaved, fallbackCount);
   $: isSaved = Boolean(effectiveInfo.viewerSaved);
   $: displayedSaveCount = clampCount(effectiveInfo.saveCount);
 


### PR DESCRIPTION
## Summary
- update `PodcastSaveButton` to derive saved state from `savedPodcastPostIds` so buttons render persisted saved state immediately after store hydration
- add a button-level test that simulates refreshed state from saved-post store data
- add a `PodcastsTopContainer` mount-cycle test to verify saved podcasts are re-fetched and rendered again after unmount/remount

## Validation
- `cd frontend && npm run lint`
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/PodcastSaveButton.test.ts src/components/__tests__/PodcastsTopContainer.test.ts src/stores/__tests__/podcastStore.test.ts`
- `cd frontend && npm run test`

Closes #983