### PR TITLE
[Books] Fix book stats (saved/read) not appearing on new posts until reload (regression)

### DIFF
--- a/frontend/src/components/PostCard.svelte
+++ b/frontend/src/components/PostCard.svelte
@@ -2,7 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import type { Link, LinkMetadata, Post } from '../stores/postStore';
-  import { postStore, currentUser, isAdmin, activeView } from '../stores';
+  import { postStore, currentUser, isAdmin, activeView, activeSection } from '../stores';
   import { api } from '../services/api';
   import CommentThread from './comments/CommentThread.svelte';
   import EditedBadge from './EditedBadge.svelte';
@@ -199,8 +199,12 @@
     return normalized || null;
   }
 
+  $: activeSectionTypeForPost =
+    $activeSection?.id === post.sectionId ? ($activeSection.type ?? null) : null;
   $: sectionType = normalizeSectionType(
-    sectionInfo?.type ?? ((post as PostWithSectionType).section?.type ?? null)
+    sectionInfo?.type ??
+      ((post as PostWithSectionType).section?.type ?? null) ??
+      activeSectionTypeForPost
   );
   $: recipeStats = post.recipeStats ?? post.recipe_stats ?? null;
   $: bookStats = post.bookStats ?? post.book_stats ?? null;

--- a/frontend/src/components/__tests__/PostCard.test.ts
+++ b/frontend/src/components/__tests__/PostCard.test.ts
@@ -576,6 +576,35 @@ describe('PostCard', () => {
     expect(screen.getByTestId('book-stats-bar')).toBeInTheDocument();
   });
 
+  it('renders book stats bar when active section is books during client navigation', () => {
+    sectionStore.setActiveSection({
+      id: 'section-1',
+      name: 'Books',
+      type: 'book',
+      icon: '📚',
+      slug: 'books',
+    });
+
+    const postWithBookStats: Post = {
+      ...basePost,
+      bookStats: {
+        bookshelfCount: 2,
+        readCount: 1,
+        averageRating: 4,
+        viewerOnBookshelf: false,
+        viewerCategories: [],
+        viewerRead: false,
+        viewerRating: null,
+      },
+    };
+
+    render(PostCard, { post: postWithBookStats });
+
+    expect(screen.getByTestId('book-stats-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('book-bookshelf-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('book-read-count')).toHaveTextContent('1');
+  });
+
   it('does not render book components for non-book sections', () => {
     uiStore.setActiveView('thread');
     sectionStore.setSections([


### PR DESCRIPTION
## Summary
- fix `PostCard` section-type resolution for client-side navigation by falling back to the currently active section type when it matches the post section
- ensure `BookStatsBar` renders immediately for book posts even when section metadata is not yet hydrated in the sections list
- add a regression test covering navigation timing where active section is books but section lookup data is temporarily unavailable

## Validation
- `cd frontend && npm run test -- src/components/__tests__/PostCard.test.ts src/stores/bookStore.test.ts`
- `cd frontend && npm run check`

Closes #1004