### PR TITLE
[Books] Fix link metadata still not loading for book posts (regression)

### DIFF
--- a/backend/internal/services/links/metadata.go
+++ b/backend/internal/services/links/metadata.go
@@ -365,7 +365,7 @@ func shouldExtractBookMetadata(rawURL string) bool {
 		if _, ok := parseAmazonASIN(segments); ok {
 			return true
 		}
-		_, ok := extractISBNFromSegments(segments)
+		_, ok := extractISBNFromURL(parsedURL, segments)
 		return ok
 	case isOpenLibraryHost(host):
 		if _, ok := parseOpenLibraryWorkKey(segments); ok {
@@ -374,10 +374,10 @@ func shouldExtractBookMetadata(rawURL string) bool {
 		if _, ok := parseOpenLibraryEditionKey(segments); ok {
 			return true
 		}
-		_, ok := extractISBNFromSegments(segments)
+		_, ok := extractISBNFromURL(parsedURL, segments)
 		return ok
 	default:
-		_, ok := extractISBNFromSegments(segments)
+		_, ok := extractISBNFromURL(parsedURL, segments)
 		return ok
 	}
 }

--- a/backend/internal/services/links/metadata_test.go
+++ b/backend/internal/services/links/metadata_test.go
@@ -568,6 +568,11 @@ func TestShouldExtractBookMetadata(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "goodreads localized book url",
+			url:  "https://www.goodreads.com/en/book/show/22328-neuromancer",
+			want: true,
+		},
+		{
 			name: "amazon dp url",
 			url:  "https://www.amazon.com/Some-Book/dp/B00TEST123",
 			want: true,
@@ -588,6 +593,11 @@ func TestShouldExtractBookMetadata(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "amazon mobile aw d url",
+			url:  "https://www.amazon.com/gp/aw/d/B00TEST123",
+			want: true,
+		},
+		{
 			name: "amazon regional host url",
 			url:  "https://www.amazon.co.uk/dp/0441569595",
 			want: true,
@@ -605,6 +615,11 @@ func TestShouldExtractBookMetadata(t *testing.T) {
 		{
 			name: "isbn in generic url",
 			url:  "https://example.com/books/isbn-9780441569595/details",
+			want: true,
+		},
+		{
+			name: "isbn in query parameter",
+			url:  "https://example.com/search?query=isbn%3A9780441569595",
 			want: true,
 		},
 		{


### PR DESCRIPTION
## Summary
- fixed book URL parsing to handle additional real-world URL shapes that were still bypassing `ParseBookMetadata`
- added Goodreads path scanning so localized URLs like `/en/book/show/...` are parsed correctly
- added Amazon mobile URL support (`/gp/aw/d/...`) and kept existing `dp`/`gp/product`/regional host behavior intact
- improved identifier cleanup to tolerate trailing punctuation in URL path segments
- extended ISBN detection beyond path segments to query parameters and fragment values (for ISBN-containing URLs that are not path-based)
- updated book metadata extraction gating (`shouldExtractBookMetadata`) to use the same broader ISBN detection logic
- added regression tests covering the newly supported Goodreads/Amazon/ISBN URL variants

## Reproduction Coverage
- Goodreads: `https://www.goodreads.com/en/book/show/22328-neuromancer`
- Amazon mobile: `https://www.amazon.com/gp/aw/d/B00TEST123`
- ISBN in query: `https://example.com/search?query=isbn%3A9780441569595`

## Tests
- `cd backend && go test ./internal/services/links -run 'TestParseBookMetadata|TestShouldExtractBookMetadata|TestFetchMetadataBook' -v`
- `cd backend && go build ./...`
- `cd backend && go test ./...`

Closes #1000