### PR TITLE
[Books] Make Bookshelf a collapsible component like Cookbook

### DIFF
--- a/frontend/src/components/books/Bookshelf.svelte
+++ b/frontend/src/components/books/Bookshelf.svelte
@@ -61,6 +61,7 @@
 
   let activeTab: TabKey = 'my';
   let selectedCategory = ALL_CATEGORY_VALUE;
+  let isCollapsed = false;
   let myHasMore = false;
   let allHasMore = false;
   let hasLoadedAllTab = false;
@@ -98,7 +99,8 @@
   $: totalSavedCount = Array.from(categoryCounts.values()).reduce((sum, count) => sum + count, 0);
   $: categoryOptions = buildCategoryOptions(customCategories);
   $: selectedCategoryLabel =
-    categoryOptions.find((option) => option.value === selectedCategory)?.label ?? ALL_CATEGORY_LABEL;
+    categoryOptions.find((option) => option.value === selectedCategory)?.label ??
+    ALL_CATEGORY_LABEL;
   $: displayCategoryError = localCategoryError ?? $bookStoreMeta.error;
 
   $: if (
@@ -251,7 +253,9 @@
     return {
       title,
       ...(rawBook?.description ? { description: rawBook.description } : {}),
-      ...(metadata?.description && !rawBook?.description ? { description: metadata.description } : {}),
+      ...(metadata?.description && !rawBook?.description
+        ? { description: metadata.description }
+        : {}),
       ...(rawBook?.coverUrl ? { coverUrl: rawBook.coverUrl } : {}),
       ...(rawBook?.cover_url ? { cover_url: rawBook.cover_url } : {}),
       ...(metadata?.image && !rawBook?.coverUrl && !rawBook?.cover_url
@@ -261,13 +265,19 @@
       ...(typeof rawBook?.page_count === 'number' ? { page_count: rawBook.page_count } : {}),
       ...(typeof rawBook?.publishDate === 'string' ? { publishDate: rawBook.publishDate } : {}),
       ...(typeof rawBook?.publish_date === 'string' ? { publish_date: rawBook.publish_date } : {}),
-      ...(typeof rawBook?.openLibraryKey === 'string' ? { openLibraryKey: rawBook.openLibraryKey } : {}),
+      ...(typeof rawBook?.openLibraryKey === 'string'
+        ? { openLibraryKey: rawBook.openLibraryKey }
+        : {}),
       ...(typeof rawBook?.open_library_key === 'string'
         ? { open_library_key: rawBook.open_library_key }
         : {}),
       ...(typeof rawBook?.goodreadsUrl === 'string' ? { goodreadsUrl: rawBook.goodreadsUrl } : {}),
-      ...(typeof rawBook?.goodreads_url === 'string' ? { goodreads_url: rawBook.goodreads_url } : {}),
-      ...(normalizeStringArray(rawBook?.genres) ? { genres: normalizeStringArray(rawBook?.genres) } : {}),
+      ...(typeof rawBook?.goodreads_url === 'string'
+        ? { goodreads_url: rawBook.goodreads_url }
+        : {}),
+      ...(normalizeStringArray(rawBook?.genres)
+        ? { genres: normalizeStringArray(rawBook?.genres) }
+        : {}),
       ...(normalizeStringArray(rawBook?.authors)
         ? { authors: normalizeStringArray(rawBook?.authors) }
         : parseAuthors(metadata?.author)
@@ -310,7 +320,7 @@
       return;
     }
 
-    const cursor = reset ? undefined : get(bookStoreMeta).cursors.myBookshelf ?? undefined;
+    const cursor = reset ? undefined : (get(bookStoreMeta).cursors.myBookshelf ?? undefined);
     const nextCursor = await bookStore.loadMyBookshelf(undefined, cursor);
     myHasMore = Boolean(nextCursor);
   }
@@ -324,7 +334,7 @@
       hasLoadedAllTab = true;
     }
 
-    const cursor = reset ? undefined : get(bookStoreMeta).cursors.allBookshelf ?? undefined;
+    const cursor = reset ? undefined : (get(bookStoreMeta).cursors.allBookshelf ?? undefined);
     const nextCursor = await bookStore.loadAllBookshelf(undefined, cursor);
     allHasMore = Boolean(nextCursor);
   }
