### PR TITLE
[Podcasts] Fix PodcastsTopContainer not showing Episode entries

### DIFF
--- a/backend/internal/handlers/section_test.go
+++ b/backend/internal/handlers/section_test.go
@@ -299,6 +299,9 @@ func TestGetRecentPodcastsSuccess(t *testing.T) {
 	if response.Items[0].Podcast.Kind != "show" {
 		t.Fatalf("expected podcast kind show, got %q", response.Items[0].Podcast.Kind)
 	}
+	if response.Items[0].Title != "Start Here" {
+		t.Fatalf("expected recent podcast title Start Here, got %q", response.Items[0].Title)
+	}
 	if len(response.Items[0].Podcast.HighlightEpisodes) != 1 {
 		t.Fatalf("expected one highlight episode")
 	}

--- a/backend/internal/models/link.go
+++ b/backend/internal/models/link.go
@@ -29,6 +29,7 @@ type RecentPodcastItem struct {
 	PostID        uuid.UUID       `json:"post_id"`
 	LinkID        uuid.UUID       `json:"link_id"`
 	URL           string          `json:"url"`
+	Title         string          `json:"title,omitempty"`
 	Podcast       PodcastMetadata `json:"podcast"`
 	UserID        uuid.UUID       `json:"user_id"`
 	Username      string          `json:"username"`

--- a/frontend/src/components/__tests__/PodcastsTopContainer.test.ts
+++ b/frontend/src/components/__tests__/PodcastsTopContainer.test.ts
@@ -103,6 +103,17 @@ describe('PodcastsTopContainer', () => {
           postCreatedAt: '2026-02-10T10:00:00Z',
           linkCreatedAt: '2026-02-10T10:01:00Z',
         },
+        {
+          postId: 'post-2',
+          linkId: 'link-2',
+          url: 'https://example.com/podcast/episode-42',
+          title: 'Episode 42: Debugging',
+          podcast: { kind: 'episode' },
+          userId: 'user-2',
+          username: 'taylor',
+          postCreatedAt: '2026-02-10T10:02:00Z',
+          linkCreatedAt: '2026-02-10T10:03:00Z',
+        },
       ],
       hasMore: false,
       nextCursor: undefined,
@@ -118,6 +129,8 @@ describe('PodcastsTopContainer', () => {
 
     expect(await screen.findByTestId('podcasts-recent-list')).toBeInTheDocument();
     expect(screen.getByText('Show')).toBeInTheDocument();
+    expect(screen.getByText('Episode 42: Debugging')).toBeInTheDocument();
+    expect(screen.getByText('Episode')).toBeInTheDocument();
 
     await fireEvent.click(screen.getByTestId('podcasts-mode-saved'));
 

--- a/frontend/src/components/podcasts/PodcastsTopContainer.svelte
+++ b/frontend/src/components/podcasts/PodcastsTopContainer.svelte
@@ -72,6 +72,10 @@
     if (firstHighlight) {
       return firstHighlight;
     }
+    const metadataTitle = item.title?.trim();
+    if (metadataTitle) {
+      return metadataTitle;
+    }
     const kind = normalizeKind(item.podcast.kind);
     if (kind === 'show') {
       return 'Podcast show';

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -499,6 +499,7 @@ describe('api client', () => {
             post_id: 'post-1',
             link_id: 'link-1',
             url: 'https://example.com/show',
+            title: 'Show Title',
             podcast: {
               kind: 'SHOW',
               highlight_episodes: [
@@ -533,6 +534,7 @@ describe('api client', () => {
       postId: 'post-1',
       linkId: 'link-1',
       url: 'https://example.com/show',
+      title: 'Show Title',
       podcast: {
         kind: 'show',
         highlightEpisodes: [

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -144,6 +144,7 @@ interface ApiRecentPodcastItem {
   post_id: string;
   link_id: string;
   url: string;
+  title?: string;
   podcast?: ApiPodcastMetadataResponse;
   user_id: string;
   username: string;
@@ -430,10 +431,12 @@ function mapApiPodcastMetadata(podcast?: ApiPodcastMetadataResponse): PodcastMet
 }
 
 function mapApiRecentPodcastItem(item: ApiRecentPodcastItem): RecentPodcastItem {
+  const title = typeof item.title === 'string' ? item.title.trim() : '';
   return {
     postId: item.post_id,
     linkId: item.link_id,
     url: item.url,
+    ...(title ? { title } : {}),
     podcast: mapApiPodcastMetadata(item.podcast),
     userId: item.user_id,
     username: item.username,
@@ -674,6 +677,7 @@ export interface RecentPodcastItem {
   postId: string;
   linkId: string;
   url: string;
+  title?: string;
   podcast: PodcastMetadata;
   userId: string;
   username: string;


### PR DESCRIPTION
## Summary
- include `title` in recent podcasts API items, sourced from highlighted episode title or metadata title
- backfill missing podcast kind in recent podcasts service using existing detection heuristics so episode links with empty `podcast.kind` are no longer dropped
- update `PodcastsTopContainer` to use API-provided recent item titles before fallback labels
- add backend and frontend tests for episode-kind/title behavior in recent podcasts

## Validation
- `cd backend && go test ./internal/services -run 'TestSectionServiceGetRecentPodcasts(PaginationDeterministic|DetectsEpisodeKindAndTitle|Empty|InvalidCursor|InvalidSectionType)' -count=1`
- `cd backend && go test ./internal/handlers -run 'TestGetRecentPodcasts(Success|InvalidCursor|InvalidSectionType)' -count=1`
- `cd frontend && npm run test -- src/components/__tests__/PodcastsTopContainer.test.ts src/services/__tests__/api.test.ts`
- `cd frontend && npm run check`
- `task ci:prek`

Closes #984