### PR TITLE
[Books] Fix BookCard rendering and fallback handling in PostCard

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -150,6 +150,7 @@
   type LinkMetadataWithBook = LinkMetadata & {
     book_data?: BookMetadata | string;
     bookData?: BookMetadata | string;
+    book?: BookMetadata | string;
   };
   type PodcastHighlightEpisodeMetadata = {
     title?: string;
@@ -187,7 +188,20 @@
   $: userReactions = new Set(post.viewerReactions ?? []);
   $: sectionSlug = getSectionSlugById($sections, post.sectionId) ?? post.sectionId;
   $: sectionInfo = $sections.find((s) => s.id === post.sectionId) ?? null;
-  $: sectionType = sectionInfo?.type ?? ((post as PostWithSectionType).section?.type ?? null);
+  function normalizeSectionType(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'books') {
+      return 'book';
+    }
+    return normalized || null;
+  }
+
+  $: sectionType = normalizeSectionType(
+    sectionInfo?.type ?? ((post as PostWithSectionType).section?.type ?? null)
+  );
   $: recipeStats = post.recipeStats ?? post.recipe_stats ?? null;
   $: bookStats = post.bookStats ?? post.book_stats ?? null;
   $: movieStats = post.movieStats ?? post.movie_stats ?? null;
@@ -993,7 +1007,7 @@
     }
 
     const metadataWithBook = link.metadata as LinkMetadataWithBook;
-    const rawBookData = metadataWithBook.book_data ?? metadataWithBook.bookData;
+    const rawBookData = metadataWithBook.book_data ?? metadataWithBook.bookData ?? metadataWithBook.book;
     return normalizeBookMetadata(rawBookData);
   }
 

--- a/frontend/src/stores/__tests__/postMapper.test.ts
+++ b/frontend/src/stores/__tests__/postMapper.test.ts
@@ -112,6 +112,38 @@ describe('mapApiPost', () => {
     expect(post.links?.[0].metadata?.recipe?.nutrition?.calories).toBe('200');
   });
 
