### PR TITLE
[Podcasts] Fix deleted post not removed from Saved tab until page refresh

### DIFF
--- a/frontend/src/stores/__tests__/podcastStore.test.ts
+++ b/frontend/src/stores/__tests__/podcastStore.test.ts
@@ -126,6 +126,34 @@ describe('podcastStore', () => {
     expect(state.savedPosts).toHaveLength(0);
   });
 
+  it('handlePostDeleted removes the post from saved and recent state', () => {
+    podcastStore.setPostSaveInfo('post-1', {
+      saveCount: 3,
+      users: [],
+      viewerSaved: true,
+    });
+    podcastStore.setSavedPosts(
+      [buildPost('post-1'), buildPost('post-2')],
+      'cursor-1',
+      true,
+      'section-podcast'
+    );
+    podcastStore.setRecentItems(
+      [buildRecentItem('1', 'show'), buildRecentItem('2', 'episode')],
+      null,
+      false,
+      'section-podcast'
+    );
+
+    podcastStore.handlePostDeleted('post-1');
+
+    const state = get(podcastStore);
+    expect(state.savedPosts.map((post) => post.id)).toEqual(['post-2']);
+    expect(state.savedPostIds.has('post-1')).toBe(false);
+    expect(state.saveInfoByPostId['post-1']).toBeUndefined();
+    expect(state.recentItems.map((item) => item.postId)).toEqual(['post-2']);
+  });
+
   it('loadSavedPodcasts and loadMoreSavedPodcasts handle cursor pagination', async () => {
     apiGetSectionSavedPodcasts
       .mockResolvedValueOnce({

--- a/frontend/src/stores/__tests__/postStore.test.ts
+++ b/frontend/src/stores/__tests__/postStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { postStore } from '../postStore';
+import { podcastStore } from '../podcastStore';
 
 const basePost = {
   id: 'post-1',
@@ -12,6 +13,7 @@ const basePost = {
 
 beforeEach(() => {
   postStore.reset();
+  podcastStore.reset();
 });
 
 describe('postStore', () => {
@@ -82,10 +84,22 @@ describe('postStore', () => {
 
   it('removePost removes by id', () => {
     postStore.setPosts([basePost, { ...basePost, id: 'post-2' }], null, true);
+    podcastStore.setPostSaveInfo('post-1', {
+      saveCount: 1,
+      users: [],
+      viewerSaved: true,
+    });
+    podcastStore.setSavedPosts([basePost], null, false, 'section-1');
     postStore.removePost('post-1');
+
     const state = get(postStore);
     expect(state.posts).toHaveLength(1);
     expect(state.posts[0].id).toBe('post-2');
+
+    const podcastState = get(podcastStore);
+    expect(podcastState.savedPosts).toHaveLength(0);
+    expect(podcastState.savedPostIds.has('post-1')).toBe(false);
+    expect(podcastState.saveInfoByPostId['post-1']).toBeUndefined();
   });
 
   it('incrementCommentCount updates count and never below zero', () => {

--- a/frontend/src/stores/__tests__/websocketStore.test.ts
+++ b/frontend/src/stores/__tests__/websocketStore.test.ts
@@ -63,6 +63,7 @@ const storeRefs = {
   },
   postStore: {
     upsertPost: vi.fn(),
+    removePost: vi.fn(),
     incrementCommentCount: vi.fn(),
     updateReactionCount: vi.fn(),
     updateHighlightReaction: vi.fn(),
@@ -162,6 +163,7 @@ beforeEach(() => {
   storeRefs.isAuthenticated.set(false);
   storeRefs.currentUser.set(null);
   storeRefs.postStore.upsertPost.mockReset();
+  storeRefs.postStore.removePost.mockReset();
   storeRefs.postStore.incrementCommentCount.mockReset();
   storeRefs.postStore.updateReactionCount.mockReset();
   storeRefs.postStore.updateHighlightReaction.mockReset();
@@ -269,6 +271,25 @@ describe('websocketStore', () => {
     });
 
     expect(storeRefs.postStore.upsertPost).toHaveBeenCalledWith({ id: 'post-1' });
+  });
+
+  it('handles post_deleted event', async () => {
+    storeRefs.isAuthenticated.set(true);
+    const { websocketStore } = await import('../websocketStore');
+
+    websocketStore.init();
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+
+    socket.emit('message', {
+      data: JSON.stringify({
+        type: 'post_deleted',
+        data: { post_id: 'post-1' },
+        timestamp: 'now',
+      }),
+    });
+
+    expect(storeRefs.postStore.removePost).toHaveBeenCalledWith('post-1');
   });
 
   it('handles link_metadata_updated event', async () => {

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -1,4 +1,5 @@
 import { writable, derived } from 'svelte/store';
+import { podcastStore } from './podcastStore';
 
 export interface Highlight {
   id?: string;
@@ -324,10 +325,13 @@ function createPostStore() {
         };
       }),
     removePost: (postId: string) =>
-      update((state) => ({
-        ...state,
-        posts: state.posts.filter((p) => p.id !== postId),
-      })),
+      update((state) => {
+        podcastStore.handlePostDeleted(postId);
+        return {
+          ...state,
+          posts: state.posts.filter((p) => p.id !== postId),
+        };
+      }),
     incrementCommentCount: (postId: string, delta: number) =>
       update((state) => ({
         ...state,


### PR DESCRIPTION
## Summary
- remove deleted podcast posts from podcast saved/recent state via a dedicated `podcastStore.handlePostDeleted` cleanup path
- wire `postStore.removePost` to invoke that cleanup so local owner/admin deletes update the Podcasts Saved tab immediately
- handle WebSocket `post_deleted` events in `websocketStore` and route them through `postStore.removePost`
- add tests for store cleanup, websocket deletion handling, and reactive Saved-tab UI updates

## Validation
- `cd frontend && npm run check`
- `cd frontend && npm run lint`
- `cd frontend && npm run test -- --run src/stores/__tests__/podcastStore.test.ts src/stores/__tests__/postStore.test.ts src/stores/__tests__/websocketStore.test.ts src/components/__tests__/PodcastsTopContainer.test.ts`

Closes #1006