### PR TITLE
[Music] Fix tracks/sets filter affecting main feed instead of Recent Music Links component

### DIFF
--- a/frontend/src/components/SectionFeed.svelte
+++ b/frontend/src/components/SectionFeed.svelte
@@ -3,14 +3,12 @@
   import {
     activeSection,
     posts,
-    filteredPosts,
     isLoadingPosts,
     postsError,
     postsPaginationError,
     hasMorePosts,
     postStore,
     threadRouteStore,
-    musicLengthFilter,
   } from '../stores';
   import { loadFeed, loadMorePosts } from '../stores/feedStore';
   import { loadThreadTargetPost } from '../stores/threadRouteStore';
@@ -26,10 +24,7 @@
     loadFeed($activeSection.id);
   }
 
-  $: displayPosts = $filteredPosts;
-  $: hasFilteredResults = displayPosts.length > 0;
-  $: filterLabel =
-    $musicLengthFilter === 'tracks' ? 'tracks' : $musicLengthFilter === 'sets' ? 'sets/mixes' : '';
+  $: displayPosts = $posts;
 
   async function handleLoadMore() {
     if (isLoadingMore || !$hasMorePosts) return;
@@ -171,23 +166,15 @@
       <p class="text-gray-500">No posts yet. Be the first to share something!</p>
     </div>
   {:else}
-    {#if !hasFilteredResults}
-      <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center">
-        <p class="text-gray-500">
-          No {filterLabel} posts yet. Try switching the length filter.
-        </p>
+    {#each displayPosts as post (post.id)}
+      {@const isTarget = $threadRouteStore.postId === post.id}
+      <div
+        id={`post-${post.id}`}
+        class={`scroll-mt-24 ${isTarget ? 'ring-2 ring-blue-200 rounded-lg' : ''}`}
+      >
+        <PostCard {post} />
       </div>
-    {:else}
-      {#each displayPosts as post (post.id)}
-        {@const isTarget = $threadRouteStore.postId === post.id}
-        <div
-          id={`post-${post.id}`}
-          class={`scroll-mt-24 ${isTarget ? 'ring-2 ring-blue-200 rounded-lg' : ''}`}
-        >
-          <PostCard {post} />
-        </div>
-      {/each}
-    {/if}
+    {/each}
 
     <div bind:this={sentinel} class="h-4"></div>
 


### PR DESCRIPTION
## Summary
- scoped the Tracks/Sets-Mixes filter state to `MusicLinksContainer` so filter clicks now apply only to Recent Music Links data
- decoupled `SectionFeed` from `musicLengthFilter`/`filteredPosts` so the main post feed no longer changes when those component filters are toggled
- removed the misleading feed empty-state pathway that referenced a non-existent "length filter"
- added component tests that verify tracks-only, sets-only, and toggle-off behavior in Recent Music Links
- added a feed test that verifies posts still render even if the music length filter store is set

## Testing
- `cd frontend && npm run test -- src/components/__tests__/MusicLinksContainer.test.ts src/components/__tests__/SectionFeed.test.ts`
- `cd frontend && npm run check`

Closes #1007