@@ -577,9 +587,22 @@
 
 <section class="rounded-2xl border border-gray-200 bg-white shadow-sm" data-testid="bookshelf">
   <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 px-4 py-3">
-    <div>
-      <h2 class="text-base font-semibold text-gray-900">Bookshelf</h2>
-      <p class="text-xs text-gray-500">Save books you want to remember and discover community picks.</p>
+    <div class="flex items-center gap-3">
+      <div>
+        <h2 class="text-base font-semibold text-gray-900">Bookshelf</h2>
+        <p class="text-xs text-gray-500">
+          Save books you want to remember and discover community picks.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="rounded-full border border-gray-200 px-3 py-1 text-xs font-semibold text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+        on:click={() => (isCollapsed = !isCollapsed)}
+        data-testid="bookshelf-collapse"
+        aria-expanded={!isCollapsed}
+      >
+        {isCollapsed ? 'Expand' : 'Collapse'}
+      </button>
     </div>
 
     <div class="flex items-center gap-2" role="tablist" aria-label="Bookshelf views">
@@ -610,296 +633,323 @@
     </div>
   </div>
 
-  <div class="p-4">
-    {#if activeTab === 'my'}
-      <div class="flex flex-col gap-4 lg:flex-row">
-        <aside class="lg:w-72" data-testid="bookshelf-category-panel">
-          <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
-            <div class="flex items-center justify-between">
-              <h3 class="text-sm font-semibold text-gray-900">Categories</h3>
-              <span class="text-xs text-gray-500">{totalSavedCount} books</span>
-            </div>
+  {#if !isCollapsed}
+    <div class="p-4">
+      {#if activeTab === 'my'}
+        <div class="flex flex-col gap-4 lg:flex-row">
+          <aside class="lg:w-72" data-testid="bookshelf-category-panel">
+            <div class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+              <div class="flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-gray-900">Categories</h3>
+                <span class="text-xs text-gray-500">{totalSavedCount} books</span>
+              </div>
 
-            <div class="mt-3 space-y-1">
-              {#each categoryOptions as option}
-                <div class="rounded-lg" data-testid={`bookshelf-category-row-${option.value}`}>
-                  {#if editingCategoryID === option.category?.id}
-                    <div class="flex flex-wrap items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2">
-                      <input
-                        class="min-w-[8rem] flex-1 rounded-md border border-blue-300 px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
-                        type="text"
-                        bind:value={editingCategoryName}
-                        placeholder="Category name"
-                        data-testid="bookshelf-category-edit-input"
-                      />
-                      <button
-                        type="button"
-                        class="rounded-md bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-                        on:click={confirmEditCategory}
-                        disabled={isCategoryActionBusy}
-                        data-testid="bookshelf-category-edit-save"
+              <div class="mt-3 space-y-1">
+                {#each categoryOptions as option}
+                  <div class="rounded-lg" data-testid={`bookshelf-category-row-${option.value}`}>
+                    {#if editingCategoryID === option.category?.id}
+                      <div
+                        class="flex flex-wrap items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2"
                       >
-                        {isCategoryActionBusy ? 'Saving...' : 'Save'}
-                      </button>
-                      <button
-                        type="button"
-                        class="rounded-md border border-blue-200 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-60"
-                        on:click={cancelEditCategory}
-                        disabled={isCategoryActionBusy}
-                        data-testid="bookshelf-category-edit-cancel"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  {:else}
-                    <div
-                      class="group flex items-center gap-1"
-                      role="listitem"
-                      data-testid={option.category ? `bookshelf-custom-category-${option.category.id}` : undefined}
-                      draggable={Boolean(option.category)}
-                      on:dragstart={() => option.category && handleCategoryDragStart(option.category.id)}
-                      on:dragend={handleCategoryDragEnd}
-                      on:dragover={handleCategoryDragOver}
-                      on:drop={() => option.category && handleCategoryDrop(option.category.id)}
-                    >
-                      <button
-                        type="button"
-                        class={`flex flex-1 items-center justify-between rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-                          selectedCategory === option.value
-                            ? 'bg-blue-50 text-blue-700'
-                            : 'text-gray-600 hover:bg-gray-100'
-                        }`}
-                        on:click={() => handleCategorySelect(option.value)}
-                        data-testid={`bookshelf-category-${option.value}`}
-                      >
-                        <span>{option.label}</span>
-                        <span class="rounded-full bg-white px-2 py-0.5 text-[11px] text-gray-500">
-                          {option.value === ALL_CATEGORY_VALUE
-                            ? totalSavedCount
-                            : (categoryCounts.get(option.value) ?? 0)}
-                        </span>
-                      </button>
-
-                      {#if option.category}
-                        <div class="hidden items-center gap-1 group-hover:flex">
-                          <button
-                            type="button"
-                            class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            on:click={() => startEditCategory(option.category)}
-                            disabled={isCategoryActionBusy}
-                            aria-label={`Edit ${option.category.name}`}
-                            data-testid={`bookshelf-category-edit-${option.category.id}`}
-                          >
-                            Edit
-                          </button>
-                          <button
-                            type="button"
-                            class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-                            on:click={() => startDeleteCategory(option.category)}
-                            disabled={isCategoryActionBusy}
-                            aria-label={`Delete ${option.category.name}`}
-                            data-testid={`bookshelf-category-delete-${option.category.id}`}
-                          >
-                            Delete
-                          </button>
-                        </div>
-                      {/if}
-                    </div>
-                  {/if}
-
-                  {#if deleteCategoryID === option.category?.id}
-                    <div
-                      class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900"
-                      data-testid="bookshelf-category-delete-confirm"
-                    >
-                      <p>
-                        Delete <span class="font-semibold">{deleteCategoryName}</span>? Books in this category will
-                        move to <span class="font-semibold">{UNCATEGORIZED_CATEGORY}</span>.
-                      </p>
-                      <div class="mt-2 flex items-center gap-2">
+                        <input
+                          class="min-w-[8rem] flex-1 rounded-md border border-blue-300 px-2 py-1 text-xs focus:border-blue-500 focus:outline-none"
+                          type="text"
+                          bind:value={editingCategoryName}
+                          placeholder="Category name"
+                          data-testid="bookshelf-category-edit-input"
+                        />
                         <button
                           type="button"
-                          class="rounded-md bg-amber-600 px-2 py-1 text-xs font-semibold text-white hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
-                          on:click={confirmDeleteCategory}
+                          class="rounded-md bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                          on:click={confirmEditCategory}
                           disabled={isCategoryActionBusy}
-                          data-testid="bookshelf-category-delete-confirm-button"
+                          data-testid="bookshelf-category-edit-save"
                         >
-                          {isCategoryActionBusy ? 'Deleting...' : 'Delete'}
+                          {isCategoryActionBusy ? 'Saving...' : 'Save'}
                         </button>
                         <button
                           type="button"
-                          class="rounded-md border border-amber-200 px-2 py-1 text-xs text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
-                          on:click={cancelDeleteCategory}
+                          class="rounded-md border border-blue-200 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-60"
+                          on:click={cancelEditCategory}
                           disabled={isCategoryActionBusy}
-                          data-testid="bookshelf-category-delete-cancel-button"
+                          data-testid="bookshelf-category-edit-cancel"
                         >
                           Cancel
                         </button>
                       </div>
-                    </div>
-                  {/if}
-                </div>
-              {/each}
-            </div>
+                    {:else}
+                      <div
+                        class="group flex items-center gap-1"
+                        role="listitem"
+                        data-testid={option.category
+                          ? `bookshelf-custom-category-${option.category.id}`
+                          : undefined}
+                        draggable={Boolean(option.category)}
+                        on:dragstart={() =>
+                          option.category && handleCategoryDragStart(option.category.id)}
+                        on:dragend={handleCategoryDragEnd}
+                        on:dragover={handleCategoryDragOver}
+                        on:drop={() => option.category && handleCategoryDrop(option.category.id)}
+                      >
+                        <button
+                          type="button"
+                          class={`flex flex-1 items-center justify-between rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+                            selectedCategory === option.value
+                              ? 'bg-blue-50 text-blue-700'
+                              : 'text-gray-600 hover:bg-gray-100'
+                          }`}
+                          on:click={() => handleCategorySelect(option.value)}
+                          data-testid={`bookshelf-category-${option.value}`}
+                        >
+                          <span>{option.label}</span>
+                          <span class="rounded-full bg-white px-2 py-0.5 text-[11px] text-gray-500">
+                            {option.value === ALL_CATEGORY_VALUE
+                              ? totalSavedCount
+                              : (categoryCounts.get(option.value) ?? 0)}
+                          </span>
+                        </button>
 
-            {#if isCreateCategoryOpen}
-              <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-2">
-                <input
-                  type="text"
-                  class="w-full rounded-md border border-gray-300 px-2 py-1 text-xs"
-                  placeholder="Category name"
-                  bind:value={createCategoryName}
-                  data-testid="bookshelf-category-create-input"
-                />
-                <div class="mt-2 flex items-center gap-2">
-                  <button
-                    type="button"
-                    class="rounded-md bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-                    on:click={confirmCreateCategory}
-                    disabled={isCategoryActionBusy}
-                    data-testid="bookshelf-category-create-save"
-                  >
-                    {isCategoryActionBusy ? 'Saving...' : 'Save'}
-                  </button>
-                  <button
-                    type="button"
-                    class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
-                    on:click={cancelCreateCategory}
-                    disabled={isCategoryActionBusy}
-                    data-testid="bookshelf-category-create-cancel"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                        {#if option.category}
+                          <div class="hidden items-center gap-1 group-hover:flex">
+                            <button
+                              type="button"
+                              class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              on:click={() => startEditCategory(option.category)}
+                              disabled={isCategoryActionBusy}
+                              aria-label={`Edit ${option.category.name}`}
+                              data-testid={`bookshelf-category-edit-${option.category.id}`}
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              class="rounded-md border border-gray-200 px-1.5 py-1 text-[11px] text-gray-500 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                              on:click={() => startDeleteCategory(option.category)}
+                              disabled={isCategoryActionBusy}
+                              aria-label={`Delete ${option.category.name}`}
+                              data-testid={`bookshelf-category-delete-${option.category.id}`}
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        {/if}
+                      </div>
+                    {/if}
+
+                    {#if deleteCategoryID === option.category?.id}
+                      <div
+                        class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+                        data-testid="bookshelf-category-delete-confirm"
+                      >
+                        <p>
+                          Delete <span class="font-semibold">{deleteCategoryName}</span>? Books in
+                          this category will move to
+                          <span class="font-semibold">{UNCATEGORIZED_CATEGORY}</span>.
+                        </p>
+                        <div class="mt-2 flex items-center gap-2">
+                          <button
+                            type="button"
+                            class="rounded-md bg-amber-600 px-2 py-1 text-xs font-semibold text-white hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+                            on:click={confirmDeleteCategory}
+                            disabled={isCategoryActionBusy}
+                            data-testid="bookshelf-category-delete-confirm-button"
+                          >
+                            {isCategoryActionBusy ? 'Deleting...' : 'Delete'}
+                          </button>
+                          <button
+                            type="button"
+                            class="rounded-md border border-amber-200 px-2 py-1 text-xs text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                            on:click={cancelDeleteCategory}
+                            disabled={isCategoryActionBusy}
+                            data-testid="bookshelf-category-delete-cancel-button"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    {/if}
+                  </div>
+                {/each}
               </div>
-            {:else}
-              <button
-                type="button"
-                class="mt-3 w-full rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-semibold text-gray-600 hover:border-gray-400 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-                on:click={startCreateCategory}
-                disabled={isCategoryActionBusy}
-                data-testid="bookshelf-category-create"
-              >
-                + Create category
-              </button>
-            {/if}
 
-            {#if displayCategoryError}
-              <div
-                class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
-                data-testid="bookshelf-category-error"
-              >
-                {displayCategoryError}
-              </div>
-            {/if}
-          </div>
-        </aside>
-
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center justify-between">
-            <div>
-              <h3 class="text-sm font-semibold text-gray-900">{selectedCategoryLabel}</h3>
-              <p class="text-xs text-gray-500">Books you have saved from book posts.</p>
-            </div>
-            <span class="text-xs text-gray-400">{myBookItems.length} books</span>
-          </div>
-
-          {#if myBookItems.length === 0}
-            <div
-              class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
-              data-testid="bookshelf-my-empty"
-            >
-              {#if totalSavedCount === 0}
-                <p>No books saved yet</p>
-                <p class="mt-1 text-xs text-gray-500">Save books from book posts to build your shelf.</p>
-              {:else if selectedCategory !== ALL_CATEGORY_VALUE}
-                <p>No books in this category</p>
+              {#if isCreateCategoryOpen}
+                <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-2">
+                  <input
+                    type="text"
+                    class="w-full rounded-md border border-gray-300 px-2 py-1 text-xs"
+                    placeholder="Category name"
+                    bind:value={createCategoryName}
+                    data-testid="bookshelf-category-create-input"
+                  />
+                  <div class="mt-2 flex items-center gap-2">
+                    <button
+                      type="button"
+                      class="rounded-md bg-blue-600 px-2 py-1 text-xs font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                      on:click={confirmCreateCategory}
+                      disabled={isCategoryActionBusy}
+                      data-testid="bookshelf-category-create-save"
+                    >
+                      {isCategoryActionBusy ? 'Saving...' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      on:click={cancelCreateCategory}
+                      disabled={isCategoryActionBusy}
+                      data-testid="bookshelf-category-create-cancel"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
               {:else}
-                <p>No books saved yet</p>
+                <button
+                  type="button"
+                  class="mt-3 w-full rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-semibold text-gray-600 hover:border-gray-400 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  on:click={startCreateCategory}
+                  disabled={isCategoryActionBusy}
+                  data-testid="bookshelf-category-create"
+                >
+                  + Create category
+                </button>
+              {/if}
+
+              {#if displayCategoryError}
+                <div
+                  class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700"
+                  data-testid="bookshelf-category-error"
+                >
+                  {displayCategoryError}
+                </div>
               {/if}
             </div>
+          </aside>
+
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center justify-between">
+              <div>
+                <h3 class="text-sm font-semibold text-gray-900">{selectedCategoryLabel}</h3>
+                <p class="text-xs text-gray-500">Books you have saved from book posts.</p>
+              </div>
+              <span class="text-xs text-gray-400">{myBookItems.length} books</span>
+            </div>
+
+            {#if myBookItems.length === 0}
+              <div
+                class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+                data-testid="bookshelf-my-empty"
+              >
+                {#if totalSavedCount === 0}
+                  <p>No books saved yet</p>
+                  <p class="mt-1 text-xs text-gray-500">
+                    Save books from book posts to build your shelf.
+                  </p>
+                {:else if selectedCategory !== ALL_CATEGORY_VALUE}
+                  <p>No books in this category</p>
+                {:else}
+                  <p>No books saved yet</p>
+                {/if}
+              </div>
+            {:else}
+              <div
+                class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2"
+                data-testid="bookshelf-my-grid"
+              >
+                {#each myBookItems as bookItem (bookItem.item.id)}
+                  <div
+                    class="rounded-xl border border-gray-200 bg-white p-2 shadow-sm"
+                    data-testid={`bookshelf-my-item-${bookItem.item.postId}`}
+                  >
+                    <BookCard
+                      bookData={bookItem.bookData}
+                      compact={true}
+                      threadHref={bookItem.threadHref}
+                    />
+                  </div>
+                {/each}
+              </div>
+            {/if}
+
+            {#if myHasMore}
+              <div class="mt-4 flex justify-center">
+                <button
+                  type="button"
+                  class="rounded-lg border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  on:click={() => void loadMyBooks(false)}
+                  disabled={$bookStoreMeta.loading.myBookshelf}
+                  data-testid="bookshelf-my-load-more"
+                >
+                  {$bookStoreMeta.loading.myBookshelf ? 'Loading...' : 'Load more'}
+                </button>
+              </div>
+            {/if}
+          </div>
+        </div>
+      {:else}
+        <div>
+          <div class="flex items-center justify-between">
+            <div>
+              <h3 class="text-sm font-semibold text-gray-900">All Books</h3>
+              <p class="text-xs text-gray-500">See what everyone in your community has saved.</p>
+            </div>
+            <span class="text-xs text-gray-400">{allBookItems.length} saved</span>
+          </div>
+
+          {#if $bookStoreMeta.loading.allBookshelf && allBookItems.length === 0}
+            <div
+              class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+              data-testid="bookshelf-all-loading"
+            >
+              Loading books...
+            </div>
+          {:else if allBookItems.length === 0}
+            <div
+              class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
+              data-testid="bookshelf-all-empty"
+            >
+              No books saved yet
+            </div>
           {:else}
-            <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2" data-testid="bookshelf-my-grid">
-              {#each myBookItems as bookItem (bookItem.item.id)}
+            <div
+              class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2"
+              data-testid="bookshelf-all-grid"
+            >
+              {#each allBookItems as bookItem (bookItem.item.id)}
                 <div
                   class="rounded-xl border border-gray-200 bg-white p-2 shadow-sm"
-                  data-testid={`bookshelf-my-item-${bookItem.item.postId}`}
+                  data-testid={`bookshelf-all-item-${bookItem.item.postId}`}
                 >
-                  <BookCard bookData={bookItem.bookData} compact={true} threadHref={bookItem.threadHref} />
+                  <p
+                    class="mb-2 text-xs font-medium text-gray-500"
+                    data-testid={`bookshelf-saver-${bookItem.item.id}`}
+                  >
+                    Saved by {bookItem.saverLabel}
+                  </p>
+                  <BookCard
+                    bookData={bookItem.bookData}
+                    compact={true}
+                    threadHref={bookItem.threadHref}
+                  />
                 </div>
               {/each}
             </div>
           {/if}
 
-          {#if myHasMore}
+          {#if allHasMore}
             <div class="mt-4 flex justify-center">
               <button
                 type="button"
                 class="rounded-lg border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-                on:click={() => void loadMyBooks(false)}
-                disabled={$bookStoreMeta.loading.myBookshelf}
-                data-testid="bookshelf-my-load-more"
+                on:click={() => void loadAllBooks(false)}
+                disabled={$bookStoreMeta.loading.allBookshelf}
+                data-testid="bookshelf-all-load-more"
               >
-                {$bookStoreMeta.loading.myBookshelf ? 'Loading...' : 'Load more'}
+                {$bookStoreMeta.loading.allBookshelf ? 'Loading...' : 'Load more'}
               </button>
             </div>
           {/if}
         </div>
-      </div>
-    {:else}
-      <div>
-        <div class="flex items-center justify-between">
-          <div>
-            <h3 class="text-sm font-semibold text-gray-900">All Books</h3>
-            <p class="text-xs text-gray-500">See what everyone in your community has saved.</p>
-          </div>
-          <span class="text-xs text-gray-400">{allBookItems.length} saved</span>
-        </div>
-
-        {#if $bookStoreMeta.loading.allBookshelf && allBookItems.length === 0}
-          <div
-            class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
-            data-testid="bookshelf-all-loading"
-          >
-            Loading books...
-          </div>
-        {:else if allBookItems.length === 0}
-          <div
-            class="mt-3 rounded-xl border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500"
-            data-testid="bookshelf-all-empty"
-          >
-            No books saved yet
-          </div>
-        {:else}
-          <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2" data-testid="bookshelf-all-grid">
-            {#each allBookItems as bookItem (bookItem.item.id)}
-              <div
-                class="rounded-xl border border-gray-200 bg-white p-2 shadow-sm"
-                data-testid={`bookshelf-all-item-${bookItem.item.postId}`}
-              >
-                <p class="mb-2 text-xs font-medium text-gray-500" data-testid={`bookshelf-saver-${bookItem.item.id}`}>
-                  Saved by {bookItem.saverLabel}
-                </p>
-                <BookCard bookData={bookItem.bookData} compact={true} threadHref={bookItem.threadHref} />
-              </div>
-            {/each}
-          </div>
-        {/if}
-
-        {#if allHasMore}
-          <div class="mt-4 flex justify-center">
-            <button
-              type="button"
-              class="rounded-lg border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-              on:click={() => void loadAllBooks(false)}
-              disabled={$bookStoreMeta.loading.allBookshelf}
-              data-testid="bookshelf-all-load-more"
-            >
-              {$bookStoreMeta.loading.allBookshelf ? 'Loading...' : 'Load more'}
-            </button>
-          </div>
-        {/if}
-      </div>
-    {/if}
-  </div>
+      {/if}
+    </div>
+  {/if}
 </section>


### PR DESCRIPTION
## Summary
- add a header collapse/expand toggle to `Bookshelf` matching the existing Cookbook/Watchlist pattern
- keep the tab switcher visible while collapsed and hide the main bookshelf content behind an `isCollapsed` gate
- add a Bookshelf component test that verifies button text/`aria-expanded` state and collapsed content visibility

## Testing
- `cd frontend && npm run test -- src/components/books/Bookshelf.test.ts`
- `cd frontend && npm run check`

Closes #980