### PR TITLE
[Movies/Series] Add Rotten Tomatoes and IMDB links to MovieCard

### DIFF
--- a/backend/internal/models/movie.go
+++ b/backend/internal/models/movie.go
@@ -37,6 +37,8 @@ type MovieData struct {
 	TMDBRating          float64      `json:"tmdb_rating"`
 	RottenTomatoesScore *int         `json:"rotten_tomatoes_score,omitempty"`
 	MetacriticScore     *int         `json:"metacritic_score,omitempty"`
+	IMDBID              string       `json:"imdb_id,omitempty"`
+	RottenTomatoesURL   string       `json:"rotten_tomatoes_url,omitempty"`
 	TrailerKey          string       `json:"trailer_key"`
 	TMDBID              int          `json:"tmdb_id,omitempty"`
 	TMDBMediaType       string       `json:"tmdb_media_type,omitempty"`

--- a/backend/internal/services/links/movie_parser_test.go
+++ b/backend/internal/services/links/movie_parser_test.go
@@ -33,6 +33,7 @@ func TestParseMovieMetadataIMDbURL(t *testing.T) {
 				"genres":[{"id":28,"name":"Action"},{"id":878,"name":"Science Fiction"}],
 				"release_date":"1999-03-30",
 				"vote_average":8.2,
+				"imdb_id":"tt0133093",
 				"credits":{
 					"cast":[
 						{"id":1,"name":"Keanu Reeves","character":"Neo","order":0},
@@ -82,6 +83,12 @@ func TestParseMovieMetadataIMDbURL(t *testing.T) {
 	}
 	if metadata.TMDBMediaType != "movie" {
 		t.Fatalf("TMDBMediaType = %q, want movie", metadata.TMDBMediaType)
+	}
+	if metadata.IMDBID != "tt0133093" {
+		t.Fatalf("IMDBID = %q, want tt0133093", metadata.IMDBID)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/m/the_matrix" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/m/the_matrix", metadata.RottenTomatoesURL)
 	}
 	if metadata.TrailerKey != "trailer-key" {
 		t.Fatalf("TrailerKey = %q, want trailer-key", metadata.TrailerKey)
@@ -162,6 +169,7 @@ func TestParseMovieMetadataTMDBTVURL(t *testing.T) {
 				{"season_number":1,"episode_count":10,"air_date":"2011-04-17","name":"Season 1","overview":"Houses rise.","poster_path":"/season1.jpg"}
 			],
 			"vote_average":8.5,
+			"external_ids":{"imdb_id":"tt0944947"},
 			"credits":{"cast":[{"id":239019,"name":"Emilia Clarke","character":"Daenerys Targaryen","order":1}],"crew":[{"id":9813,"name":"Miguel Sapochnik","job":"Director","department":"Directing"}]},
 			"videos":{"results":[{"id":"def456","key":"KPLWWIOCOOQ","name":"Teaser","site":"YouTube","type":"Teaser","official":true}]}
 		}`))
@@ -205,6 +213,12 @@ func TestParseMovieMetadataTMDBTVURL(t *testing.T) {
 	}
 	if metadata.TMDBMediaType != "tv" {
 		t.Fatalf("TMDBMediaType = %q, want tv", metadata.TMDBMediaType)
+	}
+	if metadata.IMDBID != "tt0944947" {
+		t.Fatalf("IMDBID = %q, want tt0944947", metadata.IMDBID)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/tv/game_of_thrones" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/tv/game_of_thrones", metadata.RottenTomatoesURL)
 	}
 }
 
@@ -370,6 +384,12 @@ func TestParseMovieMetadataRottenTomatoesMovieURL(t *testing.T) {
 	if metadata.RottenTomatoesScore == nil || *metadata.RottenTomatoesScore != 88 {
 		t.Fatalf("RottenTomatoesScore = %+v, want 88", metadata.RottenTomatoesScore)
 	}
+	if metadata.IMDBID != "tt0133093" {
+		t.Fatalf("IMDBID = %q, want tt0133093", metadata.IMDBID)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/m/the_matrix" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/m/the_matrix", metadata.RottenTomatoesURL)
+	}
 }
 
 func TestParseMovieMetadataRottenTomatoesTVURL(t *testing.T) {
@@ -418,6 +438,9 @@ func TestParseMovieMetadataRottenTomatoesTVURL(t *testing.T) {
 	}
 	if metadata.TMDBMediaType != "tv" {
 		t.Fatalf("TMDBMediaType = %q, want tv", metadata.TMDBMediaType)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/tv/game_of_thrones" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/tv/game_of_thrones", metadata.RottenTomatoesURL)
 	}
 }
 
@@ -643,6 +666,12 @@ func TestParseMovieMetadataEnrichesWithOMDBRatings(t *testing.T) {
 	if metadata.MetacriticScore == nil || *metadata.MetacriticScore != 73 {
 		t.Fatalf("MetacriticScore = %+v, want 73", metadata.MetacriticScore)
 	}
+	if metadata.IMDBID != "tt0133093" {
+		t.Fatalf("IMDBID = %q, want tt0133093", metadata.IMDBID)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/m/the_matrix" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/m/the_matrix", metadata.RottenTomatoesURL)
+	}
 }
 
 func TestParseMovieMetadataOMDBFailureFallsBackToTMDB(t *testing.T) {
@@ -685,6 +714,12 @@ func TestParseMovieMetadataOMDBFailureFallsBackToTMDB(t *testing.T) {
 	}
 	if metadata.Title != "Game of Thrones" {
 		t.Fatalf("Title = %q, want Game of Thrones", metadata.Title)
+	}
+	if metadata.IMDBID != "tt0944947" {
+		t.Fatalf("IMDBID = %q, want tt0944947", metadata.IMDBID)
+	}
+	if metadata.RottenTomatoesURL != "https://www.rottentomatoes.com/tv/game_of_thrones" {
+		t.Fatalf("RottenTomatoesURL = %q, want https://www.rottentomatoes.com/tv/game_of_thrones", metadata.RottenTomatoesURL)
 	}
 	if metadata.RottenTomatoesScore != nil {
 		t.Fatalf("expected RottenTomatoesScore to be nil, got %v", *metadata.RottenTomatoesScore)

--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -88,6 +88,10 @@
     rotten_tomatoes_score?: number | string;
     metacriticScore?: number | string;
     metacritic_score?: number | string;
+    imdbId?: string;
+    imdb_id?: string;
+    rottenTomatoesUrl?: string;
+    rotten_tomatoes_url?: string;
     trailerKey?: string;
     trailer_key?: string;
     tmdbId?: number;
@@ -117,6 +121,8 @@
     tmdbRating?: number;
     rottenTomatoesScore?: number;
     metacriticScore?: number;
+    imdbId?: string;
+    rottenTomatoesUrl?: string;
     trailerKey?: string;
     tmdbId?: number;
     tmdbMediaType?: 'movie' | 'tv';
@@ -835,6 +841,15 @@
       movie.metacriticScore,
       movie.metacritic_score
     );
+    const normalizedIMDBIDRaw =
+      (typeof movie.imdbId === 'string' ? movie.imdbId : undefined) ??
+      (typeof movie.imdb_id === 'string' ? movie.imdb_id : undefined);
+    const normalizedIMDBID = normalizedIMDBIDRaw?.trim().toLowerCase();
+    const imdbId = normalizedIMDBID && /^tt\d+$/.test(normalizedIMDBID) ? normalizedIMDBID : undefined;
+    const normalizedRottenTomatoesURL =
+      (typeof movie.rottenTomatoesUrl === 'string' ? movie.rottenTomatoesUrl : undefined) ??
+      (typeof movie.rotten_tomatoes_url === 'string' ? movie.rotten_tomatoes_url : undefined);
+    const rottenTomatoesUrl = normalizedRottenTomatoesURL?.trim();
     const normalizedRuntime =
       typeof movie.runtime === 'number' && Number.isFinite(movie.runtime) ? movie.runtime : undefined;
     const normalizedGenres =
@@ -933,6 +948,8 @@
       ...(typeof normalizedMetacriticScore === 'number'
         ? { metacriticScore: normalizedMetacriticScore }
         : {}),
+      ...(imdbId ? { imdbId } : {}),
+      ...(rottenTomatoesUrl ? { rottenTomatoesUrl } : {}),
       ...(normalizedTrailerKey ? { trailerKey: normalizedTrailerKey } : {}),
       ...(typeof normalizedTMDBID === 'number' ? { tmdbId: normalizedTMDBID } : {}),
       ...(normalizedTMDBMediaType ? { tmdbMediaType: normalizedTMDBMediaType } : {}),

--- a/frontend/src/components/__tests__/MovieCard.test.ts
+++ b/frontend/src/components/__tests__/MovieCard.test.ts
@@ -18,6 +18,10 @@ type MovieMetadata = {
   rotten_tomatoes_score?: number | string;
   metacriticScore?: number | string;
   metacritic_score?: number | string;
+  imdbId?: string;
+  imdb_id?: string;
+  rottenTomatoesUrl?: string;
+  rotten_tomatoes_url?: string;
   trailerKey?: string;
   tmdbId?: number;
   tmdbMediaType?: 'movie' | 'tv';
@@ -241,6 +245,45 @@ describe('MovieCard', () => {
     expect(tmdbLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
+  it('renders TMDB, IMDb, and Rotten Tomatoes links when available', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        imdbId: 'tt0816692',
+        rottenTomatoesUrl: 'https://www.rottentomatoes.com/m/interstellar_2014',
+      },
+    });
+
+    const tmdbLink = screen.getByTestId('movie-tmdb-link');
+    const imdbLink = screen.getByTestId('movie-imdb-link');
+    const rtLink = screen.getByTestId('movie-rotten-tomatoes-link');
+
+    expect(tmdbLink).toHaveAttribute('href', 'https://www.themoviedb.org/movie/157336');
+    expect(imdbLink).toHaveAttribute('href', 'https://www.imdb.com/title/tt0816692');
+    expect(rtLink).toHaveAttribute(
+      'href',
+      'https://www.rottentomatoes.com/m/interstellar_2014'
+    );
+    expect(imdbLink).toHaveAttribute('target', '_blank');
+    expect(rtLink).toHaveAttribute('target', '_blank');
+    expect(imdbLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(rtLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(imdbLink).toHaveClass(
+      'rounded-md',
+      'border',
+      'bg-slate-50',
+      'text-sm',
+      'focus-visible:outline'
+    );
+    expect(rtLink).toHaveClass(
+      'rounded-md',
+      'border',
+      'bg-slate-50',
+      'text-sm',
+      'focus-visible:outline'
+    );
+  });
+
   it('does not render TMDB link when tmdb id is missing', () => {
     render(MovieCard, {
       movie: {
@@ -250,6 +293,19 @@ describe('MovieCard', () => {
     });
 
     expect(screen.queryByTestId('movie-tmdb-link')).not.toBeInTheDocument();
+  });
+
+  it('omits IMDb and Rotten Tomatoes links when metadata is unavailable', () => {
+    render(MovieCard, {
+      movie: {
+        ...fullMovie,
+        imdbId: 'invalid-id',
+        rottenTomatoesUrl: '',
+      },
+    });
+
+    expect(screen.queryByTestId('movie-imdb-link')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('movie-rotten-tomatoes-link')).not.toBeInTheDocument();
   });
 
   it('renders fallback content for minimal metadata', () => {

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -190,6 +190,8 @@ describe('mapApiPost', () => {
               tmdb_rating: 8.6,
               rotten_tomatoes_score: '88',
               metacriticScore: 73,
+              imdb_id: 'tt0816692',
+              rotten_tomatoes_url: 'https://www.rottentomatoes.com/m/interstellar_2014',
               trailer_key: 'zSWdZVtXT7E',
               tmdb_id: '157336',
               tmdb_media_type: 'movie',
@@ -231,6 +233,8 @@ describe('mapApiPost', () => {
     expect(movie?.tmdbRating).toBe(8.6);
     expect(movie?.rottenTomatoesScore).toBe(88);
     expect(movie?.metacriticScore).toBe(73);
+    expect(movie?.imdbId).toBe('tt0816692');
+    expect(movie?.rottenTomatoesUrl).toBe('https://www.rottentomatoes.com/m/interstellar_2014');
     expect(movie?.trailerKey).toBe('zSWdZVtXT7E');
     expect(movie?.tmdbId).toBe(157336);
     expect(movie?.tmdbMediaType).toBe('movie');

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -191,6 +191,14 @@ function normalizeTMDBMediaType(value: unknown): 'movie' | 'tv' | undefined {
   return undefined;
 }
 
+function normalizeIMDBID(value: unknown): string | undefined {
+  const normalized = normalizeString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return /^tt\d+$/.test(normalized) ? normalized : undefined;
+}
+
 function normalizePodcastKind(value: unknown): 'show' | 'episode' | undefined {
   const normalized = normalizeString(value)?.toLowerCase();
   if (normalized === 'show') {
@@ -454,6 +462,10 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
     movie.rottenTomatoesScore
   );
   const metacriticScore = normalizePercentScore(movie.metacritic_score, movie.metacriticScore);
+  const imdbId = normalizeIMDBID(movie.imdb_id ?? movie.imdbId);
+  const rottenTomatoesUrl = normalizeString(
+    movie.rotten_tomatoes_url ?? movie.rottenTomatoesUrl
+  );
   const trailerKey = normalizeString(movie.trailer_key ?? movie.trailerKey);
   const tmdbId = normalizeNumber(movie.tmdb_id ?? movie.tmdbId);
   const tmdbMediaType = normalizeTMDBMediaType(
@@ -496,6 +508,8 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
     typeof tmdbRating === 'number' ||
     typeof rottenTomatoesScore === 'number' ||
     typeof metacriticScore === 'number' ||
+    !!imdbId ||
+    !!rottenTomatoesUrl ||
     !!trailerKey ||
     typeof tmdbId === 'number' ||
     !!tmdbMediaType ||
@@ -519,6 +533,8 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
     ...(typeof tmdbRating === 'number' ? { tmdbRating } : {}),
     ...(typeof rottenTomatoesScore === 'number' ? { rottenTomatoesScore } : {}),
     ...(typeof metacriticScore === 'number' ? { metacriticScore } : {}),
+    ...(imdbId ? { imdbId } : {}),
+    ...(rottenTomatoesUrl ? { rottenTomatoesUrl } : {}),
     ...(trailerKey ? { trailerKey } : {}),
     ...(typeof tmdbId === 'number' ? { tmdbId } : {}),
     ...(tmdbMediaType ? { tmdbMediaType } : {}),

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -88,6 +88,8 @@ export interface MovieMetadata {
   tmdbRating?: number;
   rottenTomatoesScore?: number;
   metacriticScore?: number;
+  imdbId?: string;
+  rottenTomatoesUrl?: string;
   trailerKey?: string;
   tmdbId?: number;
   tmdbMediaType?: 'movie' | 'tv';


### PR DESCRIPTION
## Summary
- store additional movie metadata fields in normalized payloads: `imdb_id` and `rotten_tomatoes_url`
- enrich backend movie parsing so TMDB/IMDb/RT inputs populate consistent external links for movie cards
- render TMDB, IMDb, and Rotten Tomatoes buttons in `MovieCard` when data exists, with matching button styling and secure new-tab attributes
- extend frontend and backend tests for metadata normalization and link rendering behavior

## Testing
- `cd backend && go test ./...`
- `cd frontend && npm run check`
- `cd frontend && npm run test`

Closes #978