+  it('maps book metadata from book_data payload', () => {
+    const post = mapApiPost({
+      id: 'post-book-metadata',
+      user_id: 'user-book-metadata',
+      section_id: 'section-book',
+      content: 'book',
+      created_at: '2025-01-01T00:00:00Z',
+      links: [
+        {
+          id: 'link-book',
+          url: 'https://www.goodreads.com/book/show/22328-neuromancer',
+          metadata: {
+            book_data: {
+              title: 'Neuromancer',
+              authors: ['William Gibson'],
+              description: 'A classic cyberpunk novel.',
+              cover_url: 'https://covers.openlibrary.org/b/id/12345-L.jpg',
+              page_count: 271,
+              publish_date: '1984-07-01',
+              open_library_key: '/books/OL24226054M',
+              goodreads_url: 'https://www.goodreads.com/book/show/22328-neuromancer',
+            },
+          },
+        },
+      ],
+    });
+
+    expect(post.links?.[0].metadata?.book_data?.title).toBe('Neuromancer');
+    expect(post.links?.[0].metadata?.bookData?.authors).toEqual(['William Gibson']);
+    expect(post.links?.[0].metadata?.book?.page_count).toBe(271);
+  });
+
   it('maps movie stats from API shape', () => {
     const post = mapApiPost({
       id: 'post-movie-stats',

--- a/frontend/src/stores/postMapper.ts
+++ b/frontend/src/stores/postMapper.ts
@@ -10,6 +10,7 @@ import type {
   EmbedData,
   RecipeMetadata,
   MovieMetadata,
+  BookMetadata,
   MovieCastMember,
   MovieSeason,
   PodcastMetadata,
@@ -544,6 +545,82 @@ function normalizeMovieMetadata(rawMovie: unknown): MovieMetadata | undefined {
   };
 }
 
+function normalizeBookMetadata(rawBook: unknown): BookMetadata | undefined {
+  if (!rawBook) {
+    return undefined;
+  }
+
+  let book: Record<string, unknown> | null = null;
+  if (typeof rawBook === 'string') {
+    try {
+      const parsed = JSON.parse(rawBook) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        book = parsed as Record<string, unknown>;
+      }
+    } catch {
+      return undefined;
+    }
+  } else if (typeof rawBook === 'object' && !Array.isArray(rawBook)) {
+    book = rawBook as Record<string, unknown>;
+  }
+
+  if (!book) {
+    return undefined;
+  }
+
+  const title = normalizeString(book.title);
+  const authors = normalizeStringArray(book.authors);
+  const description = normalizeString(book.description);
+  const coverUrl = normalizeString(book.coverUrl);
+  const coverURLSnake = normalizeString(book.cover_url);
+  const pageCount = normalizeNumber(book.pageCount);
+  const pageCountSnake = normalizeNumber(book.page_count);
+  const genres = normalizeStringArray(book.genres);
+  const publishDate = normalizeString(book.publishDate);
+  const publishDateSnake = normalizeString(book.publish_date);
+  const openLibraryKey = normalizeString(book.openLibraryKey);
+  const openLibraryKeySnake = normalizeString(book.open_library_key);
+  const goodreadsURL = normalizeString(book.goodreadsUrl);
+  const goodreadsURLSnake = normalizeString(book.goodreads_url);
+
+  const hasBookMetadata =
+    !!title ||
+    !!authors ||
+    !!description ||
+    !!coverUrl ||
+    !!coverURLSnake ||
+    typeof pageCount === 'number' ||
+    typeof pageCountSnake === 'number' ||
+    !!genres ||
+    !!publishDate ||
+    !!publishDateSnake ||
+    !!openLibraryKey ||
+    !!openLibraryKeySnake ||
+    !!goodreadsURL ||
+    !!goodreadsURLSnake;
+
+  if (!hasBookMetadata) {
+    return undefined;
+  }
+
+  return {
+    ...(title ? { title } : {}),
+    ...(authors ? { authors } : {}),
+    ...(description ? { description } : {}),
+    ...(coverUrl ? { coverUrl } : {}),
+    ...(coverURLSnake ? { cover_url: coverURLSnake } : {}),
+    ...(typeof pageCount === 'number' ? { pageCount } : {}),
+    ...(typeof pageCountSnake === 'number' ? { page_count: pageCountSnake } : {}),
+    ...(genres ? { genres } : {}),
+    ...(publishDate ? { publishDate } : {}),
+    ...(publishDateSnake ? { publish_date: publishDateSnake } : {}),
+    ...(openLibraryKey ? { openLibraryKey } : {}),
+    ...(openLibraryKeySnake ? { open_library_key: openLibraryKeySnake } : {}),
+    ...(goodreadsURL ? { goodreadsUrl: goodreadsURL } : {}),
+    ...(goodreadsURLSnake ? { goodreads_url: goodreadsURLSnake } : {}),
+  };
+}
+
 function normalizeRecipeStats(rawStats: unknown): RecipeStats | undefined {
   if (!rawStats || typeof rawStats !== 'object') {
     return undefined;
@@ -818,6 +895,7 @@ export function normalizeLinkMetadata(
     normalizeString(metadata.ogType);
   const recipe = normalizeRecipeMetadata(metadata.recipe);
   const movie = normalizeMovieMetadata(metadata.movie);
+  const book = normalizeBookMetadata(metadata.book_data ?? metadata.bookData ?? metadata.book);
   const podcast = normalizePodcastMetadata(metadata.podcast);
 
   const hasMetadata =
@@ -832,6 +910,7 @@ export function normalizeLinkMetadata(
     !!type ||
     !!recipe ||
     !!movie ||
+    !!book ||
     !!podcast;
   if (!hasMetadata) {
     return undefined;
@@ -850,6 +929,9 @@ export function normalizeLinkMetadata(
     type,
     ...(recipe ? { recipe } : {}),
     ...(movie ? { movie } : {}),
+    ...(book ? { book } : {}),
+    ...(book ? { book_data: book } : {}),
+    ...(book ? { bookData: book } : {}),
     ...(podcast ? { podcast } : {}),
   };
 }

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -15,6 +15,23 @@ export interface Link {
   highlights?: Highlight[];
 }
 
+export interface BookMetadata {
+  title?: string;
+  authors?: string[];
+  description?: string;
+  coverUrl?: string;
+  cover_url?: string;
+  pageCount?: number;
+  page_count?: number;
+  genres?: string[];
+  publishDate?: string;
+  publish_date?: string;
+  openLibraryKey?: string;
+  open_library_key?: string;
+  goodreadsUrl?: string;
+  goodreads_url?: string;
+}
+
 export interface LinkMetadata {
   url: string;
   provider?: string;
@@ -28,6 +45,9 @@ export interface LinkMetadata {
   type?: string;
   recipe?: RecipeMetadata;
   movie?: MovieMetadata;
+  book?: BookMetadata;
+  book_data?: BookMetadata;
+  bookData?: BookMetadata;
   podcast?: PodcastMetadata;
 }
 


### PR DESCRIPTION
## Summary
- preserve `book_data` payloads in frontend post metadata normalization so `PostCard` can read book metadata from API-mapped posts
- support legacy section type value `books` by normalizing it to `book` in `PostCard`
- expand book metadata extraction in `PostCard` to read `book_data`, `bookData`, and `book`
- add tests for API-mapped book metadata rendering and legacy `books` section fallback behavior

## Validation
- `cd frontend && npm run test -- src/components/__tests__/PostCard.test.ts`
- `cd frontend && npm run test -- src/stores/__tests__/postMapper.test.ts`
- `cd frontend && npm run lint && npm run test && npm run check`

Closes #1001