### PR TITLE
[Books] Fix link metadata not loading for book posts

### DIFF
--- a/backend/internal/services/links/book_parser.go
+++ b/backend/internal/services/links/book_parser.go
@@ -429,18 +429,23 @@ func parseAmazonIdentifierSegment(segments []string, idx int) (string, bool) {
 	identifier = strings.TrimSuffix(identifier, ".html")
 	identifier = strings.TrimSuffix(identifier, "/")
 	identifier = strings.TrimSpace(identifier)
-	if len(identifier) != 10 {
-		return "", false
-	}
-
-	for _, r := range identifier {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			continue
+	switch len(identifier) {
+	case 10:
+		for _, r := range identifier {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+				continue
+			}
+			return "", false
 		}
+		return strings.ToUpper(identifier), true
+	case 13:
+		if !isValidISBN13(identifier) {
+			return "", false
+		}
+		return identifier, true
+	default:
 		return "", false
 	}
-
-	return strings.ToUpper(identifier), true
 }
 
 func parseOpenLibraryWorkKey(segments []string) (string, bool) {

--- a/backend/internal/services/links/book_parser.go
+++ b/backend/internal/services/links/book_parser.go
@@ -75,6 +75,15 @@ func ParseBookMetadata(ctx context.Context, rawURL string, client *OpenLibraryCl
 }
 
 func parseGoodreadsBookMetadata(ctx context.Context, rawURL string, client *OpenLibraryClient, goodreadsID string) (*BookData, error) {
+	metadata, err := searchOpenLibraryByIdentifier(ctx, client, "id_goodreads", goodreadsID)
+	if err != nil {
+		return nil, fmt.Errorf("search open library for goodreads id %s: %w", goodreadsID, err)
+	}
+	if metadata != nil {
+		metadata.GoodreadsURL = strings.TrimSpace(rawURL)
+		return metadata, nil
+	}
+
 	title, err := fetchBookPageTitleFunc(ctx, rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetch goodreads title for id %s: %w", goodreadsID, err)
@@ -83,7 +92,7 @@ func parseGoodreadsBookMetadata(ctx context.Context, rawURL string, client *Open
 		return nil, nil
 	}
 
-	metadata, err := searchOpenLibraryByTitle(ctx, client, title)
+	metadata, err = searchOpenLibraryByTitle(ctx, client, title)
 	if err != nil {
 		return nil, fmt.Errorf("search open library for goodreads id %s: %w", goodreadsID, err)
 	}
@@ -108,6 +117,17 @@ func parseAmazonBookMetadata(ctx context.Context, rawURL string, client *OpenLib
 		return metadata, nil
 	}
 
+	metadata, err := searchOpenLibraryByIdentifier(ctx, client, "id_amazon", asin)
+	if err != nil {
+		if lookupErr != nil {
+			return nil, lookupErr
+		}
+		return nil, fmt.Errorf("search open library for amazon asin %s: %w", asin, err)
+	}
+	if metadata != nil {
+		return metadata, nil
+	}
+
 	title, err := fetchBookPageTitleFunc(ctx, rawURL)
 	if err != nil {
 		if lookupErr != nil {
@@ -119,7 +139,7 @@ func parseAmazonBookMetadata(ctx context.Context, rawURL string, client *OpenLib
 		return nil, lookupErr
 	}
 
-	metadata, err := searchOpenLibraryByTitle(ctx, client, title)
+	metadata, err = searchOpenLibraryByTitle(ctx, client, title)
 	if err != nil {
 		if lookupErr != nil {
 			return nil, lookupErr
@@ -139,7 +159,26 @@ func searchOpenLibraryByTitle(ctx context.Context, client *OpenLibraryClient, ti
 		return nil, nil
 	}
 
-	results, err := client.SearchBooks(ctx, title)
+	return searchOpenLibrary(ctx, client, title)
+}
+
+func searchOpenLibraryByIdentifier(ctx context.Context, client *OpenLibraryClient, identifierField string, identifierValue string) (*BookData, error) {
+	identifierField = strings.TrimSpace(identifierField)
+	identifierValue = strings.TrimSpace(identifierValue)
+	if identifierField == "" || identifierValue == "" {
+		return nil, nil
+	}
+
+	return searchOpenLibrary(ctx, client, fmt.Sprintf("%s:%s", identifierField, identifierValue))
+}
+
+func searchOpenLibrary(ctx context.Context, client *OpenLibraryClient, query string) (*BookData, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+
+	results, err := client.SearchBooks(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +369,10 @@ func isGoodreadsHost(host string) bool {
 
 func isAmazonHost(host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
-	return host == "amazon.com" || strings.HasSuffix(host, ".amazon.com")
+	return host == "amazon.com" ||
+		strings.HasSuffix(host, ".amazon.com") ||
+		strings.HasPrefix(host, "amazon.") ||
+		strings.Contains(host, ".amazon.")
 }
 
 func isOpenLibraryHost(host string) bool {
@@ -356,32 +398,49 @@ func parseAmazonASIN(segments []string) (string, bool) {
 		return "", false
 	}
 
-	for i := 0; i < len(segments)-1; i++ {
-		if !strings.EqualFold(segments[i], "dp") {
-			continue
-		}
-
-		asin := strings.TrimSpace(segments[i+1])
-		asin = strings.TrimSuffix(asin, ".html")
-		asin = strings.TrimSuffix(asin, "/")
-		if asin == "" {
-			continue
-		}
-
-		valid := true
-		for _, r := range asin {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-				continue
+	for i := 0; i < len(segments); i++ {
+		switch {
+		case strings.EqualFold(segments[i], "dp"):
+			if asin, ok := parseAmazonIdentifierSegment(segments, i+1); ok {
+				return asin, true
 			}
-			valid = false
-			break
-		}
-		if valid {
-			return asin, true
+		case strings.EqualFold(segments[i], "gp"):
+			if i+1 < len(segments) && strings.EqualFold(segments[i+1], "product") {
+				if asin, ok := parseAmazonIdentifierSegment(segments, i+2); ok {
+					return asin, true
+				}
+			}
+		case strings.EqualFold(segments[i], "asin"):
+			if asin, ok := parseAmazonIdentifierSegment(segments, i+1); ok {
+				return asin, true
+			}
 		}
 	}
 
 	return "", false
+}
+
+func parseAmazonIdentifierSegment(segments []string, idx int) (string, bool) {
+	if idx < 0 || idx >= len(segments) {
+		return "", false
+	}
+
+	identifier := strings.TrimSpace(segments[idx])
+	identifier = strings.TrimSuffix(identifier, ".html")
+	identifier = strings.TrimSuffix(identifier, "/")
+	identifier = strings.TrimSpace(identifier)
+	if len(identifier) != 10 {
+		return "", false
+	}
+
+	for _, r := range identifier {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		return "", false
+	}
+
+	return strings.ToUpper(identifier), true
 }
 
 func parseOpenLibraryWorkKey(segments []string) (string, bool) {

--- a/backend/internal/services/links/book_parser_test.go
+++ b/backend/internal/services/links/book_parser_test.go
@@ -241,6 +241,78 @@ func TestParseBookMetadataAmazonGPProductURL(t *testing.T) {
 	}
 }
 
+func TestParseBookMetadataAmazonDP13DigitISBNURL(t *testing.T) {
+	originalFetchTitle := fetchBookPageTitleFunc
+	fetchBookPageTitleFunc = func(ctx context.Context, rawURL string) (string, error) {
+		t.Fatalf("unexpected title fetch for URL: %s", rawURL)
+		return "", nil
+	}
+	defer func() {
+		fetchBookPageTitleFunc = originalFetchTitle
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/isbn/9780441569595.json" {
+			t.Fatalf("path = %q, want /isbn/9780441569595.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"key":"/books/OL24226054M",
+			"title":"Neuromancer",
+			"isbn_13":["9780441569595"]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestOpenLibraryClient(t, server.URL)
+	metadata, err := ParseBookMetadata(context.Background(), "https://www.amazon.com/dp/9780441569595", client)
+	if err != nil {
+		t.Fatalf("ParseBookMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "Neuromancer" {
+		t.Fatalf("Title = %q, want Neuromancer", metadata.Title)
+	}
+}
+
+func TestParseBookMetadataAmazonGPProduct13DigitISBNURL(t *testing.T) {
+	originalFetchTitle := fetchBookPageTitleFunc
+	fetchBookPageTitleFunc = func(ctx context.Context, rawURL string) (string, error) {
+		t.Fatalf("unexpected title fetch for URL: %s", rawURL)
+		return "", nil
+	}
+	defer func() {
+		fetchBookPageTitleFunc = originalFetchTitle
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/isbn/9780441569595.json" {
+			t.Fatalf("path = %q, want /isbn/9780441569595.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"key":"/books/OL24226054M",
+			"title":"Neuromancer",
+			"isbn_13":["9780441569595"]
+		}`))
+	}))
+	defer server.Close()
+
+	client := newTestOpenLibraryClient(t, server.URL)
+	metadata, err := ParseBookMetadata(context.Background(), "https://www.amazon.com/gp/product/9780441569595", client)
+	if err != nil {
+		t.Fatalf("ParseBookMetadata error: %v", err)
+	}
+	if metadata == nil {
+		t.Fatal("expected metadata")
+	}
+	if metadata.Title != "Neuromancer" {
+		t.Fatalf("Title = %q, want Neuromancer", metadata.Title)
+	}
+}
+
 func TestParseBookMetadataAmazonRegionalHostURL(t *testing.T) {
 	originalFetchTitle := fetchBookPageTitleFunc
 	fetchBookPageTitleFunc = func(ctx context.Context, rawURL string) (string, error) {

--- a/backend/internal/services/links/metadata_test.go
+++ b/backend/internal/services/links/metadata_test.go
@@ -578,6 +578,16 @@ func TestShouldExtractBookMetadata(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "amazon dp 13-digit isbn url",
+			url:  "https://www.amazon.com/dp/9780441569595",
+			want: true,
+		},
+		{
+			name: "amazon gp product 13-digit isbn url",
+			url:  "https://www.amazon.com/gp/product/9780441569595",
+			want: true,
+		},
+		{
 			name: "amazon regional host url",
 			url:  "https://www.amazon.co.uk/dp/0441569595",
 			want: true,

--- a/backend/internal/services/links/metadata_test.go
+++ b/backend/internal/services/links/metadata_test.go
@@ -573,6 +573,16 @@ func TestShouldExtractBookMetadata(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "amazon gp product url",
+			url:  "https://www.amazon.com/gp/product/0441569595",
+			want: true,
+		},
+		{
+			name: "amazon regional host url",
+			url:  "https://www.amazon.co.uk/dp/0441569595",
+			want: true,
+		},
+		{
 			name: "open library work url",
 			url:  "https://openlibrary.org/works/OL45883W",
 			want: true,
@@ -659,6 +669,82 @@ func TestFetchMetadataBookURLIncludesBookMetadata(t *testing.T) {
 	}
 	if bookData.Title != "Neuromancer" {
 		t.Fatalf("book title = %q, want Neuromancer", bookData.Title)
+	}
+}
+
+func TestFetchMetadataBookURLReturnsBookMetadataWhenFetchFails(t *testing.T) {
+	originalParseBookMetadataFunc := parseBookMetadataFunc
+	t.Cleanup(func() {
+		parseBookMetadataFunc = originalParseBookMetadataFunc
+	})
+
+	parseCalls := 0
+	parseBookMetadataFunc = func(ctx context.Context, rawURL string, client *OpenLibraryClient) (*BookData, error) {
+		parseCalls++
+		return &BookData{Title: "Neuromancer"}, nil
+	}
+
+	fetcher := NewFetcher(&http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, errors.New("upstream unavailable")
+		}),
+	})
+	fetcher.resolver = fakeResolver{
+		addrs: map[string][]net.IPAddr{
+			"www.goodreads.com": {{IP: net.ParseIP("93.184.216.34")}},
+		},
+	}
+
+	metadata, err := fetcher.Fetch(context.Background(), "https://www.goodreads.com/book/show/22328-neuromancer")
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if parseCalls != 1 {
+		t.Fatalf("parseCalls = %d, want 1", parseCalls)
+	}
+
+	bookData, ok := metadata["book_data"].(*BookData)
+	if !ok || bookData == nil {
+		t.Fatalf("expected book metadata to be present")
+	}
+	if metadata["provider"] != "www.goodreads.com" {
+		t.Fatalf("provider = %v, want www.goodreads.com", metadata["provider"])
+	}
+}
+
+func TestFetchMetadataBookURLReturnsBookMetadataWhenStatusIsNonSuccess(t *testing.T) {
+	originalParseBookMetadataFunc := parseBookMetadataFunc
+	t.Cleanup(func() {
+		parseBookMetadataFunc = originalParseBookMetadataFunc
+	})
+
+	parseBookMetadataFunc = func(ctx context.Context, rawURL string, client *OpenLibraryClient) (*BookData, error) {
+		return &BookData{Title: "Neuromancer"}, nil
+	}
+
+	fetcher := NewFetcher(&http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Status:     "503 Service Unavailable",
+				Header:     http.Header{"Content-Type": []string{"text/html"}},
+				Body:       io.NopCloser(strings.NewReader("down")),
+				Request:    r,
+			}, nil
+		}),
+	})
+	fetcher.resolver = fakeResolver{
+		addrs: map[string][]net.IPAddr{
+			"www.goodreads.com": {{IP: net.ParseIP("93.184.216.34")}},
+		},
+	}
+
+	metadata, err := fetcher.Fetch(context.Background(), "https://www.goodreads.com/book/show/22328-neuromancer")
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if _, ok := metadata["book_data"].(*BookData); !ok {
+		t.Fatalf("expected book metadata to be present")
 	}
 }
 


### PR DESCRIPTION
## Summary
- made Goodreads parsing resilient by querying Open Library with `id_goodreads:<id>` before falling back to brittle page-title scraping
- improved Amazon parsing to support additional real-world URL shapes (`/gp/product/<id>`, `/asin/<id>`) and regional Amazon hosts (for example `amazon.co.uk`)
- added Open Library identifier lookup for Amazon (`id_amazon:<asin>`) when direct `/isbn/<asin>` lookup fails
- updated link metadata fetch flow to attempt book extraction before HTML fetch and return `book_data` even when the page request fails or returns non-2xx
- added warning logs when book parsing fails instead of silently dropping book metadata

## Tests
- `go test ./internal/services/links -run 'TestParseBookMetadata|TestShouldExtractBookMetadata|TestFetchMetadataBook' -v`
- `go build ./...`
- `go test ./...`

## Acceptance Criteria Mapping
- Goodreads parsed and stored: covered via direct identifier lookup + tests
- Amazon parsed and stored: covered for `dp`, `gp/product`, and regional hosts + tests
- Open Library parsed and stored: existing coverage retained and passing
- ISBN-based URLs parsed and stored: existing coverage retained and passing
- Backend tests pass for supported patterns: targeted + full backend suite passing
- Error cases logged with detail: explicit warn logging added for book parse failures

Closes #972