### PR TITLE
[Books] Show link URL as fallback when book metadata is unavailable

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -2087,7 +2087,7 @@
               onReady={handleEmbedReady}
             />
           </div>
-        {:else if primaryLink && metadata && !primaryLinkIsImage}
+        {:else if primaryLink && metadata && !primaryLinkIsImage && (!isBookSection || primaryBookMetadata)}
           {#if spotifyEmbedUrl}
             <div class="mt-3">
               <SpotifyEmbed embedUrl={spotifyEmbedUrl} height={spotifyEmbedHeight} />
@@ -2135,8 +2135,18 @@
               </div>
             </a>
           {/if}
+        {:else if primaryLink && isBookSection && !primaryBookMetadata}
+          <a
+            href={primaryLink.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mt-3 inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm break-all"
+          >
+            <span>🔗</span>
+            <span class="underline">{primaryLink.url}</span>
+          </a>
         {/if}
-      {:else if !isEditing && primaryLink && metadata}
+      {:else if !isEditing && primaryLink && metadata && (!isBookSection || primaryBookMetadata)}
         {#if soundCloudEmbed}
           <SoundCloudEmbed
             embedUrl={soundCloudEmbed.embedUrl}

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -430,6 +430,38 @@ describe('PostCard', () => {
     expect(screen.getByTestId('book-title')).toHaveTextContent('Neuromancer');
   });
 
+  it('renders plain URL fallback for book sections when book metadata is unavailable', () => {
+    sectionStore.setSections([
+      {
+        id: 'section-1',
+        name: 'Books',
+        type: 'book',
+        icon: '📚',
+        slug: 'books',
+      },
+    ]);
+
+    const fallbackUrl = 'https://www.goodreads.com/book/show/22328-neuromancer';
+    const bookPostWithoutBookData: Post = {
+      ...basePost,
+      links: [
+        {
+          url: fallbackUrl,
+          metadata: {
+            url: fallbackUrl,
+            provider: 'goodreads',
+          },
+        },
+      ],
+    };
+
+    render(PostCard, { post: bookPostWithoutBookData });
+
+    expect(screen.queryByTestId('book-card')).not.toBeInTheDocument();
+    const fallbackLinkText = screen.getByText(fallbackUrl);
+    expect(fallbackLinkText.closest('a')).toHaveAttribute('href', fallbackUrl);
+  });
+
   it('renders book stats bar for book sections when book stats are present', () => {
     sectionStore.setSections([
       {


### PR DESCRIPTION
## Summary
- ensure `PostCard` falls back to a plain clickable URL for book-section posts when normalized `book_data` metadata is unavailable
- prevent book-section posts without metadata from being captured by the generic metadata card branch
- add a regression test covering book posts with link metadata but no `book_data`

## Testing
- `cd frontend && npm run check`
- `cd frontend && npm run test -- src/components/__tests__/PostCard.test.ts`

Closes #973